### PR TITLE
Throw an error when response is unserializable

### DIFF
--- a/packages/execution-environments/jest.config.js
+++ b/packages/execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 84.83,
+      branches: 85.08,
       functions: 93.23,
-      lines: 87.21,
-      statements: 87.4,
+      lines: 87.26,
+      statements: 87.45,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -1494,7 +1494,7 @@ describe('BaseSnapExecutor', () => {
     });
   });
 
-  it('throws when trying to send unserializable values', async () => {
+  it('throws when trying to respond with unserializable values', async () => {
     const CODE = `
       module.exports.onRpcRequest = () => BigInt(0);
     `;

--- a/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -1493,4 +1493,46 @@ describe('BaseSnapExecutor', () => {
       error: expect.anything(),
     });
   });
+
+  it('throws when trying to send unserializable values', async () => {
+    const CODE = `
+      module.exports.onRpcRequest = () => BigInt(0);
+    `;
+    const executor = new TestSnapExecutor();
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'executeSnap',
+      params: [FAKE_SNAP_NAME, CODE, []],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    await executor.writeCommand({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'snapRpc',
+      params: [
+        FAKE_SNAP_NAME,
+        ON_RPC_REQUEST,
+        FAKE_ORIGIN,
+        { jsonrpc: '2.0', method: '', params: [] },
+      ],
+    });
+
+    expect(await executor.readCommand()).toStrictEqual({
+      jsonrpc: '2.0',
+      id: 2,
+      error: {
+        code: -32603,
+        data: expect.any(Object),
+        message: 'JSON-RPC responses must be JSON serializable objects.',
+      },
+    });
+  });
 });

--- a/packages/execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/execution-environments/src/common/BaseSnapExecutor.ts
@@ -185,9 +185,13 @@ export class BaseSnapExecutor {
     });
   }
 
-  protected respond(id: JSONRPCID, responseObj: Record<string, unknown>) {
+  protected respond(id: JSONRPCID, requestObject: Record<string, unknown>) {
+    if (!isValidJson(requestObject) || !isObject(requestObject)) {
+      throw new Error('JSON-RPC responses must be JSON serializable objects.');
+    }
+
     this.commandStream.write({
-      ...responseObj,
+      ...requestObject,
       id,
       jsonrpc: '2.0',
     });


### PR DESCRIPTION
Previously, when a Snap would attempt to send an unserializable response, the stream would close with a cryptic error:

```
Error: PortDuplexStream - disconnected
  at PortDuplexStream._write (common-7.js:32090:23)
  at doWrite (common-8.js:42947:64)
```

This is because streams cannot serialize non-JSON-compatible values. I've added a check to make sure a response is serializable, and throw an error otherwise. Now, when a Snap tries to send an unserializable response, it will result in a more understandable JSON-RPC error:

```json
{
  "code": -32603,
  "message": "JSON-RPC responses must be JSON serializable objects"
}
```