### PR TITLE
Support for .env variables in plugins

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,6 +52,8 @@
     "@metamask/snap-types": "^0.21.0",
     "@metamask/utils": "^2.0.0",
     "ajv": "^8.11.0",
+    "dotenv": "^16.0.2",
+    "dotenv-expand": "^9.0.0",
     "eth-rpc-errors": "^4.0.3",
     "fast-deep-equal": "^3.1.3",
     "rfdc": "^1.3.0",

--- a/packages/utils/src/dotenv.ts
+++ b/packages/utils/src/dotenv.ts
@@ -1,0 +1,44 @@
+import * as dotenv from 'dotenv';
+import * as dotenvExpand from 'dotenv-expand';
+import * as fs from 'fs/promises';
+import path from 'path';
+import process from 'process';
+import { assert } from './assert';
+import { fromEntries } from './object';
+
+export function search(): string {
+  return path.resolve(process.cwd(), '.env');
+}
+
+export interface DotEnvParseArgs {
+  /**
+   * The filepath where the .env will be searched for
+   */
+  path: string;
+  /**
+   * Will filter resulting variables to only the ones starting with value of `filterPrefix`.
+   */
+  filterPrefix: string;
+}
+
+export async function parse(
+  { path, filterPrefix }: DotEnvParseArgs = {
+    path: search(),
+    filterPrefix: 'SNAP_',
+  },
+): Promise<Record<string, string>> {
+  const file = await fs.readFile(path);
+  const result = dotenvExpand.expand({
+    ignoreProcessEnv: true,
+    parsed: dotenv.parse(path),
+  });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  assert(result.parsed !== undefined);
+  return fromEntries(
+    Object.entries(result.parsed).filter(([key]) =>
+      key.startsWith(filterPrefix),
+    ),
+  );
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,7 +1,9 @@
 export * from './assert';
 export * from './deep-clone';
 export * from './default-endowments';
+export * as dotenvSnap from './dotenv';
 export * from './eval';
+export * from './flatMap';
 export * from './fs';
 export * from './json-schemas';
 export * from './manifest';
@@ -13,4 +15,3 @@ export * from './snaps';
 export * from './types';
 export * from './url';
 export * from './versions';
-export * from './flatMap';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,6 +2824,8 @@ __metadata:
     "@types/semver": ^7.3.10
     ajv: ^8.11.0
     ajv-cli: ^5.0.0
+    dotenv: ^16.0.2
+    dotenv-expand: ^9.0.0
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-import: ^2.23.4
@@ -7290,6 +7292,20 @@ __metadata:
     no-case: ^3.0.4
     tslib: ^2.0.3
   checksum: a65e3519414856df0228b9f645332f974f2bf5433370f544a681122eab59e66038fc3349b4be1cdc47152779dac71a5864f1ccda2f745e767c46e9c6543b1169
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "dotenv-expand@npm:9.0.0"
+  checksum: 76f669b87da73d6980d1235cb18e9ccd94b294927784a0c06db5e9e98d1090b0605e75ade70880f0cd812af7f61e41367a80feea223d23fd3bd0b82f3409b9ed
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.0.2":
+  version: 16.0.2
+  resolution: "dotenv@npm:16.0.2"
+  checksum: ca8f9ca2d67929c7771069f4c31b4e46b9932621009e658e5afd655dde2d69b77642bf36dbc9e72bc170523dfd908a9ee41c26f034c1fdc605ace3b1b4b10faf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes #679 

TODO:
- [x] browserify plugin
  - [ ] tests
- [ ] rollup.js plugin
  - [ ] tests
- [ ] WebPack plugin
  - [ ] tests
- [ ] documentation for cli
- [ ] Support for normal process.env variables, not only .env file