### PR TITLE
Fix an issue with installing snaps that request `eth_accounts`

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
       branches: 85.74,
       functions: 95.3,
       lines: 94.84,
-      statements: 94.92,
+      statements: 94.93,
     },
   },
   projects: [

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -182,12 +182,11 @@ describe('SnapController', () => {
       manifest: getSnapManifest(),
     });
 
-    callActionMock.mockImplementation((method) => {
-      if (
-        method === 'PermissionController:hasPermission' ||
-        method === 'ApprovalController:addRequest'
-      ) {
+    callActionMock.mockImplementation((method, ...args) => {
+      if (method === 'PermissionController:hasPermission') {
         return true;
+      } else if (method === 'ApprovalController:addRequest') {
+        return (args[0] as any).requestData;
       } else if (method === 'PermissionController:getEndowments') {
         return ['fooEndowment'] as any;
       }
@@ -557,6 +556,8 @@ describe('SnapController', () => {
           args[1] === SnapEndowments.LongRunning
         ) {
           return false;
+        } else if (method === 'ApprovalController:addRequest') {
+          return (args[0] as any).requestData;
         }
         return true;
       });
@@ -706,7 +707,7 @@ describe('SnapController', () => {
 
     jest.spyOn(messenger, 'call').mockImplementation((method) => {
       if (method === 'ApprovalController:addRequest') {
-        return false;
+        throw ethErrors.provider.userRejectedRequest();
       }
       return true;
     });
@@ -1677,12 +1678,11 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method) => {
-          if (
-            method === 'PermissionController:hasPermission' ||
-            method === 'ApprovalController:addRequest'
-          ) {
+        .mockImplementation((method, ...args) => {
+          if (method === 'PermissionController:hasPermission') {
             return true;
+          } else if (method === 'ApprovalController:addRequest') {
+            return (args[0] as any).requestData;
           } else if (method === 'PermissionController:getPermissions') {
             return {};
           }
@@ -1734,6 +1734,14 @@ describe('SnapController', () => {
         {
           approvedPermissions: getSnapManifest().initialPermissions,
           subject: { origin: MOCK_LOCAL_SNAP_ID },
+          requestData: {
+            metadata: {
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+              origin: MOCK_LOCAL_SNAP_ID,
+            },
+            snapId: MOCK_LOCAL_SNAP_ID,
+          },
         },
       );
 
@@ -1776,12 +1784,11 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method) => {
-          if (
-            method === 'PermissionController:hasPermission' ||
-            method === 'ApprovalController:addRequest'
-          ) {
+        .mockImplementation((method, ...args) => {
+          if (method === 'PermissionController:hasPermission') {
             return true;
+          } else if (method === 'ApprovalController:addRequest') {
+            return (args[0] as any).requestData;
           } else if (method === 'PermissionController:getPermissions') {
             return {};
           }
@@ -1843,6 +1850,14 @@ describe('SnapController', () => {
         {
           approvedPermissions: manifest.initialPermissions,
           subject: { origin: MOCK_LOCAL_SNAP_ID },
+          requestData: {
+            metadata: {
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+              origin: MOCK_LOCAL_SNAP_ID,
+            },
+            snapId: MOCK_LOCAL_SNAP_ID,
+          },
         },
       );
 
@@ -1895,6 +1910,14 @@ describe('SnapController', () => {
         {
           approvedPermissions: newManifest.initialPermissions,
           subject: { origin: MOCK_LOCAL_SNAP_ID },
+          requestData: {
+            metadata: {
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+              origin: MOCK_LOCAL_SNAP_ID,
+            },
+            snapId: MOCK_LOCAL_SNAP_ID,
+          },
         },
       );
 
@@ -1931,12 +1954,11 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method) => {
-          if (
-            method === 'PermissionController:hasPermission' ||
-            method === 'ApprovalController:addRequest'
-          ) {
+        .mockImplementation((method, ...args) => {
+          if (method === 'PermissionController:hasPermission') {
             return true;
+          } else if (method === 'ApprovalController:addRequest') {
+            return (args[0] as any).requestData;
           } else if (method === 'PermissionController:getPermissions') {
             return {};
           }
@@ -1988,6 +2010,14 @@ describe('SnapController', () => {
         {
           approvedPermissions: manifest.initialPermissions,
           subject: { origin: MOCK_SNAP_ID },
+          requestData: {
+            metadata: {
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+              origin: MOCK_SNAP_ID,
+            },
+            snapId: MOCK_SNAP_ID,
+          },
         },
       );
 
@@ -2075,6 +2105,14 @@ describe('SnapController', () => {
             },
           },
           subject: { origin: MOCK_SNAP_ID },
+          requestData: {
+            metadata: {
+              origin: MOCK_SNAP_ID,
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+            },
+            snapId: MOCK_SNAP_ID,
+          },
         },
       );
     });
@@ -2135,6 +2173,14 @@ describe('SnapController', () => {
             },
           },
           subject: { origin: MOCK_SNAP_ID },
+          requestData: {
+            metadata: {
+              origin: MOCK_SNAP_ID,
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+            },
+            snapId: MOCK_SNAP_ID,
+          },
         },
       );
     });
@@ -2165,12 +2211,11 @@ describe('SnapController', () => {
 
       const callActionMock = jest.spyOn(messenger, 'call');
 
-      callActionMock.mockImplementation((method) => {
-        if (
-          method === 'PermissionController:hasPermission' ||
-          method === 'ApprovalController:addRequest'
-        ) {
+      callActionMock.mockImplementation((method, ...args) => {
+        if (method === 'PermissionController:hasPermission') {
           return true;
+        } else if (method === 'ApprovalController:addRequest') {
+          return (args[0] as any).requestData;
         } else if (method === 'PermissionController:getPermissions') {
           return {};
         }
@@ -2200,6 +2245,27 @@ describe('SnapController', () => {
             },
           },
           subject: { origin: MOCK_SNAP_ID },
+          requestData: {
+            approvedPermissions: {},
+            metadata: {
+              origin: MOCK_SNAP_ID,
+              dappOrigin: MOCK_ORIGIN,
+              id: expect.any(String),
+            },
+            newPermissions: {
+              snap_getBip32Entropy: {
+                caveats: [
+                  {
+                    type: SnapCaveatType.PermittedDerivationPaths,
+                    value: [{ path: ['m', "44'", "60'"], curve: 'secp256k1' }],
+                  },
+                ],
+              },
+            },
+            newVersion: '1.1.0',
+            snapId: MOCK_SNAP_ID,
+            unusedPermissions: {},
+          },
         },
       );
     });
@@ -2260,12 +2326,11 @@ describe('SnapController', () => {
 
       const callActionMock = jest
         .spyOn(messenger, 'call')
-        .mockImplementation((method) => {
-          if (
-            method === 'PermissionController:hasPermission' ||
-            method === 'ApprovalController:addRequest'
-          ) {
+        .mockImplementation((method, ...args) => {
+          if (method === 'PermissionController:hasPermission') {
             return true;
+          } else if (method === 'ApprovalController:addRequest') {
+            return (args[0] as any).requestData;
           } else if (method === 'PermissionController:getPermissions') {
             return {};
           }
@@ -2320,6 +2385,18 @@ describe('SnapController', () => {
         {
           approvedPermissions: getSnapManifest().initialPermissions,
           subject: { origin: MOCK_SNAP_ID },
+          requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            snapId: MOCK_SNAP_ID,
+            newVersion,
+            newPermissions: getSnapManifest().initialPermissions,
+            approvedPermissions: {},
+            unusedPermissions: {},
+          },
         },
       );
 
@@ -2575,12 +2652,11 @@ describe('SnapController', () => {
           };
         });
 
-      callActionSpy.mockImplementation((method) => {
-        if (
-          method === 'PermissionController:hasPermission' ||
-          method === 'ApprovalController:addRequest'
-        ) {
+      callActionSpy.mockImplementation((method, ...args) => {
+        if (method === 'PermissionController:hasPermission') {
           return true;
+        } else if (method === 'ApprovalController:addRequest') {
+          return (args[0] as any).requestData;
         } else if (method === 'PermissionController:getPermissions') {
           return {};
         }
@@ -2651,6 +2727,18 @@ describe('SnapController', () => {
         {
           approvedPermissions: getSnapManifest().initialPermissions,
           subject: { origin: MOCK_SNAP_ID },
+          requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            snapId: MOCK_SNAP_ID,
+            newVersion: '1.1.0',
+            newPermissions: getSnapManifest().initialPermissions,
+            approvedPermissions: {},
+            unusedPermissions: {},
+          },
         },
       );
 
@@ -2690,12 +2778,11 @@ describe('SnapController', () => {
         };
       });
 
-      callActionSpy.mockImplementation((method) => {
-        if (
-          method === 'PermissionController:hasPermission' ||
-          method === 'ApprovalController:addRequest'
-        ) {
+      callActionSpy.mockImplementation((method, ...args) => {
+        if (method === 'PermissionController:hasPermission') {
           return true;
+        } else if (method === 'ApprovalController:addRequest') {
+          return (args[0] as any).requestData;
         } else if (method === 'PermissionController:getPermissions') {
           return {};
         }
@@ -2806,6 +2893,8 @@ describe('SnapController', () => {
           return true;
         } else if (method === 'PermissionController:getPermissions') {
           return {};
+        } else if (method === 'ApprovalController:addRequest') {
+          throw ethErrors.provider.userRejectedRequest();
         }
         return false;
       });
@@ -2817,11 +2906,12 @@ describe('SnapController', () => {
         manifest: getSnapManifest(),
       });
 
-      const result = await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      await expect(
+        controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID),
+      ).rejects.toThrow('User rejected the request.');
 
       const newSnap = controller.get(MOCK_SNAP_ID);
 
-      expect(result).toBeNull();
       expect(newSnap?.version).toStrictEqual('1.0.0');
       expect(fetchSnapSpy).toHaveBeenCalledTimes(1);
       expect(callActionSpy).toHaveBeenCalledTimes(2);
@@ -2907,12 +2997,11 @@ describe('SnapController', () => {
           };
         });
 
-      callActionSpy.mockImplementation((method) => {
-        if (
-          method === 'PermissionController:hasPermission' ||
-          method === 'ApprovalController:addRequest'
-        ) {
+      callActionSpy.mockImplementation((method, ...args) => {
+        if (method === 'PermissionController:hasPermission') {
           return true;
+        } else if (method === 'ApprovalController:addRequest') {
+          return (args[0] as any).requestData;
         } else if (method === 'PermissionController:getPermissions') {
           return approvedPermissions;
         } else if (
@@ -2977,6 +3066,22 @@ describe('SnapController', () => {
         {
           approvedPermissions: { 'endowment:network-access': {} },
           subject: { origin: MOCK_SNAP_ID },
+          requestData: {
+            metadata: {
+              id: expect.any(String),
+              dappOrigin: MOCK_ORIGIN,
+              origin: MOCK_SNAP_ID,
+            },
+            snapId: MOCK_SNAP_ID,
+            newVersion: '1.1.0',
+            newPermissions: { 'endowment:network-access': {} },
+            approvedPermissions: {
+              snap_confirm: approvedPermissions.snap_confirm,
+            },
+            unusedPermissions: {
+              snap_manageState: approvedPermissions.snap_manageState,
+            },
+          },
         },
       );
 
@@ -3052,16 +3157,12 @@ describe('SnapController', () => {
         });
 
       callActionSpy.mockImplementation((method, request: any) => {
-        if (
-          method === 'PermissionController:hasPermission' ||
-          method === 'ApprovalController:addRequest'
-        ) {
-          if (method === 'ApprovalController:addRequest') {
-            // eslint-disable-next-line jest/no-conditional-expect
-            expect(request.id).toBe(request.requestData.metadata.id);
-          }
-
+        if (method === 'PermissionController:hasPermission') {
           return true;
+        } else if (method === 'ApprovalController:addRequest') {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(request.id).toBe(request.requestData.metadata.id);
+          return request.requestData;
         } else if (method === 'PermissionController:getPermissions') {
           return approvedPermissions;
         } else if (
@@ -3073,9 +3174,7 @@ describe('SnapController', () => {
         return undefined;
       });
 
-      console.log(
-        await snapController.installSnaps(MOCK_ORIGIN, { [MOCK_SNAP_ID]: {} }),
-      );
+      await snapController.installSnaps(MOCK_ORIGIN, { [MOCK_SNAP_ID]: {} });
       await snapController.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
     });
   });

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -1658,7 +1658,7 @@ export class SnapController extends BaseController<
     const newVersion = newSnap.manifest.version;
     if (!gtVersion(newVersion, snap.version)) {
       console.warn(
-        `Tried updating snap "${snapId}" within "${newVersionRange}" version range, but newer version "${newVersion}" is already installed`,
+        `Tried updating snap "${snapId}" within "${newVersionRange}" version range, but newer version "${snap.version}" is already installed`,
       );
       return null;
     }

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -2145,7 +2145,7 @@ export class SnapController extends BaseController<
           true,
         )) as PermissionsRequest;
 
-      if (isNonEmptyArray(Object.keys(processedPermissions))) {
+      if (isNonEmptyArray(Object.keys(approvedPermissions))) {
         await this.messagingSystem.call(
           'PermissionController:grantPermissions',
           {

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -8,6 +8,7 @@ import {
   GrantPermissions,
   HasPermission,
   HasPermissions,
+  PermissionsRequest,
   RestrictedControllerMessenger,
   RevokeAllPermissions,
   RevokePermissionForAllSubjects,
@@ -1675,29 +1676,26 @@ export class SnapController extends BaseController<
       await this.calculatePermissionsChange(snapId, processedPermissions);
 
     const id = nanoid();
-    const isApproved = await this.messagingSystem.call(
-      'ApprovalController:addRequest',
-      {
-        origin,
-        id,
-        type: SNAP_APPROVAL_UPDATE,
-        requestData: {
-          // First two keys mirror installation params
-          metadata: { id, origin: snapId, dappOrigin: origin },
-          permissions: newPermissions,
-          snapId,
-          newVersion: newSnap.manifest.version,
-          newPermissions,
-          approvedPermissions,
-          unusedPermissions,
+    const { permissions: approvedNewPermissions, ...requestData } =
+      (await this.messagingSystem.call(
+        'ApprovalController:addRequest',
+        {
+          origin,
+          id,
+          type: SNAP_APPROVAL_UPDATE,
+          requestData: {
+            // First two keys mirror installation params
+            metadata: { id, origin: snapId, dappOrigin: origin },
+            permissions: newPermissions,
+            snapId,
+            newVersion: newSnap.manifest.version,
+            newPermissions,
+            approvedPermissions,
+            unusedPermissions,
+          },
         },
-      },
-      true,
-    );
-
-    if (!isApproved) {
-      return null;
-    }
+        true,
+      )) as PermissionsRequest;
 
     if (this.isRunning(snapId)) {
       await this.stopSnap(snapId, SnapStatusEvents.Stop);
@@ -1723,10 +1721,11 @@ export class SnapController extends BaseController<
       );
     }
 
-    if (isNonEmptyArray(Object.keys(newPermissions))) {
+    if (isNonEmptyArray(Object.keys(approvedNewPermissions))) {
       await this.messagingSystem.call('PermissionController:grantPermissions', {
-        approvedPermissions: newPermissions,
+        approvedPermissions: approvedNewPermissions,
         subject: { origin: snapId },
+        requestData,
       });
     }
 
@@ -2129,32 +2128,30 @@ export class SnapController extends BaseController<
       const processedPermissions =
         this.processSnapPermissions(initialPermissions);
       const id = nanoid();
-      const isApproved = await this.messagingSystem.call(
-        'ApprovalController:addRequest',
-        {
-          origin,
-          id,
-          type: SNAP_APPROVAL_INSTALL,
-          requestData: {
-            // Mirror previous installation metadata
-            metadata: { id, origin: snapId, dappOrigin: origin },
-            permissions: processedPermissions,
-            snapId,
+      const { permissions: approvedPermissions, ...requestData } =
+        (await this.messagingSystem.call(
+          'ApprovalController:addRequest',
+          {
+            origin,
+            id,
+            type: SNAP_APPROVAL_INSTALL,
+            requestData: {
+              // Mirror previous installation metadata
+              metadata: { id, origin: snapId, dappOrigin: origin },
+              permissions: processedPermissions,
+              snapId,
+            },
           },
-        },
-        true,
-      );
-
-      if (!isApproved) {
-        throw ethErrors.provider.userRejectedRequest();
-      }
+          true,
+        )) as PermissionsRequest;
 
       if (isNonEmptyArray(Object.keys(processedPermissions))) {
         await this.messagingSystem.call(
           'PermissionController:grantPermissions',
           {
-            approvedPermissions: processedPermissions,
+            approvedPermissions,
             subject: { origin: snapId },
+            requestData,
           },
         );
       }

--- a/packages/controllers/src/test-utils/controller.ts
+++ b/packages/controllers/src/test-utils/controller.ts
@@ -80,6 +80,8 @@ export const getSnapControllerMessenger = (
         args[1] === SnapEndowments.LongRunning
       ) {
         return false;
+      } else if (method === 'ApprovalController:addRequest') {
+        return (args[0] as any).requestData;
       }
       return true;
     });


### PR DESCRIPTION
This PR fixes an issue with installing snaps that request `eth_accounts`. 

To create the `eth_accounts` permission, we need the selected accounts from the UI, these are normally passed back in the result of the approval (see https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/app/permission-page-container/permission-page-container.component.js#L90-L109).

`grantPermissions` expects the selected accounts to be in `requestData`, to fix this we can mirror the logic from the PermissionController (what we were using previously): https://github.com/MetaMask/controllers/blob/main/src/permissions/PermissionController.ts#L1861-L1877

This will also need a small change in the extension.

