### PR TITLE
Add a list of derivation path exceptions to `snap_getBip32Entropy`

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 40,
-      functions: 53.52,
-      lines: 37.98,
-      statements: 38.12,
+      branches: 41.17,
+      functions: 54.16,
+      lines: 39.65,
+      statements: 39.6,
     },
   },
   globals: {

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -13,7 +13,11 @@ import { BIP32Node, SLIP10Node } from '@metamask/key-tree';
 
 import { SnapCaveatType } from '../caveats';
 import { isEqual } from '../utils';
-import { validateCaveatPaths, validatePath } from './getBip32Entropy';
+import {
+  validateCaveatPaths,
+  validatePath,
+  validatePathLength,
+} from './getBip32Entropy';
 
 const targetKey = 'snap_getBip32PublicKey';
 
@@ -106,6 +110,7 @@ export const getBip32PublicKeyCaveatSpecifications: Record<
       return async (args) => {
         const { params } = args;
         validatePath(params);
+        validatePathLength(params);
 
         const path = caveat.value.find(
           (caveatPath) =>


### PR DESCRIPTION
Right now, it's not possible to derive using any derivation paths shorter than depth 2 (e.g., `m/44'/60'`). There are some use cases for shorter derivation paths, like [deriving passwords from a secret recovery phrase](https://github.com/LedgerHQ/app-passwords/).

This PR adds a list of permitted derivation path indices that a Snap can request permissions for, with a derivation path of depth 1, like `m/5265220'`. When actually requesting a derivation path, either through `snap_getBip32Entropy` or `snap_getBip32PublicKey`, a depth of 2 is still required, meaning that. `m/5265220'` itself **cannot** be requested by a Snap, only the permissions for it (allowing it to derive `m/5265220'/...`).

Other indices can be added to the list, as use cases for them come up.