### PR TITLE
Add transaction insights example snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ typings/
 
 # Mac files
 .DS_Store
+
+# Webpack generated files
+packages/examples/examples/webpack/index.html

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "publish:all": "./scripts/publish-all.sh",
     "link-packages": "./scripts/link-packages.sh",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!**/CHANGELOG.md' '**/*.yml' '**/*.html' --ignore-path .gitignore",
     "lint:changelogs": "yarn workspaces foreach --parallel --verbose run lint:changelog",
     "lint:tsconfig": "node scripts/verify-tsconfig.mjs",
     "lint": "yarn lint:tsconfig && yarn lint:eslint && yarn lint:misc --check",

--- a/packages/examples/examples/bls-signer/index.html
+++ b/packages/examples/examples/bls-signer/index.html
@@ -1,6 +1,6 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  </head>
+  <head>
     <title>BLS Signature Example</title>
   </head>
 
@@ -13,20 +13,23 @@
         <li>Please note that:</li>
         <ul>
           <li>
-            The <code>snap.manifest.json</code> and <code>package.json</code> must be located in located in the server root directory.
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in located in the server
+            root directory.
           </li>
           <li>
-            The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
           </li>
         </ul>
       </ul>
     </details>
-    <br/>
+    <br />
 
     <button class="connect">Connect</button>
     <button class="account">Get Public Key</button>
 
-    <br>
+    <br />
 
     <input class="challenge" placeholder="enter data to sign" />
     <button class="sign">Sign Message</button>
@@ -35,56 +38,63 @@
   <script>
     const snapId = `local:${window.location.href}`;
 
-    const connectButton = document.querySelector('button.connect')
-    const accountButton = document.querySelector('button.account')
-    const signButton = document.querySelector('button.sign')
+    const connectButton = document.querySelector('button.connect');
+    const accountButton = document.querySelector('button.account');
+    const signButton = document.querySelector('button.sign');
 
-    connectButton.addEventListener('click', connect)
-    signButton.addEventListener('click', signMessage)
-    accountButton.addEventListener('click', getAccount)
+    connectButton.addEventListener('click', connect);
+    signButton.addEventListener('click', signMessage);
+    accountButton.addEventListener('click', getAccount);
 
-    async function connect () {
+    async function connect() {
       await ethereum.request({
         method: 'wallet_enable',
-        params: [{
-          wallet_snap: { [snapId]: {} },
-        }]
-      })
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
     }
 
-    async function getAccount () {
+    async function getAccount() {
       try {
         const response = await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'getAccount'
-          }]
-        })
+          params: [
+            snapId,
+            {
+              method: 'getAccount',
+            },
+          ],
+        });
 
-        alert('received back: ' + JSON.stringify(response))
+        alert('received back: ' + JSON.stringify(response));
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
 
-    async function signMessage () {
+    async function signMessage() {
       try {
-        const data = document.querySelector('.challenge').value
+        const data = document.querySelector('.challenge').value;
         const response = await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'signMessage',
-            params: [data]
-          }]
-        })
+          params: [
+            snapId,
+            {
+              method: 'signMessage',
+              params: [data],
+            },
+          ],
+        });
 
-        alert('received back: ' + JSON.stringify(response))
+        alert('received back: ' + JSON.stringify(response));
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
-
   </script>
 </html>

--- a/packages/examples/examples/browserify/index.html
+++ b/packages/examples/examples/browserify/index.html
@@ -1,8 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  </head>
+  <head>
     <title>Hello, Snaps!</title>
-    <link rel="icon" type="image/svg" href="./images/icon.svg"/>
+    <link rel="icon" type="image/svg" href="./images/icon.svg" />
   </head>
 
   <body>
@@ -14,15 +14,18 @@
         <li>Please note that:</li>
         <ul>
           <li>
-            The <code>snap.manifest.json</code> and <code>package.json</code> must be located in the server root directory.
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in the server root
+            directory.
           </li>
           <li>
-            The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
           </li>
         </ul>
       </ul>
     </details>
-    <br/>
+    <br />
 
     <button class="connect">Connect</button>
     <button class="sendInApp">Send in-app notification</button>
@@ -32,36 +35,41 @@
   <script>
     const snapId = `local:${window.location.href}`;
 
-    const connectButton = document.querySelector('button.connect')
-    const sendInAppButton = document.querySelector('button.sendInApp')
-    const sendNativeButton = document.querySelector('button.sendNative')
+    const connectButton = document.querySelector('button.connect');
+    const sendInAppButton = document.querySelector('button.sendInApp');
+    const sendNativeButton = document.querySelector('button.sendNative');
 
-    connectButton.addEventListener('click', connect)
-    sendInAppButton.addEventListener('click', () => send('inApp'))
-    sendNativeButton.addEventListener('click', () => send('native'))
+    connectButton.addEventListener('click', connect);
+    sendInAppButton.addEventListener('click', () => send('inApp'));
+    sendNativeButton.addEventListener('click', () => send('native'));
 
     // here we get permissions to interact with and install the snap
-    async function connect () {
+    async function connect() {
       await ethereum.request({
         method: 'wallet_enable',
-        params: [{
-          wallet_snap: { [snapId]: {} },
-        }]
-      })
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
     }
 
     // here we call the snap's "inApp" or "native" method
-    async function send (method) {
+    async function send(method) {
       try {
         await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: method
-          }]
-        })
+          params: [
+            snapId,
+            {
+              method: method,
+            },
+          ],
+        });
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
   </script>

--- a/packages/examples/examples/ethers-js/index.html
+++ b/packages/examples/examples/ethers-js/index.html
@@ -1,6 +1,6 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  </head>
+  <head>
     <title>Hello Snaps!</title>
   </head>
 
@@ -13,15 +13,18 @@
         <li>Please note that:</li>
         <ul>
           <li>
-            The <code>snap.manifest.json</code> and <code>package.json</code> must be located in located in the server root directory.
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in located in the server
+            root directory.
           </li>
           <li>
-            The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
           </li>
         </ul>
       </ul>
     </details>
-    <br/>
+    <br />
 
     <button class="connect">Connect</button>
     <button class="getAddress">Get Address</button>
@@ -31,57 +34,64 @@
   <script>
     const snapId = `local:${window.location.href}`;
 
-    const connectButton = document.querySelector('button.connect')
-    const sendButton = document.querySelector('button.sendHello')
-    const getAddressButton = document.querySelector('button.getAddress')
+    const connectButton = document.querySelector('button.connect');
+    const sendButton = document.querySelector('button.sendHello');
+    const getAddressButton = document.querySelector('button.getAddress');
 
-    connectButton.addEventListener('click', connect)
-    sendButton.addEventListener('click', send)
-    getAddressButton.addEventListener('click', getAddress)
+    connectButton.addEventListener('click', connect);
+    sendButton.addEventListener('click', send);
+    getAddressButton.addEventListener('click', getAddress);
 
-    async function connect () {
+    async function connect() {
       await ethereum.request({
         method: 'wallet_enable',
-        params: [{
-          wallet_snap: { [snapId]: {} }
-        }]
-      })
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
     }
 
-    async function getAddress () {
+    async function getAddress() {
       try {
         const response = await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'address',
-          }]
-        })
-        const msg = `responded ${response}`
-        console.log(msg)
-        alert(msg)
+          params: [
+            snapId,
+            {
+              method: 'address',
+            },
+          ],
+        });
+        const msg = `responded ${response}`;
+        console.log(msg);
+        alert(msg);
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
 
-    async function send () {
+    async function send() {
       try {
         const response = await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'signMessage',
-            params: ['Hello, world!'],
-          }]
-        })
-        const msg = `responded: ${response}`
-        console.log(msg)
-        alert(msg)
+          params: [
+            snapId,
+            {
+              method: 'signMessage',
+              params: ['Hello, world!'],
+            },
+          ],
+        });
+        const msg = `responded: ${response}`;
+        console.log(msg);
+        alert(msg);
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
-
   </script>
 </html>

--- a/packages/examples/examples/insights/README.md
+++ b/packages/examples/examples/insights/README.md
@@ -1,0 +1,14 @@
+# Transaction Insights Example Snap
+
+This Snap demonstrates how to use the transaction insights feature.
+
+## Notes
+
+- Babel is used for transpiling TypeScript to JavaScript, so when building with the CLI,
+  `transpilationMode` must be set to `localOnly` (default) or `localAndDeps`.
+- For the global `wallet` type to work, you have to add the following to your `tsconfig.json`:
+  ```json
+  {
+    "files": ["./node_modules/@metamask/snap-types/global.d.ts"]
+  }
+  ```

--- a/packages/examples/examples/insights/index.html
+++ b/packages/examples/examples/insights/index.html
@@ -28,22 +28,28 @@
     <br />
 
     <button class="connect">Connect</button>
-    <button class="sendTransaction">Send ERC-20 Transaction</button>
-    <button class="sendNFTTransaction">Send NFT Transaction</button>
-    <button class="sendUnknownTransaction">Send Unknown Transaction</button>
+    <button class="updateWithdrawalAccount">
+      Send "Update withdrawal account" Transaction
+    </button>
+    <button class="updateMigrateMode">
+      Send "Update migrate mode" Transaction
+    </button>
+    <button class="updateCap">Send "Update cap" Transaction</button>
   </body>
 
   <script>
     const snapId = `local:${window.location.href}`;
 
     const connectButton = document.querySelector('button.connect');
-    const sendButton = document.querySelector('button.sendTransaction');
-    const sendNFTButton = document.querySelector('button.sendNFTTransaction');
-    const sendUnknownButton = document.querySelector(
-      'button.sendUnknownTransaction',
+    const updateWithdrawalAccountButton = document.querySelector(
+      'button.updateWithdrawalAccount',
     );
+    const updateMigrateModeButton = document.querySelector(
+      'button.updateMigrateMode',
+    );
+    const updateCapButton = document.querySelector('button.updateCap');
 
-    const send = (selector) => async () => {
+    const send = (data) => async () => {
       try {
         // Get the user's account from MetaMask.
         const accounts = await ethereum.request({
@@ -59,7 +65,7 @@
               from,
               to: '0x08A8fDBddc160A7d5b957256b903dCAb1aE512C5',
               value: '0x0',
-              data: `0x${selector}00000000000000000000000047170ceae335a9db7e96b72de630389669b334710000000000000000000000000000000000000000000000000000000000000001`,
+              data,
             },
           ],
         });
@@ -70,9 +76,25 @@
     };
 
     connectButton.addEventListener('click', connect);
-    sendButton.addEventListener('click', send('f0f0f0f0'));
-    sendNFTButton.addEventListener('click', send('e1e1e1e1'));
-    sendUnknownButton.addEventListener('click', send('d2d2d2d2'));
+
+    updateWithdrawalAccountButton.addEventListener(
+      'click',
+      send(
+        '0x83ade3dc00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000047170ceae335a9db7e96b72de630389669b334710000000000000000000000006b175474e89094c44da98b954eedeac495271d0f',
+      ),
+    );
+    updateMigrateModeButton.addEventListener(
+      'click',
+      send(
+        '0x2e26065e0000000000000000000000000000000000000000000000000000000000000000',
+      ),
+    );
+    updateCapButton.addEventListener(
+      'click',
+      send(
+        '0x85b2c14a00000000000000000000000047170ceae335a9db7e96b72de630389669b334710000000000000000000000000000000000000000000000000de0b6b3a7640000',
+      ),
+    );
 
     // here we get permissions to interact with and install the snap
     async function connect() {

--- a/packages/examples/examples/insights/index.html
+++ b/packages/examples/examples/insights/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello, Snaps!</title>
+    <link rel="icon" type="image/svg" href="./images/icon.svg" />
+  </head>
+
+  <body>
+    <h1>Hello, Snaps!</h1>
+    <details>
+      <summary>Instructions</summary>
+      <ul>
+        <li>First, click "Connect". Then, try out the other buttons!</li>
+        <li>Please note that:</li>
+        <ul>
+          <li>
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in the server root
+            directory..
+          </li>
+          <li>
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
+          </li>
+        </ul>
+      </ul>
+    </details>
+    <br />
+
+    <button class="connect">Connect</button>
+    <button class="sendTransaction">Send ERC-20 Transaction</button>
+    <button class="sendNFTTransaction">Send NFT Transaction</button>
+    <button class="sendUnknownTransaction">Send Unknown Transaction</button>
+  </body>
+
+  <script>
+    const snapId = `local:${window.location.href}`;
+
+    const connectButton = document.querySelector('button.connect');
+    const sendButton = document.querySelector('button.sendTransaction');
+    const sendNFTButton = document.querySelector('button.sendNFTTransaction');
+    const sendUnknownButton = document.querySelector(
+      'button.sendUnknownTransaction',
+    );
+
+    const send = (selector) => async () => {
+      try {
+        // Get the user's account from MetaMask.
+        const accounts = await ethereum.request({
+          method: 'eth_requestAccounts',
+        });
+        const from = accounts[0];
+
+        // Send a transaction to MetaMask.
+        await ethereum.request({
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              from,
+              to: '0x08A8fDBddc160A7d5b957256b903dCAb1aE512C5',
+              value: '0x0',
+              data: `0x${selector}00000000000000000000000047170ceae335a9db7e96b72de630389669b334710000000000000000000000000000000000000000000000000000000000000001`,
+            },
+          ],
+        });
+      } catch (err) {
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
+      }
+    };
+
+    connectButton.addEventListener('click', connect);
+    sendButton.addEventListener('click', send('f0f0f0f0'));
+    sendNFTButton.addEventListener('click', send('e1e1e1e1'));
+    sendUnknownButton.addEventListener('click', send('d2d2d2d2'));
+
+    // here we get permissions to interact with and install the snap
+    async function connect() {
+      await ethereum.request({
+        method: 'wallet_enable',
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
+    }
+  </script>
+</html>

--- a/packages/examples/examples/insights/package.json
+++ b/packages/examples/examples/insights/package.json
@@ -1,27 +1,33 @@
 {
-  "name": "examples",
-  "version": "0.22.2",
+  "name": "transaction-insights-snap",
+  "version": "0.22.1",
   "private": true,
-  "description": "Example MetaMask Snaps.",
+  "description": "An example transaction insights Snap.",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "MIT",
+  "main": "src/index.ts",
   "files": [
-    "examples/"
-  ],
-  "workspaces": [
-    "examples/*"
+    "dist/",
+    "images/",
+    "snap.manifest.json"
   ],
   "scripts": {
-    "lint:changelog": "yarn auto-changelog validate",
+    "build:clean": "yarn clean && yarn build",
+    "build:website": "node ./scripts/build-website.js",
+    "build": "mm-snap build",
+    "serve": "mm-snap serve",
+    "clean": "rimraf 'dist/*'",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.html' '!CHANGELOG.md' --ignore-path ../../.gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "build": "yarn workspaces foreach --parallel --verbose run build",
-    "build:post-tsc": "yarn build"
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write"
+  },
+  "dependencies": {
+    "@metamask/abi-utils": "^1.0.0",
+    "@metamask/utils": "^3.2.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
@@ -30,9 +36,8 @@
     "@metamask/eslint-config-jest": "^9.0.0",
     "@metamask/eslint-config-nodejs": "^9.0.0",
     "@metamask/eslint-config-typescript": "^9.0.1",
-    "@metamask/snaps-cli": "^0.22.2",
-    "@typescript-eslint/eslint-plugin": "^5.19.0",
-    "@typescript-eslint/parser": "^5.19.0",
+    "@metamask/snap-types": "^0.22.1",
+    "@metamask/snaps-cli": "^0.22.1",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.23.4",
@@ -51,10 +56,5 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
-  },
-  "lavamoat": {
-    "allowScripts": {
-      "@lavamoat/preinstall-always-fail": false
-    }
   }
 }

--- a/packages/examples/examples/insights/package.json
+++ b/packages/examples/examples/insights/package.json
@@ -21,7 +21,7 @@
     "serve": "mm-snap serve",
     "clean": "rimraf 'dist/*'",
     "lint:eslint": "eslint . --cache --ext js,ts",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
+    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.html' '!CHANGELOG.md' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write"
   },

--- a/packages/examples/examples/insights/snap.config.js
+++ b/packages/examples/examples/insights/snap.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  cliOptions: {
+    src: './src/index.ts',
+    port: 8087,
+  },
+};

--- a/packages/examples/examples/insights/snap.manifest.json
+++ b/packages/examples/examples/insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "Qw/8wzOL1NypcGM4owKVlpdlQsg2gAk2ZQjt4vpR1iU=",
+    "shasum": "7akrt/wVNBq0/Up8xWg8POIPQx+6W2EaXdkJp7gLqbs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/insights/snap.manifest.json
+++ b/packages/examples/examples/insights/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "7akrt/wVNBq0/Up8xWg8POIPQx+6W2EaXdkJp7gLqbs=",
+    "shasum": "l3QRoIUw1LSiuN1Y3bl88eqWDj3pc6AL5Wwp/j+ClhA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -17,7 +17,8 @@
     }
   },
   "initialPermissions": {
-    "endowment:transaction-insight": {}
+    "endowment:transaction-insight": {},
+    "endowment:network-access": {}
   },
   "manifestVersion": "0.1"
 }

--- a/packages/examples/examples/insights/snap.manifest.json
+++ b/packages/examples/examples/insights/snap.manifest.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.22.1",
+  "description": "An example transaction insights Snap.",
+  "proposedName": "Transaction Insights Example Snap",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
+  },
+  "source": {
+    "shasum": "Qw/8wzOL1NypcGM4owKVlpdlQsg2gAk2ZQjt4vpR1iU=",
+    "location": {
+      "npm": {
+        "filePath": "dist/bundle.js",
+        "packageName": "transaction-insights-snap",
+        "registry": "https://registry.npmjs.org/"
+      }
+    }
+  },
+  "initialPermissions": {
+    "endowment:transaction-insight": {}
+  },
+  "manifestVersion": "0.1"
+}

--- a/packages/examples/examples/insights/src/index.ts
+++ b/packages/examples/examples/insights/src/index.ts
@@ -1,0 +1,15 @@
+import { OnTransactionHandler } from '@metamask/snap-types';
+import { getInsights } from './insights';
+
+/**
+ * Handle an incoming transaction, and return any insights.
+ *
+ * @param args - The request handler args as object.
+ * @param args.transaction - The transaction object.
+ * @returns The transaction insights.
+ */
+export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
+  return {
+    insights: getInsights(transaction),
+  };
+};

--- a/packages/examples/examples/insights/src/index.ts
+++ b/packages/examples/examples/insights/src/index.ts
@@ -10,6 +10,6 @@ import { getInsights } from './insights';
  */
 export const onTransaction: OnTransactionHandler = async ({ transaction }) => {
   return {
-    insights: getInsights(transaction),
+    insights: await getInsights(transaction),
   };
 };

--- a/packages/examples/examples/insights/src/insights.ts
+++ b/packages/examples/examples/insights/src/insights.ts
@@ -120,7 +120,7 @@ export const getInsights = async (transaction: Record<string, unknown>) => {
     const types = fn.slice(fn.indexOf('(') + 1, fn.indexOf(')')).split(',');
 
     // Decode the data using the ABI utils library.
-    const decoded: any[] = decode(types, add0x(data.slice(8)));
+    const decoded = decode(types, add0x(data.slice(8)));
 
     // Return the function name and decoded arguments.
     return {

--- a/packages/examples/examples/insights/src/insights.ts
+++ b/packages/examples/examples/insights/src/insights.ts
@@ -1,0 +1,70 @@
+import { add0x, hasProperty, isObject, remove0x } from '@metamask/utils';
+import { decode } from '@metamask/abi-utils';
+
+/**
+ * As an example, get transaction insights by looking at the transaction data
+ * and attempting to decode it.
+ *
+ * @param transaction - The transaction to get insights for.
+ * @returns The transaction insights.
+ */
+export const getInsights = (transaction: Record<string, unknown>) => {
+  try {
+    // Check if the transaction has data.
+    if (
+      !isObject(transaction) ||
+      !hasProperty(transaction, 'data') ||
+      typeof transaction.data !== 'string'
+    ) {
+      return {
+        type: 'Unknown transaction',
+      };
+    }
+
+    const data = remove0x(transaction.data);
+
+    // Get the function selector from the transaction data.
+    const selector = data.slice(0, 8);
+
+    // Check the function selector against the known selectors.
+    switch (selector) {
+      // Random "token transfer" example selector.
+      case 'f0f0f0f0': {
+        // Decode the transaction data.
+        const [to, value] = decode(
+          ['address', 'uint256'],
+          add0x(data.slice(8)),
+        );
+
+        return {
+          type: 'Sending Tokens',
+          to,
+          value: value.toString(10),
+        };
+      }
+
+      // Random "NFT transfer" example selector.
+      case 'e1e1e1e1': {
+        // Decode the transaction data.
+        const [to, id] = decode(['address', 'uint256'], add0x(data.slice(8)));
+
+        return {
+          type: 'Sending NFT',
+          to,
+          id: id.toString(10),
+        };
+      }
+
+      default: {
+        return {
+          type: 'Unknown transaction',
+        };
+      }
+    }
+  } catch (error) {
+    console.error(error);
+    return {
+      type: 'Unknown transaction',
+    };
+  }
+};

--- a/packages/examples/examples/insights/src/insights.ts
+++ b/packages/examples/examples/insights/src/insights.ts
@@ -1,5 +1,84 @@
-import { add0x, hasProperty, isObject, remove0x } from '@metamask/utils';
+import {
+  add0x,
+  bytesToHex,
+  hasProperty,
+  isObject,
+  remove0x,
+} from '@metamask/utils';
 import { decode } from '@metamask/abi-utils';
+
+// The API endpoint to get a list of functions by 4 byte signature.
+const API_ENDPOINT =
+  'https://www.4byte.directory/api/v1/signatures/?hex_signature=';
+
+/* eslint-disable camelcase */
+type FourByteSignature = {
+  id: number;
+  created_at: string;
+  text_signature: string;
+  hex_signature: string;
+  bytes_signature: string;
+};
+/* eslint-enable camelcase */
+
+/**
+ * Gets the function name(s) for the given 4 byte signature.
+ *
+ * @param signature - The 4 byte signature to get the function name(s) for. This
+ * should be a hex string prefixed with '0x'.
+ * @returns The function name(s) for the given 4 byte signature, or an empty
+ * array if none are found.
+ */
+export const getFunctionsBySignature = async (
+  signature: `0x${string}`,
+): Promise<string[]> => {
+  const response = await fetch(`${API_ENDPOINT}${signature}`, {
+    method: 'get',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Unable to fetch functions for signature "${signature}": ${response.status} ${response.statusText}.`,
+    );
+  }
+
+  // The response is an array of objects, each with a "text_signature" property.
+  const { results } = (await response.json()) as {
+    results: FourByteSignature[];
+  };
+
+  // The "text_signature" property is a string like "transfer(address,uint256)",
+  // which is what we want. They are sorted by oldest first.
+  return results
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .map((result) => result.text_signature);
+};
+
+/**
+ * The ABI decoder returns certain which are not JSON serializable. This
+ * function converts them to strings.
+ *
+ * @param value - The value to convert.
+ * @returns The converted value.
+ */
+const normalizeValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(normalizeValue);
+  }
+
+  if (value instanceof Uint8Array) {
+    return bytesToHex(value);
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  return value;
+};
 
 /**
  * As an example, get transaction insights by looking at the transaction data
@@ -8,7 +87,7 @@ import { decode } from '@metamask/abi-utils';
  * @param transaction - The transaction to get insights for.
  * @returns The transaction insights.
  */
-export const getInsights = (transaction: Record<string, unknown>) => {
+export const getInsights = async (transaction: Record<string, unknown>) => {
   try {
     // Check if the transaction has data.
     if (
@@ -23,44 +102,31 @@ export const getInsights = (transaction: Record<string, unknown>) => {
 
     const data = remove0x(transaction.data);
 
-    // Get the function selector from the transaction data.
-    const selector = data.slice(0, 8);
+    // Get possible function names for the function signature, i.e., the first
+    // 4 bytes of the data.
+    const signature = data.slice(0, 8);
+    const functions = await getFunctionsBySignature(add0x(signature));
 
-    // Check the function selector against the known selectors.
-    switch (selector) {
-      // Random "token transfer" example selector.
-      case 'f0f0f0f0': {
-        // Decode the transaction data.
-        const [to, value] = decode(
-          ['address', 'uint256'],
-          add0x(data.slice(8)),
-        );
-
-        return {
-          type: 'Sending Tokens',
-          to,
-          value: value.toString(10),
-        };
-      }
-
-      // Random "NFT transfer" example selector.
-      case 'e1e1e1e1': {
-        // Decode the transaction data.
-        const [to, id] = decode(['address', 'uint256'], add0x(data.slice(8)));
-
-        return {
-          type: 'Sending NFT',
-          to,
-          id: id.toString(10),
-        };
-      }
-
-      default: {
-        return {
-          type: 'Unknown transaction',
-        };
-      }
+    // No functions found for the signature.
+    if (functions.length === 0) {
+      return {
+        type: 'Unknown transaction',
+      };
     }
+
+    // This is a function in the shape "functionName(arg1Type,arg2Type,...)", so
+    // we do a simple slice to get the argument types.
+    const fn = functions[0];
+    const types = fn.slice(fn.indexOf('(') + 1, fn.indexOf(')')).split(',');
+
+    // Decode the data using the ABI utils library.
+    const decoded: any[] = decode(types, add0x(data.slice(8)));
+
+    // Return the function name and decoded arguments.
+    return {
+      type: fn,
+      args: decoded.map(normalizeValue),
+    };
   } catch (error) {
     console.error(error);
     return {

--- a/packages/examples/examples/insights/tsconfig.json
+++ b/packages/examples/examples/insights/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.packages.json",
+  "compilerOptions": {
+    "typeRoots": ["../../../../node_modules/@types"]
+  },
+  "files": ["../../../types/global.d.ts"],
+  "include": ["src"]
+}

--- a/packages/examples/examples/ipfs/index.html
+++ b/packages/examples/examples/ipfs/index.html
@@ -1,6 +1,6 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  </head>
+  <head>
     <title>IPFS Snap Example</title>
   </head>
 
@@ -13,89 +13,98 @@
         <li>Please note that:</li>
         <ul>
           <li>
-            The <code>snap.manifest.json</code> and <code>package.json</code> must be located in located in the server root directory.
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in located in the server
+            root directory.
           </li>
           <li>
-            The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
           </li>
         </ul>
       </ul>
     </details>
-    <br/>
+    <br />
 
     <button class="connect">Connect</button>
 
     <p>
-      <input class="toAdd" placeholder="String to upload"></input>
+      <input class="toAdd" placeholder="String to upload" />
       <button class="add">Add</button>
       <span class="addOutput"></span>
     </p>
 
     <p>
-      <input class="toGet" placeholder="IPFS content's hash"></input>
+      <input class="toGet" placeholder="IPFS content's hash" />
       <button class="get">Get</button>
       <span class="getOutput"></span>
     </p>
-
   </body>
 
   <script>
     const snapId = `local:${window.location.href}`;
 
-    const connectButton = document.querySelector('button.connect')
+    const connectButton = document.querySelector('button.connect');
 
-    const toAdd = document.querySelector('input.toAdd')
-    const addButton = document.querySelector('button.add')
-    const addOutput = document.querySelector('span.addOutput')
+    const toAdd = document.querySelector('input.toAdd');
+    const addButton = document.querySelector('button.add');
+    const addOutput = document.querySelector('span.addOutput');
 
-    const toGet = document.querySelector('input.toGet')
-    const getButton = document.querySelector('button.get')
-    const getOutput = document.querySelector('span.getOutput')
+    const toGet = document.querySelector('input.toGet');
+    const getButton = document.querySelector('button.get');
+    const getOutput = document.querySelector('span.getOutput');
 
-    connectButton.addEventListener('click', connect)
-    addButton.addEventListener('click', add)
-    getButton.addEventListener('click', get)
+    connectButton.addEventListener('click', connect);
+    addButton.addEventListener('click', add);
+    getButton.addEventListener('click', get);
 
-    async function connect () {
+    async function connect() {
       await ethereum.request({
         method: 'wallet_enable',
-        params: [{
-          wallet_snap: { [snapId]: {} },
-        }]
-      })
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
     }
 
-    async function add () {
+    async function add() {
       try {
         const response = await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'add',
-            params: [ toAdd.value ],
-          }]
-        })
-        addOutput.innerText = response
+          params: [
+            snapId,
+            {
+              method: 'add',
+              params: [toAdd.value],
+            },
+          ],
+        });
+        addOutput.innerText = response;
       } catch (err) {
-        console.error(err)
-        addOutput.innerText = `Problem getting: ${JSON.stringify(err)}`
+        console.error(err);
+        addOutput.innerText = `Problem getting: ${JSON.stringify(err)}`;
       }
     }
 
-    async function get () {
+    async function get() {
       try {
         const response = await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'cat',
-            params: [ toGet.value ],
-          }]
-        })
-        getOutput.innerText = response
+          params: [
+            snapId,
+            {
+              method: 'cat',
+              params: [toGet.value],
+            },
+          ],
+        });
+        getOutput.innerText = response;
       } catch (err) {
-        console.error(err)
-        getOutput.innerText = `Problem getting: ${JSON.stringify(err)}`
+        console.error(err);
+        getOutput.innerText = `Problem getting: ${JSON.stringify(err)}`;
       }
     }
-
   </script>
 </html>

--- a/packages/examples/examples/notifications/index.html
+++ b/packages/examples/examples/notifications/index.html
@@ -1,8 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  </head>
+  <head>
     <title>Hello, Snaps!</title>
-    <link rel="icon" type="image/svg" href="./images/icon.svg"/>
+    <link rel="icon" type="image/svg" href="./images/icon.svg" />
   </head>
 
   <body>
@@ -14,15 +14,18 @@
         <li>Please note that:</li>
         <ul>
           <li>
-            The <code>snap.manifest.json</code> and <code>package.json</code> must be located in the server root directory.
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in the server root
+            directory.
           </li>
           <li>
-            The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
           </li>
         </ul>
       </ul>
     </details>
-    <br/>
+    <br />
 
     <button class="connect">Connect</button>
     <button class="sendInApp">Send in-app notification</button>
@@ -32,36 +35,41 @@
   <script>
     const snapId = `local:${window.location.href}`;
 
-    const connectButton = document.querySelector('button.connect')
-    const sendInAppButton = document.querySelector('button.sendInApp')
-    const sendNativeButton = document.querySelector('button.sendNative')
+    const connectButton = document.querySelector('button.connect');
+    const sendInAppButton = document.querySelector('button.sendInApp');
+    const sendNativeButton = document.querySelector('button.sendNative');
 
-    connectButton.addEventListener('click', connect)
-    sendInAppButton.addEventListener('click', () => send('inApp'))
-    sendNativeButton.addEventListener('click', () => send('native'))
+    connectButton.addEventListener('click', connect);
+    sendInAppButton.addEventListener('click', () => send('inApp'));
+    sendNativeButton.addEventListener('click', () => send('native'));
 
     // here we get permissions to interact with and install the snap
-    async function connect () {
+    async function connect() {
       await ethereum.request({
         method: 'wallet_enable',
-        params: [{
-          wallet_snap: { [snapId]: {} },
-        }]
-      })
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
     }
 
     // here we call the snap's "inApp" or "native" method
-    async function send (method) {
+    async function send(method) {
       try {
         await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: method
-          }]
-        })
+          params: [
+            snapId,
+            {
+              method: method,
+            },
+          ],
+        });
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
   </script>

--- a/packages/examples/examples/rollup/index.html
+++ b/packages/examples/examples/rollup/index.html
@@ -1,29 +1,32 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <title>Rollup Snap</title>
-  <script defer src="./dist/main.js"></script>
-</head>
-<body>
-<h1>Hello, Snaps!</h1>
-<details>
-  <summary>Instructions</summary>
-  <ul>
-    <li>First, click "Connect". Then, try out the other buttons!</li>
-    <li>Please note that:</li>
-    <ul>
-      <li>
-        The <code>snap.manifest.json</code> and <code>package.json</code> must be located in the server root directory.
-      </li>
-      <li>
-        The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
-      </li>
-    </ul>
-  </ul>
-</details>
-<br/>
-<button class="connect">Connect</button>
-<button class="sendInApp">Send in-app notification</button>
-<button class="sendNative">Send native notification</button>
-</body>
+  <head>
+    <title>Rollup Snap</title>
+    <script defer src="./dist/main.js"></script>
+  </head>
+  <body>
+    <h1>Hello, Snaps!</h1>
+    <details>
+      <summary>Instructions</summary>
+      <ul>
+        <li>First, click "Connect". Then, try out the other buttons!</li>
+        <li>Please note that:</li>
+        <ul>
+          <li>
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in the server root
+            directory.
+          </li>
+          <li>
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
+          </li>
+        </ul>
+      </ul>
+    </details>
+    <br />
+    <button class="connect">Connect</button>
+    <button class="sendInApp">Send in-app notification</button>
+    <button class="sendNative">Send native notification</button>
+  </body>
 </html>

--- a/packages/examples/examples/typescript/index.html
+++ b/packages/examples/examples/typescript/index.html
@@ -1,8 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  </head>
+  <head>
     <title>Hello, Snaps!</title>
-    <link rel="icon" type="image/svg" href="./images/icon.svg"/>
+    <link rel="icon" type="image/svg" href="./images/icon.svg" />
   </head>
 
   <body>
@@ -14,15 +14,18 @@
         <li>Please note that:</li>
         <ul>
           <li>
-            The <code>snap.manifest.json</code> and <code>package.json</code> must be located in located in the server root directory..
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in located in the server
+            root directory..
           </li>
           <li>
-            The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
           </li>
         </ul>
       </ul>
     </details>
-    <br/>
+    <br />
 
     <button class="connect">Connect</button>
     <button class="sendHello">Send Hello</button>
@@ -31,34 +34,39 @@
   <script>
     const snapId = `local:${window.location.href}`;
 
-    const connectButton = document.querySelector('button.connect')
-    const sendButton = document.querySelector('button.sendHello')
+    const connectButton = document.querySelector('button.connect');
+    const sendButton = document.querySelector('button.sendHello');
 
-    connectButton.addEventListener('click', connect)
-    sendButton.addEventListener('click', send)
+    connectButton.addEventListener('click', connect);
+    sendButton.addEventListener('click', send);
 
     // here we get permissions to interact with and install the snap
-    async function connect () {
+    async function connect() {
       await ethereum.request({
         method: 'wallet_enable',
-        params: [{
-          wallet_snap: { [snapId]: {} },
-        }]
-      })
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
     }
 
     // here we call the snap's "inApp" or "native" method
-    async function send () {
+    async function send() {
       try {
         await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'hello'
-          }]
-        })
+          params: [
+            snapId,
+            {
+              method: 'hello',
+            },
+          ],
+        });
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
   </script>

--- a/packages/examples/examples/wasm/index.html
+++ b/packages/examples/examples/wasm/index.html
@@ -1,6 +1,6 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  </head>
+  <head>
     <title>WebAssembly Example</title>
   </head>
 
@@ -13,21 +13,24 @@
         <li>Please note that:</li>
         <ul>
           <li>
-            The <code>snap.manifest.json</code> and <code>package.json</code> must be located in located in the server root directory.
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in located in the server
+            root directory.
           </li>
           <li>
-            The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
           </li>
         </ul>
       </ul>
     </details>
-    <br/>
+    <br />
 
     <button class="connect">Connect</button>
-    <br>
+    <br />
 
-    <input type="number" class="num" value="4">
-    <br>
+    <input type="number" class="num" value="4" />
+    <br />
 
     <button class="callWasm">Call WebAssembly Function</button>
   </body>
@@ -35,36 +38,41 @@
   <script>
     const snapId = `local:${window.location.href}`;
 
-    const connectButton = document.querySelector('button.connect')
-    const wasmButton = document.querySelector('button.callWasm')
+    const connectButton = document.querySelector('button.connect');
+    const wasmButton = document.querySelector('button.callWasm');
 
-    connectButton.addEventListener('click', connect)
-    wasmButton.addEventListener('click', callWasm)
+    connectButton.addEventListener('click', connect);
+    wasmButton.addEventListener('click', callWasm);
 
-    async function connect () {
+    async function connect() {
       await ethereum.request({
         method: 'wallet_enable',
-        params: [{
-          wallet_snap: { [snapId]: {} },
-        }]
-      })
+        params: [
+          {
+            wallet_snap: { [snapId]: {} },
+          },
+        ],
+      });
     }
 
-    async function callWasm () {
+    async function callWasm() {
       try {
-        const value = parseInt(document.querySelector("input.num").value, 10);
+        const value = parseInt(document.querySelector('input.num').value, 10);
         const response = await ethereum.request({
           method: 'wallet_invokeSnap',
-          params: [snapId, {
-            method: 'fib',
-            params: [value]
-          }]
-        })
+          params: [
+            snapId,
+            {
+              method: 'fib',
+              params: [value],
+            },
+          ],
+        });
 
-        alert('Received: ' + JSON.stringify(response))
+        alert('Received: ' + JSON.stringify(response));
       } catch (err) {
-        console.error(err)
-        alert('Problem happened: ' + err.message || err)
+        console.error(err);
+        alert('Problem happened: ' + err.message || err);
       }
     }
   </script>

--- a/packages/examples/examples/webpack/src/index.html
+++ b/packages/examples/examples/webpack/src/index.html
@@ -1,28 +1,31 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <title>Webpack Snap</title>
-</head>
-<body>
-<h1>Hello, Snaps!</h1>
-<details>
-  <summary>Instructions</summary>
-  <ul>
-    <li>First, click "Connect". Then, try out the other buttons!</li>
-    <li>Please note that:</li>
-    <ul>
-      <li>
-        The <code>snap.manifest.json</code> and <code>package.json</code> must be located in the server root directory.
-      </li>
-      <li>
-        The Snap bundle must be hosted at the location specified by the <code>location</code> field of <code>snap.manifest.json</code>.
-      </li>
-    </ul>
-  </ul>
-</details>
-<br/>
-<button class="connect">Connect</button>
-<button class="sendInApp">Send in-app notification</button>
-<button class="sendNative">Send native notification</button>
-</body>
+  <head>
+    <title>Webpack Snap</title>
+  </head>
+  <body>
+    <h1>Hello, Snaps!</h1>
+    <details>
+      <summary>Instructions</summary>
+      <ul>
+        <li>First, click "Connect". Then, try out the other buttons!</li>
+        <li>Please note that:</li>
+        <ul>
+          <li>
+            The <code>snap.manifest.json</code> and
+            <code>package.json</code> must be located in the server root
+            directory.
+          </li>
+          <li>
+            The Snap bundle must be hosted at the location specified by the
+            <code>location</code> field of <code>snap.manifest.json</code>.
+          </li>
+        </ul>
+      </ul>
+    </details>
+    <br />
+    <button class="connect">Connect</button>
+    <button class="sendInApp">Send in-app notification</button>
+    <button class="sendNative">Send native notification</button>
+  </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,6 +2653,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/abi-utils@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/abi-utils@npm:1.0.0"
+  dependencies:
+    "@metamask/utils": ^3.2.0
+    superstruct: ^0.16.5
+  checksum: d8f8eab61d56248f6fa4bc9d59e68f505ee089be536c98875a6b152550682d60fae6656e1a479ca20fa4ece1615f5e54403e10b0f2a0b439a249899c880eeabc
+  languageName: node
+  linkType: hard
+
 "@metamask/auto-changelog@npm:^2.6.0":
   version: 2.6.0
   resolution: "@metamask/auto-changelog@npm:2.6.0"
@@ -3336,15 +3346,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@metamask/utils@npm:3.1.0"
+"@metamask/utils@npm:^3.1.0, @metamask/utils@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@metamask/utils@npm:3.2.0"
   dependencies:
     "@types/debug": ^4.1.7
     debug: ^4.3.4
     fast-deep-equal: ^3.1.3
     superstruct: ^0.16.5
-  checksum: 6d2c3dab762554d783b49411dd5e285457642d821bc81eee56d2d47af0923bdbc297b7970c71a45dfa870122d00e5613a51c7433ce604d6a1b64ee292d95df0d
+  checksum: 99adcbd273c69075628913259f8c3fb843291898eba813f4f5fe0bfc060ae5955e2c69e70e15b04156793f8d84edd077d1fac3f8c3927e067d0f311eef9d4469
   languageName: node
   linkType: hard
 
@@ -16565,6 +16575,34 @@ __metadata:
   checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
   languageName: node
   linkType: hard
+
+"transaction-insights-snap@workspace:packages/examples/examples/insights":
+  version: 0.0.0-use.local
+  resolution: "transaction-insights-snap@workspace:packages/examples/examples/insights"
+  dependencies:
+    "@lavamoat/allow-scripts": ^2.0.3
+    "@metamask/abi-utils": ^1.0.0
+    "@metamask/auto-changelog": ^2.6.0
+    "@metamask/eslint-config": ^9.0.0
+    "@metamask/eslint-config-jest": ^9.0.0
+    "@metamask/eslint-config-nodejs": ^9.0.0
+    "@metamask/eslint-config-typescript": ^9.0.1
+    "@metamask/snap-types": ^0.22.1
+    "@metamask/snaps-cli": ^0.22.1
+    "@metamask/utils": ^3.2.0
+    eslint: ^7.30.0
+    eslint-config-prettier: ^8.3.0
+    eslint-plugin-import: ^2.23.4
+    eslint-plugin-jest: ^24.4.0
+    eslint-plugin-jsdoc: ^36.1.0
+    eslint-plugin-node: ^11.1.0
+    eslint-plugin-prettier: ^3.4.0
+    prettier: ^2.3.2
+    prettier-plugin-packagejson: ^2.2.11
+    rimraf: ^3.0.2
+    typescript: ^4.4.0
+  languageName: unknown
+  linkType: soft
 
 "tree-kill@npm:^1.2.2":
   version: 1.2.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,7 +3114,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snap-types@^0.22.2, @metamask/snap-types@workspace:packages/types":
+"@metamask/snap-types@^0.22.1, @metamask/snap-types@^0.22.2, @metamask/snap-types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@metamask/snap-types@workspace:packages/types"
   dependencies:
@@ -3223,7 +3223,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-cli@^0.22.2, @metamask/snaps-cli@workspace:packages/cli":
+"@metamask/snaps-cli@^0.22.1, @metamask/snaps-cli@^0.22.2, @metamask/snaps-cli@workspace:packages/cli":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-cli@workspace:packages/cli"
   dependencies:


### PR DESCRIPTION
This adds a basic transaction insights example snap, which looks at the transaction data of an arbitrary transaction, and attempts to decode it.

I've also fixed some linting issues on other HTML files.