### PR TITLE
Rename repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# snaps-skunkworks
+# snaps-monorepo
 
 Monorepo for experimental snaps dependencies.
 
@@ -40,7 +40,7 @@ Run `yarn test` and `yarn lint` in the project root directory, or in a workspace
 
 ### Publishing
 
-1. Run [Create Release Pull Request workflow](https://github.com/MetaMask/snaps-skunkworks/actions/workflows/create-release-pr.yml)
+1. Run [Create Release Pull Request workflow](https://github.com/MetaMask/snaps-monorepo/actions/workflows/create-release-pr.yml)
 2. Checkout the created branch.
 3. Update CHANGELOG.md in each package, moving changes to their categories and make them more descriptive.
 4. Run `yarn install` in root to update `yarn.lock`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -24,14 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.1]
 ### Fixed
-- Fixed 0.19.0 not being able to run ([#697](https://github.com/MetaMask/snaps-skunkworks/pull/697))
+- Fixed 0.19.0 not being able to run ([#697](https://github.com/MetaMask/snaps-monorepo/pull/697))
 
 ## [0.19.0]
 ### Added
-- Add 'Access-Control-Allow-Origin': * to serve ([#638](https://github.com/MetaMask/snaps-skunkworks/pull/638))
+- Add 'Access-Control-Allow-Origin': * to serve ([#638](https://github.com/MetaMask/snaps-monorepo/pull/638))
 
 ### Changed
-- **BREAKING:** Replace RegEx-based bundle processing and comment stripping with an AST-based solution ([#583](https://github.com/MetaMask/snaps-skunkworks/pull/583))
+- **BREAKING:** Replace RegEx-based bundle processing and comment stripping with an AST-based solution ([#583](https://github.com/MetaMask/snaps-monorepo/pull/583))
 
 ## [0.18.1]
 ### Changed
@@ -39,39 +39,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
-- Update template files ([#632](https://github.com/MetaMask/snaps-skunkworks/pull/632))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
+- Update template files ([#632](https://github.com/MetaMask/snaps-monorepo/pull/632))
 
 ## [0.17.0]
 ### Added
-- Add a TypeScript template for `mm-snap init` ([#546](https://github.com/MetaMask/snaps-skunkworks/pull/546))
-- Add serving to `mm-snap watch` ([#507](https://github.com/MetaMask/snaps-skunkworks/pull/507))
+- Add a TypeScript template for `mm-snap init` ([#546](https://github.com/MetaMask/snaps-monorepo/pull/546))
+- Add serving to `mm-snap watch` ([#507](https://github.com/MetaMask/snaps-monorepo/pull/507))
 
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
 
 ### Fixed
-- Fix segfault when using `mm-snap watch` ([#556](https://github.com/MetaMask/snaps-skunkworks/pull/556))
+- Fix segfault when using `mm-snap watch` ([#556](https://github.com/MetaMask/snaps-monorepo/pull/556))
 
 ## [0.16.0]
 ### Changed
-- **BREAKING:** Snaps are now required to export `onRpcRequest` to receive RPC requests ([#481](https://github.com/MetaMask/snaps-skunkworks/pull/481), [#533](https://github.com/MetaMask/snaps-skunkworks/pull/533), [#538](https://github.com/MetaMask/snaps-skunkworks/pull/538), [#541](https://github.com/MetaMask/snaps-skunkworks/pull/541), [#544](https://github.com/MetaMask/snaps-skunkworks/pull/544))
+- **BREAKING:** Snaps are now required to export `onRpcRequest` to receive RPC requests ([#481](https://github.com/MetaMask/snaps-monorepo/pull/481), [#533](https://github.com/MetaMask/snaps-monorepo/pull/533), [#538](https://github.com/MetaMask/snaps-monorepo/pull/538), [#541](https://github.com/MetaMask/snaps-monorepo/pull/541), [#544](https://github.com/MetaMask/snaps-monorepo/pull/544))
   - The type of the function is available in `@metamask/snap-types` as `OnRpcRequestHandler`.
 
 ### Fixed
-- Fix importing local files in TypeScript Snaps ([#527](https://github.com/MetaMask/snaps-skunkworks/pull/527))
-- Fix `build` command when the CLI is installed globally ([#542](https://github.com/MetaMask/snaps-skunkworks/pull/542))
+- Fix importing local files in TypeScript Snaps ([#527](https://github.com/MetaMask/snaps-monorepo/pull/527))
+- Fix `build` command when the CLI is installed globally ([#542](https://github.com/MetaMask/snaps-monorepo/pull/542))
 
 ## [0.15.0]
 ### Added
-- Add support for building TypeScript Snaps ([#443](https://github.com/MetaMask/snaps-skunkworks/pull/443))
+- Add support for building TypeScript Snaps ([#443](https://github.com/MetaMask/snaps-monorepo/pull/443))
 
 ### Fixed
-- Fix an issue where comment stripping would break for large files ([#468](https://github.com/MetaMask/snaps-skunkworks/pull/468))
+- Fix an issue where comment stripping would break for large files ([#468](https://github.com/MetaMask/snaps-monorepo/pull/468))
 
 ## [0.14.0]
 ### Changed
-- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - This should not be breaking for consumers on any non-deprecated browser or Node.js version.
 
 ## [0.13.0]
@@ -88,24 +88,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0]
 ### Added
-- Add self to mock endowments ([#341](https://github.com/MetaMask/snaps-skunkworks/pull/341))
+- Add self to mock endowments ([#341](https://github.com/MetaMask/snaps-monorepo/pull/341))
 
 ### Changed
-- Bump `ses` to `0.15.15` ([#396](https://github.com/MetaMask/snaps-skunkworks/pull/396))
-- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-skunkworks/pull/360))
-- Update template files ([#350](https://github.com/MetaMask/snaps-skunkworks/pull/350))
+- Bump `ses` to `0.15.15` ([#396](https://github.com/MetaMask/snaps-monorepo/pull/396))
+- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-monorepo/pull/360))
+- Update template files ([#350](https://github.com/MetaMask/snaps-monorepo/pull/350))
 
 ## [0.10.7]
 ### Changed
-- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-skunkworks/pull/331))
-- Update `mm-snap init` template files ([#330](https://github.com/MetaMask/snaps-skunkworks/pull/330))
+- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-monorepo/pull/331))
+- Update `mm-snap init` template files ([#330](https://github.com/MetaMask/snaps-monorepo/pull/330))
 
 ### Fixed
-- Fix issue where comment stripping would create invalid bundles ([#336](https://github.com/MetaMask/snaps-skunkworks/pull/336))
+- Fix issue where comment stripping would create invalid bundles ([#336](https://github.com/MetaMask/snaps-monorepo/pull/336))
 
 ## [0.10.6]
 ### Fixed
-- Fix endowment mocking during `mm-snap eval` ([#311](https://github.com/MetaMask/snaps-skunkworks/pull/311))
+- Fix endowment mocking during `mm-snap eval` ([#311](https://github.com/MetaMask/snaps-monorepo/pull/311))
 
 ## [0.10.5]
 ### Changed
@@ -113,65 +113,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.3]
 ### Fixed
-- Improve dynamic mocking ([#262](https://github.com/MetaMask/snaps-skunkworks/pull/262))
+- Improve dynamic mocking ([#262](https://github.com/MetaMask/snaps-monorepo/pull/262))
 
 ## [0.10.2]
 ### Fixed
-- Installation failure ([#279](https://github.com/MetaMask/snaps-skunkworks/pull/279))
+- Installation failure ([#279](https://github.com/MetaMask/snaps-monorepo/pull/279))
   - A faulty installation script in a dependency caused the installation of this package to fail.
 
 ## [0.10.1]
 ### Fixed
-- Comment stripping will no longer remove empty block comments in strings ([#276](https://github.com/MetaMask/snaps-skunkworks/pull/276))
+- Comment stripping will no longer remove empty block comments in strings ([#276](https://github.com/MetaMask/snaps-monorepo/pull/276))
 
 ## [0.10.0]
 ### Added
-- **BREAKING:** Transform HTML comments by default ([#237](https://github.com/MetaMask/snaps-skunkworks/pull/237))
+- **BREAKING:** Transform HTML comments by default ([#237](https://github.com/MetaMask/snaps-monorepo/pull/237))
   - The strings `<!--` and `-->` will be transformed into `< !--` and `-- >` respectively by default. If these strings appear as operands in an expression or in a string literal, this transform will change the behavior of your program. This behavior was added because these strings are rejected by SES. The behavior can be toggled using the `--transformHtmlComments` option.
-- `--transpiledDeps` flag to `build` and `watch` commands ([#221](https://github.com/MetaMask/snaps-skunkworks/pull/221))
+- `--transpiledDeps` flag to `build` and `watch` commands ([#221](https://github.com/MetaMask/snaps-monorepo/pull/221))
   - This flag allows the user to specify which dependencies will be transpiled at build time if the `--transpilationMode` is `--localAndDeps`.
-- Add CLI usage instructions to readme ([#228](https://github.com/MetaMask/snaps-skunkworks/pull/228))
-- Build process customization ([#251](https://github.com/MetaMask/snaps-skunkworks/pull/251))
+- Add CLI usage instructions to readme ([#228](https://github.com/MetaMask/snaps-monorepo/pull/228))
+- Build process customization ([#251](https://github.com/MetaMask/snaps-monorepo/pull/251))
   - Builds can now be customized by adding a `bundlerCustomizer` function to `snap.config.js`. See the README for details.
 
 ### Changed
-- **BREAKING:** Change Snap config file format ([#251](https://github.com/MetaMask/snaps-skunkworks/pull/251))
+- **BREAKING:** Change Snap config file format ([#251](https://github.com/MetaMask/snaps-monorepo/pull/251))
   - The CLI now expects a file `snap.config.js` instead of `snap.config.json`, with a different structure. See the README for details.
-- **BREAKING:** Strip comments in source code by default ([#243](https://github.com/MetaMask/snaps-skunkworks/pull/243))
+- **BREAKING:** Strip comments in source code by default ([#243](https://github.com/MetaMask/snaps-monorepo/pull/243))
   - All comments will now be stripped from snap source code (including dependencies) by default.
-- Enable `--verboseErrors` by default ([#249](https://github.com/MetaMask/snaps-skunkworks/pull/249))
+- Enable `--verboseErrors` by default ([#249](https://github.com/MetaMask/snaps-monorepo/pull/249))
 
 ### Fixed
-- Comment stripping bug ([#270](https://github.com/MetaMask/snaps-skunkworks/pull/270))
+- Comment stripping bug ([#270](https://github.com/MetaMask/snaps-monorepo/pull/270))
   - Prior to this change, if the `--strip-comments` option was provided to `mm-snap build` and an empty block comment of the form `/**/` appeared anywhere in the source code (including dependencies), the remainder of the string after the empty block comment would be truncated. This was resolved by removing all instances of the string `/**/` from the raw bundle string.
   - In an upcoming release, the string `/**/` will only be removed if it is in fact an empty block comment, and not if it e.g. appears in a string literal.
-- `watch` command parity with `build` command ([#241](https://github.com/MetaMask/snaps-skunkworks/pull/241))
+- `watch` command parity with `build` command ([#241](https://github.com/MetaMask/snaps-monorepo/pull/241))
   - The `build` command had received a number of options that were not made available to the `watch` command. They now have the same options.
-- Update dead link in readme ([#240](https://github.com/MetaMask/snaps-skunkworks/pull/240))
+- Update dead link in readme ([#240](https://github.com/MetaMask/snaps-monorepo/pull/240))
 
 ## [0.9.0]
 ### Added
-- Transpilation configuration ([#213](https://github.com/MetaMask/snaps-skunkworks/pull/213))
+- Transpilation configuration ([#213](https://github.com/MetaMask/snaps-monorepo/pull/213))
   - `mm-snap build` now takes a `--transpilationMode` argument which determines what will be transpiled by Babel during building: all source code (including dependencies), local source code only, or nothing.
 
 ### Fixed
-- `mm-snap build` command when CLI is installed globally ([#216](https://github.com/MetaMask/snaps-skunkworks/pull/216))
-- Update installation command in readme ([#205](https://github.com/MetaMask/snaps-skunkworks/pull/205))
+- `mm-snap build` command when CLI is installed globally ([#216](https://github.com/MetaMask/snaps-monorepo/pull/216))
+- Update installation command in readme ([#205](https://github.com/MetaMask/snaps-monorepo/pull/205))
 
 ## [0.8.0]
 ### Changed
-- Update template snap created by `mm-snap init` ([#195](https://github.com/MetaMask/snaps-skunkworks/pull/195))
-- Exit by throwing errors instead of calling `process.exit` ([#190](https://github.com/MetaMask/snaps-skunkworks/pull/190))
+- Update template snap created by `mm-snap init` ([#195](https://github.com/MetaMask/snaps-monorepo/pull/195))
+- Exit by throwing errors instead of calling `process.exit` ([#190](https://github.com/MetaMask/snaps-monorepo/pull/190))
 
 ## [0.7.0]
 ### Added
-- ESM support for `mm-snap build` ([#185](https://github.com/MetaMask/snaps-skunkworks/pull/185))
+- ESM support for `mm-snap build` ([#185](https://github.com/MetaMask/snaps-monorepo/pull/185))
   - The `build` command can now handle snap source code that includes ESM import / export statements. They will be transpiled to their CommonJS equivalents via Babel.
 
 ### Fixed
-- Fix `mm-snap init` `src` default value ([#186](https://github.com/MetaMask/snaps-skunkworks/pull/186))
+- Fix `mm-snap init` `src` default value ([#186](https://github.com/MetaMask/snaps-monorepo/pull/186))
   - It now correctly defaults to `src/index.js` instead of just `index.js`.
-- Fix comment stripping ([#189](https://github.com/MetaMask/snaps-skunkworks/pull/189))
+- Fix comment stripping ([#189](https://github.com/MetaMask/snaps-monorepo/pull/189))
   - Comments wouldn't be stripped under certain circumstances due to a RegEx error, details [here](https://github.com/jonschlinkert/strip-comments/pull/49).
 
 ## [0.6.3]
@@ -184,27 +184,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1]
 ### Fixed
-- `mm-snap init` Snap `snap_confirm` call ([#168](https://github.com/MetaMask/snaps-skunkworks/pull/168))
+- `mm-snap init` Snap `snap_confirm` call ([#168](https://github.com/MetaMask/snaps-monorepo/pull/168))
   - The generated Snap was passing invalid parameters to the method.
 
 ## [0.6.0]
 ### Added
-- Snap SVG icon support ([#163](https://github.com/MetaMask/snaps-skunkworks/pull/163))
+- Snap SVG icon support ([#163](https://github.com/MetaMask/snaps-monorepo/pull/163))
 
 ### Changed
-- **BREAKING:** Support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-skunkworks/pull/140), [#160](https://github.com/MetaMask/snaps-skunkworks/pull/160))
+- **BREAKING:** Support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-monorepo/pull/140), [#160](https://github.com/MetaMask/snaps-monorepo/pull/160))
   - This introduces several breaking changes to how Snaps are developed, hosted, and represented at runtime. See [the specification](https://github.com/MetaMask/specifications/blob/d4a5bf5d6990bb5b02a98bd3f95a24ffb28c701c/snaps/publishing.md) and the referenced pull requests for details.
-- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-skunkworks/pull/147))
-- **BREAKING:** Update `ses` to version `^0.15.3` ([#159](https://github.com/MetaMask/snaps-skunkworks/pull/159))
+- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-monorepo/pull/147))
+- **BREAKING:** Update `ses` to version `^0.15.3` ([#159](https://github.com/MetaMask/snaps-monorepo/pull/159))
   - This will cause behavioral changes for code executed under SES, and may require modifications to code that previously executed without issues.
 
 ## [0.5.0]
 ### Changed
-- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-skunkworks/pull/143))
+- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-monorepo/pull/143))
 
 ## [0.4.0]
 ### Fixed
-- Make Windows-compatible ([#131](https://github.com/MetaMask/snaps-skunkworks/pull/131))
+- Make Windows-compatible ([#131](https://github.com/MetaMask/snaps-monorepo/pull/131))
 
 ## [0.3.1]
 ### Changed
@@ -212,20 +212,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0]
 ### Changed
-- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-skunkworks/pull/119))
+- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-monorepo/pull/119))
 
 ## [0.2.2]
 ### Fixed
-- Package script issues ([#97](https://github.com/MetaMask/snaps-skunkworks/pull/97), [#98](https://github.com/MetaMask/snaps-skunkworks/pull/98))
+- Package script issues ([#97](https://github.com/MetaMask/snaps-monorepo/pull/97), [#98](https://github.com/MetaMask/snaps-monorepo/pull/98))
 
 ## [0.2.1]
 ### Fixed
-- Snap produced by `mm-snap init` ([#94](https://github.com/MetaMask/snaps-skunkworks/pull/94))
+- Snap produced by `mm-snap init` ([#94](https://github.com/MetaMask/snaps-monorepo/pull/94))
   - The template used to create the "Hello, world!" snap had become outdated due to a build-time bug.
 
 ## [0.2.0]
 ### Changed
-- Update publish scripts ([#92](https://github.com/MetaMask/snaps-skunkworks/pull/92))
+- Update publish scripts ([#92](https://github.com/MetaMask/snaps-monorepo/pull/92))
 
 ## [0.1.1]
 ### Added
@@ -233,51 +233,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0]
 ### Changed
-- **BREAKING:** Rename package to `@metamask/snaps-cli` ([#72](https://github.com/MetaMask/snaps-skunkworks/pull/72))
+- **BREAKING:** Rename package to `@metamask/snaps-cli` ([#72](https://github.com/MetaMask/snaps-monorepo/pull/72))
   - This package was previously named [`snaps-cli`](https://npmjs.com/package/snaps-cli).
   - As part of the renaming, and due to the scope of the changes to both this package and MetaMask Snaps generally, its versioning and changelog have been reset. The original changelog can be found [here](https://github.com/MetaMask/snaps-cli/blob/main/CHANGELOG.md).
 
 ### Removed
-- Example snaps ([#72](https://github.com/MetaMask/snaps-skunkworks/pull/72))
+- Example snaps ([#72](https://github.com/MetaMask/snaps-monorepo/pull/72))
   - The examples now live in their own package, [`@metamask/snap-examples`](https://npmjs.com/package/@metamask/snap-examples).
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.1...v0.12.0
-[0.11.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.7...v0.11.0
-[0.10.7]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.6...v0.10.7
-[0.10.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.5...v0.10.6
-[0.10.5]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.3...v0.10.5
-[0.10.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.2...v0.10.3
-[0.10.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.1...v0.10.2
-[0.10.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.3...v0.7.0
-[0.6.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.1.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.7...v0.11.0
+[0.10.7]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.6...v0.10.7
+[0.10.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.5...v0.10.6
+[0.10.5]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.3...v0.10.5
+[0.10.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.2...v0.10.3
+[0.10.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.1.0

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,7 +90,7 @@ Here's an example manifest:
 }
 ```
 
-Refer to [the Snaps publishing specification](https://github.com/MetaMask/specifications/blob/main/snaps/publishing.md) and the [manifest JSON schema](https://github.com/MetaMask/snaps-skunkworks/blob/main/packages/controllers/src/snaps/json-schemas/snap-manifest.schema.json) for details.
+Refer to [the Snaps publishing specification](https://github.com/MetaMask/specifications/blob/main/snaps/publishing.md) and the [manifest JSON schema](https://github.com/MetaMask/snaps-monorepo/blob/main/packages/controllers/src/snaps/json-schemas/snap-manifest.schema.json) for details.
 
 > **ATTN:** If your Snap is not compatible with the publishing specification, your Snap may not work properly or install at all.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "A CLI for developing MetaMask Snaps.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "bin": {

--- a/packages/cli/src/utils/misc.ts
+++ b/packages/cli/src/utils/misc.ts
@@ -156,7 +156,7 @@ export async function writeError(
   // unless the watcher is active, exit
   if (!global.snaps.isWatching) {
     // TODO(ritave): Remove process exit and change into collapse of functions
-    //               https://github.com/MetaMask/snaps-skunkworks/issues/81
+    //               https://github.com/MetaMask/snaps-monorepo/issues/81
     process.exit(1);
   }
 }

--- a/packages/controllers/CHANGELOG.md
+++ b/packages/controllers/CHANGELOG.md
@@ -8,41 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.1]
 ### Fixed
-- Assert that multichain RPC methods are supported before usage ([#814](https://github.com/MetaMask/snaps-skunkworks/pull/814))
+- Assert that multichain RPC methods are supported before usage ([#814](https://github.com/MetaMask/snaps-monorepo/pull/814))
 
 ## [0.22.0]
 ### Added
-- Add Snap Keyring support ([#700](https://github.com/MetaMask/snaps-skunkworks/pull/700), [#775](https://github.com/MetaMask/snaps-skunkworks/pull/775), [#777](https://github.com/MetaMask/snaps-skunkworks/pull/777), [#740](https://github.com/MetaMask/snaps-skunkworks/pull/740))
+- Add Snap Keyring support ([#700](https://github.com/MetaMask/snaps-monorepo/pull/700), [#775](https://github.com/MetaMask/snaps-monorepo/pull/775), [#777](https://github.com/MetaMask/snaps-monorepo/pull/777), [#740](https://github.com/MetaMask/snaps-monorepo/pull/740))
   - Add `endowment:keyring` permission
   - Add `MultiChainController`
 
 ### Changed
-- **BREAKING:** Renamed `SnapController:getSnaps` to `SnapController:getPermittedSnaps` [#775](https://github.com/MetaMask/snaps-skunkworks/pull/775)
+- **BREAKING:** Renamed `SnapController:getSnaps` to `SnapController:getPermittedSnaps` [#775](https://github.com/MetaMask/snaps-monorepo/pull/775)
 
 ## [0.21.0]
 ### Changed
-- **BREAKING:** Add changes to support blocking snaps by shasum ([#767](https://github.com/MetaMask/snaps-skunkworks/pull/767))
-- **BREAKING:** Rework snap install logic ([#754](https://github.com/MetaMask/snaps-skunkworks/pull/754))
-- Stop including `installing` snaps in `wallet_getSnaps` ([#765](https://github.com/MetaMask/snaps-skunkworks/pull/765))
+- **BREAKING:** Add changes to support blocking snaps by shasum ([#767](https://github.com/MetaMask/snaps-monorepo/pull/767))
+- **BREAKING:** Rework snap install logic ([#754](https://github.com/MetaMask/snaps-monorepo/pull/754))
+- Stop including `installing` snaps in `wallet_getSnaps` ([#765](https://github.com/MetaMask/snaps-monorepo/pull/765))
 
 ### Fixed
-- Process snap permissions before snap update ([#753](https://github.com/MetaMask/snaps-skunkworks/pull/753))
-- Only pause running timers ([#725](https://github.com/MetaMask/snaps-skunkworks/pull/725))
+- Process snap permissions before snap update ([#753](https://github.com/MetaMask/snaps-monorepo/pull/753))
+- Only pause running timers ([#725](https://github.com/MetaMask/snaps-monorepo/pull/725))
 
 ## [0.20.0]
 ### Added
-- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-skunkworks/pull/642))
+- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-monorepo/pull/642))
   - This feature required changes to the RPC request handling functionality, hence the breaking change
-- Register missing actions ([#659](https://github.com/MetaMask/snaps-skunkworks/pull/659))
+- Register missing actions ([#659](https://github.com/MetaMask/snaps-monorepo/pull/659))
   - All APIs accessed outside the SnapController are now registered as actions in the messaging system
 
 ### Changed
-- **BREAKING:** Simplify manifest format for permission caveats ([#705](https://github.com/MetaMask/snaps-skunkworks/pull/705))
-- Reduce TypeScript compilation target for `snap-controllers` ([#708](https://github.com/MetaMask/snaps-skunkworks/pull/708))
-- Move all internal types from `@metamask/snap-types` to `@metamask/snap-utils` ([#695](https://github.com/MetaMask/snaps-skunkworks/pull/695))
+- **BREAKING:** Simplify manifest format for permission caveats ([#705](https://github.com/MetaMask/snaps-monorepo/pull/705))
+- Reduce TypeScript compilation target for `snap-controllers` ([#708](https://github.com/MetaMask/snaps-monorepo/pull/708))
+- Move all internal types from `@metamask/snap-types` to `@metamask/snap-utils` ([#695](https://github.com/MetaMask/snaps-monorepo/pull/695))
 
 ### Removed
-- **BREAKING:** Removed ExternalResourceController ([#701](https://github.com/MetaMask/snaps-skunkworks/pull/701))
+- **BREAKING:** Removed ExternalResourceController ([#701](https://github.com/MetaMask/snaps-monorepo/pull/701))
 
 ## [0.19.1]
 ### Changed
@@ -50,8 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.0]
 ### Fixed
-- Fixed update snap approval missing metadata ([#673](https://github.com/MetaMask/snaps-skunkworks/pull/673))
-- Fixed executors sending malformed JSON-RPC notifications ([#639](https://github.com/MetaMask/snaps-skunkworks/pull/639))
+- Fixed update snap approval missing metadata ([#673](https://github.com/MetaMask/snaps-monorepo/pull/673))
+- Fixed executors sending malformed JSON-RPC notifications ([#639](https://github.com/MetaMask/snaps-monorepo/pull/639))
 
 ## [0.18.1]
 ### Changed
@@ -59,186 +59,186 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
-- **BREAKING:** Add browser entrypoint for execution services ([#629](https://github.com/MetaMask/snaps-skunkworks/pull/629))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
+- **BREAKING:** Add browser entrypoint for execution services ([#629](https://github.com/MetaMask/snaps-monorepo/pull/629))
   - Node.js execution services are now omitted in browser environments
 
 ## [0.17.0]
 ### Added
-- Add snap blocklist functionality ([#597](https://github.com/MetaMask/snaps-skunkworks/pull/597))
-- Add Node.js `worker_threads` execution environment ([#587](https://github.com/MetaMask/snaps-skunkworks/pull/587))
-- Add Node.js `child_process` execution environment ([#523](https://github.com/MetaMask/snaps-skunkworks/pull/523))
-- Added network endowment teardown ([#514](https://github.com/MetaMask/snaps-skunkworks/pull/514))
+- Add snap blocklist functionality ([#597](https://github.com/MetaMask/snaps-monorepo/pull/597))
+- Add Node.js `worker_threads` execution environment ([#587](https://github.com/MetaMask/snaps-monorepo/pull/587))
+- Add Node.js `child_process` execution environment ([#523](https://github.com/MetaMask/snaps-monorepo/pull/523))
+- Added network endowment teardown ([#514](https://github.com/MetaMask/snaps-monorepo/pull/514))
 
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
-- **BREAKING:** Remove ExecutionService actions from constructor arguments ([#486](https://github.com/MetaMask/snaps-skunkworks/pull/486))
-- **BREAKING:** Emit appropriate snap objects for SnapController events ([#608](https://github.com/MetaMask/snaps-skunkworks/pull/608))
-- **BREAKING:** Replace `getRpcMessageHandler` action with `handleRpcRequest` ([#497](https://github.com/MetaMask/snaps-skunkworks/pull/497), [#557](https://github.com/MetaMask/snaps-skunkworks/pull/557))
-- Monitor outbound snap requests to pause request timeout ([#593](https://github.com/MetaMask/snaps-skunkworks/pull/593))
-- Change Update Snap `requestData` ([#614](https://github.com/MetaMask/snaps-skunkworks/pull/614))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
+- **BREAKING:** Remove ExecutionService actions from constructor arguments ([#486](https://github.com/MetaMask/snaps-monorepo/pull/486))
+- **BREAKING:** Emit appropriate snap objects for SnapController events ([#608](https://github.com/MetaMask/snaps-monorepo/pull/608))
+- **BREAKING:** Replace `getRpcMessageHandler` action with `handleRpcRequest` ([#497](https://github.com/MetaMask/snaps-monorepo/pull/497), [#557](https://github.com/MetaMask/snaps-monorepo/pull/557))
+- Monitor outbound snap requests to pause request timeout ([#593](https://github.com/MetaMask/snaps-monorepo/pull/593))
+- Change Update Snap `requestData` ([#614](https://github.com/MetaMask/snaps-monorepo/pull/614))
 
 ### Removed
-- Remove WebWorker implementation ([#591](https://github.com/MetaMask/snaps-skunkworks/pull/591))
+- Remove WebWorker implementation ([#591](https://github.com/MetaMask/snaps-monorepo/pull/591))
 
 ## [0.16.0]
 ### Added
-- **BREAKING:** Encrypt Snap state by default ([#369](https://github.com/MetaMask/snaps-skunkworks/pull/369))
+- **BREAKING:** Encrypt Snap state by default ([#369](https://github.com/MetaMask/snaps-monorepo/pull/369))
   - Breaks existing installed snaps that use `snap_manageState`. All such Snaps must be reinstalled.
 
 ### Changed
-- **BREAKING:** Snaps are now required to export `onRpcRequest` to receive RPC requests ([#481](https://github.com/MetaMask/snaps-skunkworks/pull/481), [#533](https://github.com/MetaMask/snaps-skunkworks/pull/533), [#538](https://github.com/MetaMask/snaps-skunkworks/pull/538))
+- **BREAKING:** Snaps are now required to export `onRpcRequest` to receive RPC requests ([#481](https://github.com/MetaMask/snaps-monorepo/pull/481), [#533](https://github.com/MetaMask/snaps-monorepo/pull/533), [#538](https://github.com/MetaMask/snaps-monorepo/pull/538))
   - The type of the function is available in `@metamask/snap-types` as `OnRpcRequestHandler`.
-- Snaps can no longer run timers outside of pending RPC requests ([#490](https://github.com/MetaMask/snaps-skunkworks/pull/490))
+- Snaps can no longer run timers outside of pending RPC requests ([#490](https://github.com/MetaMask/snaps-monorepo/pull/490))
 
 ### Fixed
-- Allow version matching with prerelease versions ([#508](https://github.com/MetaMask/snaps-skunkworks/pull/508))
-- Fix issue with iframe error reporting ([#501](https://github.com/MetaMask/snaps-skunkworks/pull/501))
-- Fix an issue with file paths with leading `./` in npm snap manifests ([#537](https://github.com/MetaMask/snaps-skunkworks/pull/537))
+- Allow version matching with prerelease versions ([#508](https://github.com/MetaMask/snaps-monorepo/pull/508))
+- Fix issue with iframe error reporting ([#501](https://github.com/MetaMask/snaps-monorepo/pull/501))
+- Fix an issue with file paths with leading `./` in npm snap manifests ([#537](https://github.com/MetaMask/snaps-monorepo/pull/537))
 
 ## [0.15.0]
 ### Fixed
-- Fix an issue with detecting iframe execution environment load ([#464](https://github.com/MetaMask/snaps-skunkworks/pull/464))
+- Fix an issue with detecting iframe execution environment load ([#464](https://github.com/MetaMask/snaps-monorepo/pull/464))
 
 ## [0.14.0]
 ### Changed
-- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - This should not be breaking for consumers on any non-deprecated browser or Node.js version.
 
 ## [0.13.0]
 ### Added
-- Add long-running endowment permission ([#386](https://github.com/MetaMask/snaps-skunkworks/pull/386))
-- Add `network-access` endowment from `controllers` ([#439](https://github.com/MetaMask/snaps-skunkworks/pull/439))
+- Add long-running endowment permission ([#386](https://github.com/MetaMask/snaps-monorepo/pull/386))
+- Add `network-access` endowment from `controllers` ([#439](https://github.com/MetaMask/snaps-monorepo/pull/439))
 
 ### Changed
-- **BREAKING:** Rename SnapController constructor argument ([#435](https://github.com/MetaMask/snaps-skunkworks/pull/435))
+- **BREAKING:** Rename SnapController constructor argument ([#435](https://github.com/MetaMask/snaps-monorepo/pull/435))
 
 ## [0.12.0]
 ### Added
-- Add support for endowment teardown ([#407](https://github.com/MetaMask/snaps-skunkworks/pull/407))
-- Emit `snapTerminated` event ([#406](https://github.com/MetaMask/snaps-skunkworks/pull/406))
-- Add `IframeExecutionService` previously published via `@metamask/iframe-execution-environment-service` ([#415](https://github.com/MetaMask/snaps-skunkworks/pull/415))
+- Add support for endowment teardown ([#407](https://github.com/MetaMask/snaps-monorepo/pull/407))
+- Emit `snapTerminated` event ([#406](https://github.com/MetaMask/snaps-monorepo/pull/406))
+- Add `IframeExecutionService` previously published via `@metamask/iframe-execution-environment-service` ([#415](https://github.com/MetaMask/snaps-monorepo/pull/415))
 
 ### Removed
-- Remove `_createWindowTimeout` ([#404](https://github.com/MetaMask/snaps-skunkworks/pull/404))
-- Remove unresponsive timeout ([#395](https://github.com/MetaMask/snaps-skunkworks/pull/395))
+- Remove `_createWindowTimeout` ([#404](https://github.com/MetaMask/snaps-monorepo/pull/404))
+- Remove unresponsive timeout ([#395](https://github.com/MetaMask/snaps-monorepo/pull/395))
 
 ### Fixed
-- Correctly categorize ungracefully terminated snaps as crashed ([#427](https://github.com/MetaMask/snaps-skunkworks/pull/427))
+- Correctly categorize ungracefully terminated snaps as crashed ([#427](https://github.com/MetaMask/snaps-monorepo/pull/427))
 
 ## [0.11.1]
 ### Changed
-- Always bind `fetch` by default ([#402](https://github.com/MetaMask/snaps-skunkworks/pull/402))
+- Always bind `fetch` by default ([#402](https://github.com/MetaMask/snaps-monorepo/pull/402))
 
 ## [0.11.0]
 ### Added
-- Add clearSnapState ([#346](https://github.com/MetaMask/snaps-skunkworks/pull/346))
+- Add clearSnapState ([#346](https://github.com/MetaMask/snaps-monorepo/pull/346))
 
 ### Changed
-- Robustify snap startup procedure and iframe error handling ([#379](https://github.com/MetaMask/snaps-skunkworks/pull/379))
-- Added ability to update snaps when installing them ([#322](https://github.com/MetaMask/snaps-skunkworks/pull/322))
-- **BREAKING:** Use PermissionController:revokePermissionForAllSubjects ([#351](https://github.com/MetaMask/snaps-skunkworks/pull/351))
-- Changed console.logs to console.info ([#361](https://github.com/MetaMask/snaps-skunkworks/pull/361))
-- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-skunkworks/pull/360))
-- Remove cross-fetch ([#349](https://github.com/MetaMask/snaps-skunkworks/pull/349))
+- Robustify snap startup procedure and iframe error handling ([#379](https://github.com/MetaMask/snaps-monorepo/pull/379))
+- Added ability to update snaps when installing them ([#322](https://github.com/MetaMask/snaps-monorepo/pull/322))
+- **BREAKING:** Use PermissionController:revokePermissionForAllSubjects ([#351](https://github.com/MetaMask/snaps-monorepo/pull/351))
+- Changed console.logs to console.info ([#361](https://github.com/MetaMask/snaps-monorepo/pull/361))
+- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-monorepo/pull/360))
+- Remove cross-fetch ([#349](https://github.com/MetaMask/snaps-monorepo/pull/349))
 
 ### Fixed
-- Fix idle timeout implementation ([#385](https://github.com/MetaMask/snaps-skunkworks/pull/385))
+- Fix idle timeout implementation ([#385](https://github.com/MetaMask/snaps-monorepo/pull/385))
 
 ## [0.10.7]
 ### Added
-- Add version history information ([#317](https://github.com/MetaMask/snaps-skunkworks/pull/317))
-- Add setInterval and clearInterval as default endowments ([#326](https://github.com/MetaMask/snaps-skunkworks/pull/326))
-- Add queue for RPC requests to starting snaps ([#288](https://github.com/MetaMask/snaps-skunkworks/pull/288))
+- Add version history information ([#317](https://github.com/MetaMask/snaps-monorepo/pull/317))
+- Add setInterval and clearInterval as default endowments ([#326](https://github.com/MetaMask/snaps-monorepo/pull/326))
+- Add queue for RPC requests to starting snaps ([#288](https://github.com/MetaMask/snaps-monorepo/pull/288))
   - This improves the experience of invoking a starting snap, waiting for the snap to be ready instead of throwing an error.
 
 ### Changed
-- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-skunkworks/pull/331))
+- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-monorepo/pull/331))
 
 ## [0.10.6]
 ### Fixed
-- Fix ID validation during Snap installation ([#308](https://github.com/MetaMask/snaps-skunkworks/pull/308))
+- Fix ID validation during Snap installation ([#308](https://github.com/MetaMask/snaps-monorepo/pull/308))
 
 ## [0.10.5]
 ### Added
-- Add updateSnap function to SnapController ([#259](https://github.com/MetaMask/snaps-skunkworks/pull/259))
+- Add updateSnap function to SnapController ([#259](https://github.com/MetaMask/snaps-monorepo/pull/259))
 
 ### Fixed
-- Fix issue where installation errors were repeatedly thrown ([#301](https://github.com/MetaMask/snaps-skunkworks/pull/301))
-- Fix snap crash handling ([#298](https://github.com/MetaMask/snaps-skunkworks/pull/298))
+- Fix issue where installation errors were repeatedly thrown ([#301](https://github.com/MetaMask/snaps-monorepo/pull/301))
+- Fix snap crash handling ([#298](https://github.com/MetaMask/snaps-monorepo/pull/298))
 
 ## [0.10.3]
 ### Changed
-- Always reinstall local snaps ([#289](https://github.com/MetaMask/snaps-skunkworks/pull/289))
+- Always reinstall local snaps ([#289](https://github.com/MetaMask/snaps-monorepo/pull/289))
 
 ## [0.10.2]
 ### Fixed
-- Installation failure ([#279](https://github.com/MetaMask/snaps-skunkworks/pull/279))
+- Installation failure ([#279](https://github.com/MetaMask/snaps-monorepo/pull/279))
   - A faulty installation script in a dependency caused the installation of this package to fail.
 
 ## [0.10.1]
 ### Changed
-- Populate `jsonrpc` field in Snap RPC requests ([#273](https://github.com/MetaMask/snaps-skunkworks/pull/273))
+- Populate `jsonrpc` field in Snap RPC requests ([#273](https://github.com/MetaMask/snaps-monorepo/pull/273))
 
 ### Fixed
-- Various bugs ([#275](https://github.com/MetaMask/snaps-skunkworks/pull/275))
+- Various bugs ([#275](https://github.com/MetaMask/snaps-monorepo/pull/275))
   - Snap fetching during installation.
   - Snap removal when cancelling a Snap installation request.
 
 ## [0.10.0]
 ### Added
-- Allow specifying a version range when installing snap ([#250](https://github.com/MetaMask/snaps-skunkworks/pull/250))
-- Add more safe default endowments to snaps ([#252](https://github.com/MetaMask/snaps-skunkworks/pull/252))
+- Allow specifying a version range when installing snap ([#250](https://github.com/MetaMask/snaps-monorepo/pull/250))
+- Add more safe default endowments to snaps ([#252](https://github.com/MetaMask/snaps-monorepo/pull/252))
 
 ### Changed
-- **BREAKING:** Specify all endowments in the `SnapController` ([#252](https://github.com/MetaMask/snaps-skunkworks/pull/252)), ([#266](https://github.com/MetaMask/snaps-skunkworks/pull/266))
+- **BREAKING:** Specify all endowments in the `SnapController` ([#252](https://github.com/MetaMask/snaps-monorepo/pull/252)), ([#266](https://github.com/MetaMask/snaps-monorepo/pull/266))
   - Previously, default endowments were specified in the execution environment. Now, default endowments are specified in the `SnapController`, and the execution environment will only add endowments specified by the execution command, except for the `wallet` API object.
-- Disable caching when fetching local snaps ([#227](https://github.com/MetaMask/snaps-skunkworks/pull/227))
+- Disable caching when fetching local snaps ([#227](https://github.com/MetaMask/snaps-monorepo/pull/227))
   - This ensures that the `SnapController` will always fetch the latest snap manifest and source code during local development.
 
 ### Removed
-- **BREAKING:** Remove the `PermissionController` and `SubjectMetadataController` ([#261](https://github.com/MetaMask/snaps-skunkworks/pull/261))
+- **BREAKING:** Remove the `PermissionController` and `SubjectMetadataController` ([#261](https://github.com/MetaMask/snaps-monorepo/pull/261))
   - They are part of the [`@metamask/controllers`](https://npmjs.com/package/@metamask/controllers) as of version [26.0.0](https://github.com/MetaMask/controllers/releases/tag/v26.0.0) of that package.
 
 ### Fixed
-- Prevent useless errors from being thrown when a snap is removed ([#215](https://github.com/MetaMask/snaps-skunkworks/pull/215))
+- Prevent useless errors from being thrown when a snap is removed ([#215](https://github.com/MetaMask/snaps-monorepo/pull/215))
 
 ## [0.9.0]
 ### Added
-- Make `SnapController` npm registry configurable ([#200](https://github.com/MetaMask/snaps-skunkworks/pull/200))
+- Make `SnapController` npm registry configurable ([#200](https://github.com/MetaMask/snaps-monorepo/pull/200))
 
 ### Changed
-- **BREAKING:** Return `null` from `SnapController.getSnapState` if the snap has no state ([#203](https://github.com/MetaMask/snaps-skunkworks/pull/203))
+- **BREAKING:** Return `null` from `SnapController.getSnapState` if the snap has no state ([#203](https://github.com/MetaMask/snaps-monorepo/pull/203))
   - Previously it would return `undefined` in this case.
-- `@metamask/controllers@^25.1.0` ([#207](https://github.com/MetaMask/snaps-skunkworks/pull/207))
+- `@metamask/controllers@^25.1.0` ([#207](https://github.com/MetaMask/snaps-monorepo/pull/207))
 
 ## [0.8.1]
 ### Added
-- A variety of `SnapController` actions ([#199](https://github.com/MetaMask/snaps-skunkworks/pull/199))
+- A variety of `SnapController` actions ([#199](https://github.com/MetaMask/snaps-monorepo/pull/199))
 
 ## [0.8.0]
 ### Added
-- Expose more `PermissionController` functionality via actions ([#194](https://github.com/MetaMask/snaps-skunkworks/pull/194))
+- Expose more `PermissionController` functionality via actions ([#194](https://github.com/MetaMask/snaps-monorepo/pull/194))
 
 ### Changed
-- **BREAKING:** Replace `PermissionController` functions with actions in `SnapController` ([#194](https://github.com/MetaMask/snaps-skunkworks/pull/194))
+- **BREAKING:** Replace `PermissionController` functions with actions in `SnapController` ([#194](https://github.com/MetaMask/snaps-monorepo/pull/194))
 
 ## [0.7.0]
 ### Changed
-- **BREAKING:** Rename execution environment service class and events ([#188](https://github.com/MetaMask/snaps-skunkworks/pull/188))
+- **BREAKING:** Rename execution environment service class and events ([#188](https://github.com/MetaMask/snaps-monorepo/pull/188))
   - `ServiceMessenger` events are now named `ExecutionService`.
   - `WebWorkerExecutionEnvironmentService` is now named `WebWorkerExecutionService`.
 
 ## [0.6.3]
 ### Fixed
-- Prevent `disableSnap` from throwing if the specified Snap is stopped ([#175](https://github.com/MetaMask/snaps-skunkworks/pull/175))
+- Prevent `disableSnap` from throwing if the specified Snap is stopped ([#175](https://github.com/MetaMask/snaps-monorepo/pull/175))
 
 ## [0.6.2]
 ### Changed
-- **BREAKING:** Rename endowment permission builder exports ([#171](https://github.com/MetaMask/snaps-skunkworks/pull/171))
+- **BREAKING:** Rename endowment permission builder exports ([#171](https://github.com/MetaMask/snaps-monorepo/pull/171))
 
 ### Removed
-- **BREAKING:** Remove the `svgIcon` property from Snap state ([#172](https://github.com/MetaMask/snaps-skunkworks/pull/172))
+- **BREAKING:** Remove the `svgIcon` property from Snap state ([#172](https://github.com/MetaMask/snaps-monorepo/pull/172))
   - The SVG icon content string is instead emitted with the `SnapController:snapAdded` event.
 
 ## [0.6.1]
@@ -247,165 +247,165 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0]
 ### Added
-- "Endowment" permissions ([#152](https://github.com/MetaMask/snaps-skunkworks/pull/152))
-- `SnapController` endowment permissions support ([#155](https://github.com/MetaMask/snaps-skunkworks/pull/155))
-- Network access endowment permission ([#154](https://github.com/MetaMask/snaps-skunkworks/pull/154))
-- Snap installation events ([#162](https://github.com/MetaMask/snaps-skunkworks/pull/162))
+- "Endowment" permissions ([#152](https://github.com/MetaMask/snaps-monorepo/pull/152))
+- `SnapController` endowment permissions support ([#155](https://github.com/MetaMask/snaps-monorepo/pull/155))
+- Network access endowment permission ([#154](https://github.com/MetaMask/snaps-monorepo/pull/154))
+- Snap installation events ([#162](https://github.com/MetaMask/snaps-monorepo/pull/162))
 
 ### Changed
-- **BREAKING:** Refactor `SnapController` to support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-skunkworks/pull/140), [#157](https://github.com/MetaMask/snaps-skunkworks/pull/157), [#163](https://github.com/MetaMask/snaps-skunkworks/pull/163))
+- **BREAKING:** Refactor `SnapController` to support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-monorepo/pull/140), [#157](https://github.com/MetaMask/snaps-monorepo/pull/157), [#163](https://github.com/MetaMask/snaps-monorepo/pull/163))
   - This introduces several breaking changes to how Snaps are developed, hosted, and represented at runtime. See [the specification](https://github.com/MetaMask/specifications/blob/d4a5bf5d6990bb5b02a98bd3f95a24ffb28c701c/snaps/publishing.md) and the referenced pull requests for details.
-- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-skunkworks/pull/147))
-- **BREAKING:** Introduce the required `permissionType` field to `PermissionController` permission specifications ([#152](https://github.com/MetaMask/snaps-skunkworks/pull/152))
-- Make `SubjectMetadataController` subject metadata `name` optional ([#151](https://github.com/MetaMask/snaps-skunkworks/pull/151))
+- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-monorepo/pull/147))
+- **BREAKING:** Introduce the required `permissionType` field to `PermissionController` permission specifications ([#152](https://github.com/MetaMask/snaps-monorepo/pull/152))
+- Make `SubjectMetadataController` subject metadata `name` optional ([#151](https://github.com/MetaMask/snaps-monorepo/pull/151))
 
 ### Removed
-- **BREAKING:** Inline snap functionality ([#148](https://github.com/MetaMask/snaps-skunkworks/pull/148))
+- **BREAKING:** Inline snap functionality ([#148](https://github.com/MetaMask/snaps-monorepo/pull/148))
 
 ## [0.5.0]
 ### Changed
-- **BREAKING:** Update restricted RPC methods per new `PermissionController` ([#143](https://github.com/MetaMask/snaps-skunkworks/pull/143))
-- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-skunkworks/pull/143))
-- Bump `@metamask/obs-store` to `7.0.0` ([#144](https://github.com/MetaMask/snaps-skunkworks/pull/144))
+- **BREAKING:** Update restricted RPC methods per new `PermissionController` ([#143](https://github.com/MetaMask/snaps-monorepo/pull/143))
+- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-monorepo/pull/143))
+- Bump `@metamask/obs-store` to `7.0.0` ([#144](https://github.com/MetaMask/snaps-monorepo/pull/144))
 
 ## [0.4.0]
 ### Added
-- `SubjectMetadataController` ([#61](https://github.com/MetaMask/snaps-skunkworks/pull/61))
-- `PermissionController` ([#132](https://github.com/MetaMask/snaps-skunkworks/pull/132), [#141](https://github.com/MetaMask/snaps-skunkworks/pull/141))
-- **BREAKING:** `SnapController`: Add max request processing time ([#128](https://github.com/MetaMask/snaps-skunkworks/pull/128))
+- `SubjectMetadataController` ([#61](https://github.com/MetaMask/snaps-monorepo/pull/61))
+- `PermissionController` ([#132](https://github.com/MetaMask/snaps-monorepo/pull/132), [#141](https://github.com/MetaMask/snaps-monorepo/pull/141))
+- **BREAKING:** `SnapController`: Add max request processing time ([#128](https://github.com/MetaMask/snaps-monorepo/pull/128))
 
 ### Fixed
-- `SnapController`: Clean up timeouts after stopping a Snap ([#139](https://github.com/MetaMask/snaps-skunkworks/pull/139))
-- `WebWorkerExecutionEnvironmentService`: Clean up post-termination timeouts ([#128](https://github.com/MetaMask/snaps-skunkworks/pull/128))
+- `SnapController`: Clean up timeouts after stopping a Snap ([#139](https://github.com/MetaMask/snaps-monorepo/pull/139))
+- `WebWorkerExecutionEnvironmentService`: Clean up post-termination timeouts ([#128](https://github.com/MetaMask/snaps-monorepo/pull/128))
 
 ## [0.3.1]
 ### Changed
-- **BREAKING:** Update Snap initial states ([#126](https://github.com/MetaMask/snaps-skunkworks/pull/126))
+- **BREAKING:** Update Snap initial states ([#126](https://github.com/MetaMask/snaps-monorepo/pull/126))
   - The `idle` status is now named `installing`, and rehydrated snaps will have the status `stopped`.
 
 ### Fixed
-- Fix Snap execution and installation bugs ([#125](https://github.com/MetaMask/snaps-skunkworks/pull/125))
-- Prevent Snaps from being started before installation is finished ([#124](https://github.com/MetaMask/snaps-skunkworks/pull/124))
-- Correctly identify breaking changes in [0.3.0] release ([#123](https://github.com/MetaMask/snaps-skunkworks/pull/123))
+- Fix Snap execution and installation bugs ([#125](https://github.com/MetaMask/snaps-monorepo/pull/125))
+- Prevent Snaps from being started before installation is finished ([#124](https://github.com/MetaMask/snaps-monorepo/pull/124))
+- Correctly identify breaking changes in [0.3.0] release ([#123](https://github.com/MetaMask/snaps-monorepo/pull/123))
 
 ## [0.3.0]
 ### Added
-- Allow disabling and enabling Snaps ([#116](https://github.com/MetaMask/snaps-skunkworks/pull/116))
+- Allow disabling and enabling Snaps ([#116](https://github.com/MetaMask/snaps-monorepo/pull/116))
   - Only enabled Snaps can be started.
-- Start stopped Snaps that receive an RPC message ([#114](https://github.com/MetaMask/snaps-skunkworks/pull/114))
-- Add Snap max idle time ([#105](https://github.com/MetaMask/snaps-skunkworks/pull/105))
+- Start stopped Snaps that receive an RPC message ([#114](https://github.com/MetaMask/snaps-monorepo/pull/114))
+- Add Snap max idle time ([#105](https://github.com/MetaMask/snaps-monorepo/pull/105))
   - A Snap that is idle for more than the max idle time will be stopped.
-- Poll Snaps for their status ([#104](https://github.com/MetaMask/snaps-skunkworks/pull/104))
+- Poll Snaps for their status ([#104](https://github.com/MetaMask/snaps-monorepo/pull/104))
   - If a Snap stops responding, it will be forced to stop.
 
 ### Changed
-- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-skunkworks/pull/119))
-- **BREAKING:** Use the `ControllerMessenger` to communicate between the `SnapController` and its execution environment service ([#100](https://github.com/MetaMask/snaps-skunkworks/pull/100))
+- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-monorepo/pull/119))
+- **BREAKING:** Use the `ControllerMessenger` to communicate between the `SnapController` and its execution environment service ([#100](https://github.com/MetaMask/snaps-monorepo/pull/100))
 
 ## [0.2.2]
 ### Added
-- Add Snap error state ([#96](https://github.com/MetaMask/snaps-skunkworks/pull/96))
+- Add Snap error state ([#96](https://github.com/MetaMask/snaps-monorepo/pull/96))
 
 ### Fixed
-- Package script issues ([#97](https://github.com/MetaMask/snaps-skunkworks/pull/97), [#98](https://github.com/MetaMask/snaps-skunkworks/pull/98))
+- Package script issues ([#97](https://github.com/MetaMask/snaps-monorepo/pull/97), [#98](https://github.com/MetaMask/snaps-monorepo/pull/98))
 
 ## [0.2.0]
 ### Changed
-- Update publish scripts ([#92](https://github.com/MetaMask/snaps-skunkworks/pull/92))
+- Update publish scripts ([#92](https://github.com/MetaMask/snaps-monorepo/pull/92))
 
 ## [0.1.2]
 ### Changed
-- Restore name of `handshake` method to `ping` ([#90](https://github.com/MetaMask/snaps-skunkworks/pull/90))
+- Restore name of `handshake` method to `ping` ([#90](https://github.com/MetaMask/snaps-monorepo/pull/90))
 
 ## [0.1.1]
 ### Added
-- Out of band error support ([#88](https://github.com/MetaMask/snaps-skunkworks/pull/88))
+- Out of band error support ([#88](https://github.com/MetaMask/snaps-monorepo/pull/88))
 
 ### Changed
-- @metamask/controllers@17.0.0 ([#87](https://github.com/MetaMask/snaps-skunkworks/pull/87))
+- @metamask/controllers@17.0.0 ([#87](https://github.com/MetaMask/snaps-monorepo/pull/87))
 
 ## [0.1.0]
 ### Added
-- Readme file ([#71](https://github.com/MetaMask/snaps-skunkworks/pull/71))
+- Readme file ([#71](https://github.com/MetaMask/snaps-monorepo/pull/71))
 
 ### Changed
-- **BREAKING:** Rename package to `@metamask/snap-controllers` ([#73](https://github.com/MetaMask/snaps-skunkworks/pull/73))
+- **BREAKING:** Rename package to `@metamask/snap-controllers` ([#73](https://github.com/MetaMask/snaps-monorepo/pull/73))
 
 ## [0.0.9]
 ### Added
-- `PluginController`: Always persist plugin `isRunning` state as `false` ([#64](https://github.com/MetaMask/snaps-skunkworks/pull/64))
+- `PluginController`: Always persist plugin `isRunning` state as `false` ([#64](https://github.com/MetaMask/snaps-monorepo/pull/64))
   - Plugins are not automatically running on boot, and we should never persist this state as `true`.
 
 ### Changed
-- **BREAKING:** `@metamask/controllers@15.0.0` ([#66](https://github.com/MetaMask/snaps-skunkworks/pull/66))
+- **BREAKING:** `@metamask/controllers@15.0.0` ([#66](https://github.com/MetaMask/snaps-monorepo/pull/66))
   - This may cause incompatibilities with other versions of the `@metamask/controllers` package.
 
 ## [0.0.7]
 ### Fixed
-- Store plugin states in the correct place ([#48](https://github.com/MetaMask/snaps-skunkworks/pull/48))
+- Store plugin states in the correct place ([#48](https://github.com/MetaMask/snaps-monorepo/pull/48))
   - Previously, plugin states would be set as top-level keys of the `PluginController`'s state. This broke retrieving plugin states. They are now correctly stored under `state.pluginStates`.
 
 ## [0.0.6]
 ### Added
-- iframe execution environment ([#33](https://github.com/MetaMask/snaps-skunkworks/pull/33))
-- Execution environment OpenRPC spec ([#23](https://github.com/MetaMask/snaps-skunkworks/pull/23))
+- iframe execution environment ([#33](https://github.com/MetaMask/snaps-monorepo/pull/33))
+- Execution environment OpenRPC spec ([#23](https://github.com/MetaMask/snaps-monorepo/pull/23))
 
 ### Changed
-- **BREAKING:** Migrate `CommandEngine` message format to JSON-RPC ([#11](https://github.com/MetaMask/snaps-skunkworks/pull/11))
-- **BREAKING:** Refactor `PluginController` to use `BaseControllerV2` ([#13](https://github.com/MetaMask/snaps-skunkworks/pull/13))
-- **BREAKING:** Use generic execution environment interface ([#19](https://github.com/MetaMask/snaps-skunkworks/pull/19))
-- **BREAKING:** Restore origin parameter to `setupWorkerConnection`, rename to `setupPluginProvider` ([#20](https://github.com/MetaMask/snaps-skunkworks/pull/20))
-- **BREAKING:** Rename some execution environment methods ([#23](https://github.com/MetaMask/snaps-skunkworks/pull/23))
+- **BREAKING:** Migrate `CommandEngine` message format to JSON-RPC ([#11](https://github.com/MetaMask/snaps-monorepo/pull/11))
+- **BREAKING:** Refactor `PluginController` to use `BaseControllerV2` ([#13](https://github.com/MetaMask/snaps-monorepo/pull/13))
+- **BREAKING:** Use generic execution environment interface ([#19](https://github.com/MetaMask/snaps-monorepo/pull/19))
+- **BREAKING:** Restore origin parameter to `setupWorkerConnection`, rename to `setupPluginProvider` ([#20](https://github.com/MetaMask/snaps-monorepo/pull/20))
+- **BREAKING:** Rename some execution environment methods ([#23](https://github.com/MetaMask/snaps-monorepo/pull/23))
 
 ### Fixed
-- Ensure that the plugin `isRunning` check always runs when a plugin is started ([#21](https://github.com/MetaMask/snaps-skunkworks/pull/21))
+- Ensure that the plugin `isRunning` check always runs when a plugin is started ([#21](https://github.com/MetaMask/snaps-monorepo/pull/21))
 
 ## [0.0.5]
 ### Added
 - First semi-stable release.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.1...v0.12.0
-[0.11.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.7...v0.11.0
-[0.10.7]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.6...v0.10.7
-[0.10.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.5...v0.10.6
-[0.10.5]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.3...v0.10.5
-[0.10.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.2...v0.10.3
-[0.10.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.1...v0.10.2
-[0.10.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.8.1...v0.9.0
-[0.8.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.8.0...v0.8.1
-[0.8.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.3...v0.7.0
-[0.6.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.0...v0.2.2
-[0.2.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.2...v0.2.0
-[0.1.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.9...v0.1.0
-[0.0.9]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.7...v0.0.9
-[0.0.7]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.6...v0.0.7
-[0.0.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.0.5
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.7...v0.11.0
+[0.10.7]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.6...v0.10.7
+[0.10.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.5...v0.10.6
+[0.10.5]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.3...v0.10.5
+[0.10.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.2...v0.10.3
+[0.10.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.8.1...v0.9.0
+[0.8.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.0...v0.2.2
+[0.2.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.9...v0.1.0
+[0.0.9]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.7...v0.0.9
+[0.0.7]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.0.5

--- a/packages/controllers/package.json
+++ b/packages/controllers/package.json
@@ -4,7 +4,7 @@
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "dist/index.js",
   "browser": {

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0]
 ### Added
-- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-skunkworks/pull/731))
+- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-monorepo/pull/731))
 
 ## [0.20.0]
 ### Changed
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.1]
 ### Added
-- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-skunkworks/pull/615))
+- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-monorepo/pull/615))
 
 ## [0.19.0]
 ### Changed
@@ -36,27 +36,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ## [0.17.0]
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
 
 ## [0.16.0]
 ### Added
-- Add Browserify Snap example ([#478](https://github.com/MetaMask/snaps-skunkworks/pull/478))
-- Add CLI as dependency to examples ([#528](https://github.com/MetaMask/snaps-skunkworks/pull/528))
+- Add Browserify Snap example ([#478](https://github.com/MetaMask/snaps-monorepo/pull/478))
+- Add CLI as dependency to examples ([#528](https://github.com/MetaMask/snaps-monorepo/pull/528))
 
 ### Changed
-- **BREAKING:** Update examples to use CommonJS exported `onRpcRequest` and named parameters ([#481](https://github.com/MetaMask/snaps-skunkworks/pull/481), [#533](https://github.com/MetaMask/snaps-skunkworks/pull/533), [#538](https://github.com/MetaMask/snaps-skunkworks/pull/538), [#541](https://github.com/MetaMask/snaps-skunkworks/pull/541))
-- Update TypeScript example to use `OnRpcRequestHandler` ([#531](https://github.com/MetaMask/snaps-skunkworks/pull/531), [#533](https://github.com/MetaMask/snaps-skunkworks/pull/533), [#538](https://github.com/MetaMask/snaps-skunkworks/pull/538))
-- Update TypeScript example to use multiple files ([#527](https://github.com/MetaMask/snaps-skunkworks/pull/527))
+- **BREAKING:** Update examples to use CommonJS exported `onRpcRequest` and named parameters ([#481](https://github.com/MetaMask/snaps-monorepo/pull/481), [#533](https://github.com/MetaMask/snaps-monorepo/pull/533), [#538](https://github.com/MetaMask/snaps-monorepo/pull/538), [#541](https://github.com/MetaMask/snaps-monorepo/pull/541))
+- Update TypeScript example to use `OnRpcRequestHandler` ([#531](https://github.com/MetaMask/snaps-monorepo/pull/531), [#533](https://github.com/MetaMask/snaps-monorepo/pull/533), [#538](https://github.com/MetaMask/snaps-monorepo/pull/538))
+- Update TypeScript example to use multiple files ([#527](https://github.com/MetaMask/snaps-monorepo/pull/527))
 
 ## [0.15.0]
 ### Added
-- Add Rollup Snap example ([#472](https://github.com/MetaMask/snaps-skunkworks/pull/472))
-- Add Webpack Snap example ([#462](https://github.com/MetaMask/snaps-skunkworks/pull/462))
-- Add TypeScript Snap example ([#443](https://github.com/MetaMask/snaps-skunkworks/pull/443))
+- Add Rollup Snap example ([#472](https://github.com/MetaMask/snaps-monorepo/pull/472))
+- Add Webpack Snap example ([#462](https://github.com/MetaMask/snaps-monorepo/pull/462))
+- Add TypeScript Snap example ([#443](https://github.com/MetaMask/snaps-monorepo/pull/443))
 
 ## [0.14.0]
 ### Changed
@@ -76,14 +76,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0]
 ### Added
-- Add WebAssembly example snap ([#242](https://github.com/MetaMask/snaps-skunkworks/pull/242), [#381](https://github.com/MetaMask/snaps-skunkworks/pull/381), [#371](https://github.com/MetaMask/snaps-skunkworks/pull/371))
+- Add WebAssembly example snap ([#242](https://github.com/MetaMask/snaps-monorepo/pull/242), [#381](https://github.com/MetaMask/snaps-monorepo/pull/381), [#371](https://github.com/MetaMask/snaps-monorepo/pull/371))
 
 ### Changed
-- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-skunkworks/pull/360))
+- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-monorepo/pull/360))
 
 ## [0.10.7]
 ### Changed
-- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-skunkworks/pull/331))
+- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-monorepo/pull/331))
 
 ## [0.10.6]
 ### Changed
@@ -95,14 +95,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.3]
 ### Added
-- Add notification example snap ([#248](https://github.com/MetaMask/snaps-skunkworks/pull/248))
+- Add notification example snap ([#248](https://github.com/MetaMask/snaps-monorepo/pull/248))
 
 ## [0.10.0]
 ### Changed
-- **BREAKING:** Update config files per `@metamask/snaps-cli@0.10.0` ([#251](https://github.com/MetaMask/snaps-skunkworks/pull/251))
+- **BREAKING:** Update config files per `@metamask/snaps-cli@0.10.0` ([#251](https://github.com/MetaMask/snaps-monorepo/pull/251))
 
 ### Fixed
-- Ensure that all examples work with the current Snaps implementation ([#219](https://github.com/MetaMask/snaps-skunkworks/pull/219))
+- Ensure that all examples work with the current Snaps implementation ([#219](https://github.com/MetaMask/snaps-monorepo/pull/219))
 
 ## [0.9.0]
 ### Changed
@@ -126,17 +126,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1]
 ### Fixed
-- `bls-signer` example Snap `snap_confirm` call ([#168](https://github.com/MetaMask/snaps-skunkworks/pull/168))
+- `bls-signer` example Snap `snap_confirm` call ([#168](https://github.com/MetaMask/snaps-monorepo/pull/168))
   - The `bls-signer` Snap was passing invalid parameters to the method.
 
 ## [0.6.0]
 ### Changed
-- **BREAKING:** Support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-skunkworks/pull/140))
+- **BREAKING:** Support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-monorepo/pull/140))
   - This introduces several breaking changes to how Snaps are developed, hosted, and represented at runtime. See [the specification](https://github.com/MetaMask/specifications/blob/d4a5bf5d6990bb5b02a98bd3f95a24ffb28c701c/snaps/publishing.md) and the referenced pull request for details.
-- **BREAKING:** Update all example Snaps per new publishing specification ([#157](https://github.com/MetaMask/snaps-skunkworks/pull/157))
+- **BREAKING:** Update all example Snaps per new publishing specification ([#157](https://github.com/MetaMask/snaps-monorepo/pull/157))
 
 ### Removed
-- **BREAKING:** "hello-snaps` example ([#157](https://github.com/MetaMask/snaps-skunkworks/pull/157))
+- **BREAKING:** "hello-snaps` example ([#157](https://github.com/MetaMask/snaps-monorepo/pull/157))
 
 ## [0.5.0]
 ### Changed
@@ -152,16 +152,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0]
 ### Changed
-- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-skunkworks/pull/119))
+- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-monorepo/pull/119))
 
 ## [0.2.2]
 ### Fixed
-- Package script issues ([#97](https://github.com/MetaMask/snaps-skunkworks/pull/97), [#98](https://github.com/MetaMask/snaps-skunkworks/pull/98))
+- Package script issues ([#97](https://github.com/MetaMask/snaps-monorepo/pull/97), [#98](https://github.com/MetaMask/snaps-monorepo/pull/98))
 
 
 ## [0.2.0]
 ### Changed
-- Update publish scripts ([#92](https://github.com/MetaMask/snaps-skunkworks/pull/92))
+- Update publish scripts ([#92](https://github.com/MetaMask/snaps-monorepo/pull/92))
 
 ## [0.1.1]
 ### Added
@@ -172,44 +172,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0]
 ### Changed
-- Initial release ([#72](https://github.com/MetaMask/snaps-skunkworks/pull/72))
+- Initial release ([#72](https://github.com/MetaMask/snaps-monorepo/pull/72))
   - This package was previously a subset of [`snaps-cli`](https://github.com/MetaMask/snaps-cli/tree/main/examples), which has been renamed to [`@metamask/snaps-cli`](https://npmjs.com/package/@metamask/snaps-cli).
   - Some examples have been deleted because they were outdated.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.1...v0.12.0
-[0.11.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.7...v0.11.0
-[0.10.7]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.6...v0.10.7
-[0.10.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.5...v0.10.6
-[0.10.5]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.3...v0.10.5
-[0.10.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.0...v0.10.3
-[0.10.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.3...v0.7.0
-[0.6.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.0...v0.2.2
-[0.2.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.1.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.7...v0.11.0
+[0.10.7]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.6...v0.10.7
+[0.10.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.5...v0.10.6
+[0.10.5]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.3...v0.10.5
+[0.10.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.0...v0.10.3
+[0.10.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.0...v0.2.2
+[0.2.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.1.0

--- a/packages/examples/examples/bls-signer/package.json
+++ b/packages/examples/examples/bls-signer/package.json
@@ -5,7 +5,7 @@
   "description": "An example Snap that signs messages using BLS.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "main": "src/index.js",

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -4,7 +4,7 @@
   "proposedName": "bls-signer",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
     "shasum": "qNYd+o17O8kEwz40rxgBftRiyss2sYS7ir++rlLBQXo=",

--- a/packages/examples/examples/browserify/package.json
+++ b/packages/examples/examples/browserify/package.json
@@ -5,7 +5,7 @@
   "description": "An example Snap built using TypeScript and Browserify",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "main": "src/index.js",

--- a/packages/examples/examples/browserify/snap.manifest.json
+++ b/packages/examples/examples/browserify/snap.manifest.json
@@ -4,7 +4,7 @@
   "proposedName": "browserify-snap",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
     "shasum": "C25lIsH+SbFGCJM9i1lGLdPYq7YsUX0UHr/tZFMfsHI=",

--- a/packages/examples/examples/ethers-js/package.json
+++ b/packages/examples/examples/ethers-js/package.json
@@ -5,7 +5,7 @@
   "description": "An example Snap that that uses ethers.js.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "main": "src/index.js",

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -4,7 +4,7 @@
   "proposedName": "ethers-js-snap",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
     "shasum": "tZZq/cE7FBqjMguHM+WWaoUFTTqCE2qwV70VeOJSX4g=",

--- a/packages/examples/examples/ipfs/package.json
+++ b/packages/examples/examples/ipfs/package.json
@@ -5,7 +5,7 @@
   "description": "An example Snap that performs IPFS operations.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "main": "src/index.js",

--- a/packages/examples/examples/ipfs/snap.manifest.json
+++ b/packages/examples/examples/ipfs/snap.manifest.json
@@ -4,7 +4,7 @@
   "proposedName": "ipfs-snap",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
     "shasum": "ZcetnugqubraghMtlmyOiPDlUut7RiwTLmQbUwUypls=",

--- a/packages/examples/examples/rollup/package.json
+++ b/packages/examples/examples/rollup/package.json
@@ -5,7 +5,7 @@
   "description": "An example Snap built using TypeScript and Rollup",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "main": "src/index.js",

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -4,7 +4,7 @@
   "proposedName": "rollup-snap",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
     "shasum": "KBCbe8PgRkiublGQuK8NPeUex737E8Px3fSrSdnYuIg=",

--- a/packages/examples/examples/wasm/package.json
+++ b/packages/examples/examples/wasm/package.json
@@ -5,7 +5,7 @@
   "description": "An example Snap that uses WebAssembly.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "main": "src/index.js",

--- a/packages/examples/examples/wasm/snap.manifest.json
+++ b/packages/examples/examples/wasm/snap.manifest.json
@@ -4,7 +4,7 @@
   "proposedName": "wasm",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
     "shasum": "v/lRHVNTJ+lK+83EWqeQJ7XyE5lQkB49kZxzrIpDZVo=",

--- a/packages/examples/examples/webpack/package.json
+++ b/packages/examples/examples/webpack/package.json
@@ -5,7 +5,7 @@
   "description": "An example Snap built using TypeScript and Webpack",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "ISC",
   "main": "src/index.js",

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -4,7 +4,7 @@
   "proposedName": "webpack-snap",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
     "shasum": "ZWFcrhWfJfQko9o1PLh+IdOh+GbmDVpA5Ndhq8rhLJM=",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -5,7 +5,7 @@
   "description": "Example MetaMask Snaps.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "license": "MIT",
   "files": [

--- a/packages/execution-environments/CHANGELOG.md
+++ b/packages/execution-environments/CHANGELOG.md
@@ -12,15 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0]
 ### Added
-- Add Snap Keyring support ([#728](https://github.com/MetaMask/snaps-skunkworks/pull/728), [#700](https://github.com/MetaMask/snaps-skunkworks/pull/700))
+- Add Snap Keyring support ([#728](https://github.com/MetaMask/snaps-monorepo/pull/728), [#700](https://github.com/MetaMask/snaps-monorepo/pull/700))
 
 ## [0.21.0]
 ### Removed
-- **BREAKING:** Remove origin parameter from transaction insight payload ([#730](https://github.com/MetaMask/snaps-skunkworks/pull/730))
+- **BREAKING:** Remove origin parameter from transaction insight payload ([#730](https://github.com/MetaMask/snaps-monorepo/pull/730))
 
 ## [0.20.0]
 ### Added
-- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-skunkworks/pull/642))
+- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-monorepo/pull/642))
   - Part of this change made changes to the execution environments to support multiple request handlers
   - It also changed the exports of `@metamask/execution-environments`
 
@@ -30,61 +30,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.0]
 ### Fixed
-- Fixed network teardown so that snaps can't be escape by late returning promises ([#661](https://github.com/MetaMask/snaps-skunkworks/pull/661))
+- Fixed network teardown so that snaps can't be escape by late returning promises ([#661](https://github.com/MetaMask/snaps-monorepo/pull/661))
 
 ## [0.18.1]
 ### Fixed
-- Fix error serialization issues ([#637](https://github.com/MetaMask/snaps-skunkworks/pull/637))
+- Fix error serialization issues ([#637](https://github.com/MetaMask/snaps-monorepo/pull/637))
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ### Fixed
-- Fix `crypto` and `SubtleCrypto` endowments ([#631](https://github.com/MetaMask/snaps-skunkworks/pull/631))
+- Fix `crypto` and `SubtleCrypto` endowments ([#631](https://github.com/MetaMask/snaps-monorepo/pull/631))
 
 ## [0.17.0]
 ### Added
-- Add Node.js `child_process` execution environment ([#523](https://github.com/MetaMask/snaps-skunkworks/pull/523))
-- Add Node.js `worker_threads` execution environment ([#587](https://github.com/MetaMask/snaps-skunkworks/pull/587))
-- Added network endowment teardown ([#514](https://github.com/MetaMask/snaps-skunkworks/pull/514))
+- Add Node.js `child_process` execution environment ([#523](https://github.com/MetaMask/snaps-monorepo/pull/523))
+- Add Node.js `worker_threads` execution environment ([#587](https://github.com/MetaMask/snaps-monorepo/pull/587))
+- Added network endowment teardown ([#514](https://github.com/MetaMask/snaps-monorepo/pull/514))
 
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
-- Monitor outbound snap requests to pause request timeout ([#593](https://github.com/MetaMask/snaps-skunkworks/pull/593))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
+- Monitor outbound snap requests to pause request timeout ([#593](https://github.com/MetaMask/snaps-monorepo/pull/593))
 
 ### Removed
-- Remove WebWorker implementation ([#591](https://github.com/MetaMask/snaps-skunkworks/pull/591))
+- Remove WebWorker implementation ([#591](https://github.com/MetaMask/snaps-monorepo/pull/591))
 
 ## [0.16.0]
 ### Changed
-- **BREAKING:** Snaps are now required to export `onRpcRequest` to receive RPC requests ([#481](https://github.com/MetaMask/snaps-skunkworks/pull/481), [#533](https://github.com/MetaMask/snaps-skunkworks/pull/533), [#538](https://github.com/MetaMask/snaps-skunkworks/pull/538), [#541](https://github.com/MetaMask/snaps-skunkworks/pull/541))
-- Snaps can no longer run timers outside of pending RPC requests ([#490](https://github.com/MetaMask/snaps-skunkworks/pull/490))
+- **BREAKING:** Snaps are now required to export `onRpcRequest` to receive RPC requests ([#481](https://github.com/MetaMask/snaps-monorepo/pull/481), [#533](https://github.com/MetaMask/snaps-monorepo/pull/533), [#538](https://github.com/MetaMask/snaps-monorepo/pull/538), [#541](https://github.com/MetaMask/snaps-monorepo/pull/541))
+- Snaps can no longer run timers outside of pending RPC requests ([#490](https://github.com/MetaMask/snaps-monorepo/pull/490))
 
 ### Removed
-- **BREAKING:** Remove `wallet.registerRpcMessageHandler` support [#481](https://github.com/MetaMask/snaps-skunkworks/pull/481)
+- **BREAKING:** Remove `wallet.registerRpcMessageHandler` support [#481](https://github.com/MetaMask/snaps-monorepo/pull/481)
 
 ### Fixed
-- Fix issue with iframe error reporting ([#501](https://github.com/MetaMask/snaps-skunkworks/pull/501))
+- Fix issue with iframe error reporting ([#501](https://github.com/MetaMask/snaps-monorepo/pull/501))
 
 ## [0.15.0]
 ### Fixed
-- Added missing properties to `WebAssembly` global ([#459](https://github.com/MetaMask/snaps-skunkworks/pull/459))
-- Fix interval handle leak ([#485](https://github.com/MetaMask/snaps-skunkworks/pull/485))
-- Fix timer handle leak ([#483](https://github.com/MetaMask/snaps-skunkworks/pull/483))
+- Added missing properties to `WebAssembly` global ([#459](https://github.com/MetaMask/snaps-monorepo/pull/459))
+- Fix interval handle leak ([#485](https://github.com/MetaMask/snaps-monorepo/pull/485))
+- Fix timer handle leak ([#483](https://github.com/MetaMask/snaps-monorepo/pull/483))
 
 ## [0.14.0]
 ### Changed
-- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - This should not be breaking for consumers on any non-deprecated browser or Node.js version.
 
 ## [0.13.0]
 ### Changed
-- **BREAKING:** Change `execution-environment` build output ([#424](https://github.com/MetaMask/snaps-skunkworks/pull/424))
+- **BREAKING:** Change `execution-environment` build output ([#424](https://github.com/MetaMask/snaps-monorepo/pull/424))
 
 ## [0.12.0]
 ### Added
-- Add support for endowment teardown ([#407](https://github.com/MetaMask/snaps-skunkworks/pull/407))
+- Add support for endowment teardown ([#407](https://github.com/MetaMask/snaps-monorepo/pull/407))
 
 ## [0.11.1]
 ### Changed
@@ -92,31 +92,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0]
 ### Changed
-- Bump `ses` to `0.15.15` ([#396](https://github.com/MetaMask/snaps-skunkworks/pull/396))
-- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-skunkworks/pull/360))
-- Remove cross-fetch ([#349](https://github.com/MetaMask/snaps-skunkworks/pull/349))
+- Bump `ses` to `0.15.15` ([#396](https://github.com/MetaMask/snaps-monorepo/pull/396))
+- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-monorepo/pull/360))
+- Remove cross-fetch ([#349](https://github.com/MetaMask/snaps-monorepo/pull/349))
 
 ## [0.10.7]
 ### Added
-- Add setInterval and clearInterval as default endowments ([#326](https://github.com/MetaMask/snaps-skunkworks/pull/326))
+- Add setInterval and clearInterval as default endowments ([#326](https://github.com/MetaMask/snaps-monorepo/pull/326))
 
 ### Changed
-- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-skunkworks/pull/331))
+- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-monorepo/pull/331))
 
 ### Fixed
-- Fix missing properties on WebAssembly endowment ([#334](https://github.com/MetaMask/snaps-skunkworks/pull/334))
+- Fix missing properties on WebAssembly endowment ([#334](https://github.com/MetaMask/snaps-monorepo/pull/334))
 
 ## [0.10.6]
 ### Fixed
-- Fix function endowment bindings ([#311](https://github.com/MetaMask/snaps-skunkworks/pull/311))
+- Fix function endowment bindings ([#311](https://github.com/MetaMask/snaps-monorepo/pull/311))
 
 ## [0.10.5]
 ### Fixed
-- Fix missing index.js ([#303](https://github.com/MetaMask/snaps-skunkworks/pull/303))
+- Fix missing index.js ([#303](https://github.com/MetaMask/snaps-monorepo/pull/303))
 
 ## [0.10.4]
 ### Fixed
-- Fix endowed global functions with properties ([#294](https://github.com/MetaMask/snaps-skunkworks/pull/294))
+- Fix endowed global functions with properties ([#294](https://github.com/MetaMask/snaps-monorepo/pull/294))
   - Endowments like `Date` were missing all properties except `name` and `length`, causing e.g. `Date.now` to be `undefined`. This is no longer the case.
 
 ## [0.10.3]
@@ -125,44 +125,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.2]
 ### Fixed
-- Remove faulty postinstall script ([#279](https://github.com/MetaMask/snaps-skunkworks/pull/279))
+- Remove faulty postinstall script ([#279](https://github.com/MetaMask/snaps-monorepo/pull/279))
   - The faulty script caused the installation of this package to fail for consumers.
 
 ## [0.10.1]
 ### Fixed
-- Removed deprecated package ([#272](https://github.com/MetaMask/snaps-skunkworks/pull/272))
+- Removed deprecated package ([#272](https://github.com/MetaMask/snaps-monorepo/pull/272))
   - This package now uses the functionally equivalent `@metamask/providers` instead of the deprecated `@metamask/inpage-provider`.
 
 ## [0.10.0]
 ### Changed
-- Initial release, made using components from the deprecated [`@metamask/snap-workers`](https://npmjs.com/package/@metamask/snap-workers) package. ([#231](https://github.com/MetaMask/snaps-skunkworks/pull/231))
+- Initial release, made using components from the deprecated [`@metamask/snap-workers`](https://npmjs.com/package/@metamask/snap-workers) package. ([#231](https://github.com/MetaMask/snaps-monorepo/pull/231))
   - Breaking changes are relative to the old package.
-- **BREAKING:** Endowments must be passed to the execution environment ([#252](https://github.com/MetaMask/snaps-skunkworks/pull/252)), ([#266](https://github.com/MetaMask/snaps-skunkworks/pull/266))
+- **BREAKING:** Endowments must be passed to the execution environment ([#252](https://github.com/MetaMask/snaps-monorepo/pull/252)), ([#266](https://github.com/MetaMask/snaps-monorepo/pull/266))
   - Previously, default endowments were specified in the execution environment itself. Now, all endowments must be specified in the `executeSnap` RPC parameters, except for the `wallet` API object.
-- Add endowments to the global `self` in addition to `window` ([#263](https://github.com/MetaMask/snaps-skunkworks/pull/263))
+- Add endowments to the global `self` in addition to `window` ([#263](https://github.com/MetaMask/snaps-monorepo/pull/263))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.1...v0.12.0
-[0.11.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.7...v0.11.0
-[0.10.7]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.6...v0.10.7
-[0.10.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.5...v0.10.6
-[0.10.5]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.4...v0.10.5
-[0.10.4]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.3...v0.10.4
-[0.10.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.2...v0.10.3
-[0.10.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.1...v0.10.2
-[0.10.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.10.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.7...v0.11.0
+[0.10.7]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.6...v0.10.7
+[0.10.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.5...v0.10.6
+[0.10.5]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.4...v0.10.5
+[0.10.4]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.3...v0.10.4
+[0.10.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.2...v0.10.3
+[0.10.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.10.0

--- a/packages/execution-environments/package.json
+++ b/packages/execution-environments/package.json
@@ -4,7 +4,7 @@
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/plugin-browserify/CHANGELOG.md
+++ b/packages/plugin-browserify/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0]
 ### Added
-- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-skunkworks/pull/731))
+- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-monorepo/pull/731))
 
 ## [0.20.0]
 ### Changed
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.1]
 ### Added
-- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-skunkworks/pull/615))
+- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-monorepo/pull/615))
 
 ## [0.19.0]
 ### Changed
@@ -36,11 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ## [0.17.0]
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
 
 ## [0.16.0]
 ### Changed
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0]
 ### Fixed
-- Actually publish package contents ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- Actually publish package contents ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - Package contents were omitted from the previous version due to a build failure.
 
 ## [0.13.0]
@@ -61,20 +61,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0]
 ### Added
-- Initial release ([#410](https://github.com/MetaMask/snaps-skunkworks/pull/410), [#421](https://github.com/MetaMask/snaps-skunkworks/pull/421))
+- Initial release ([#410](https://github.com/MetaMask/snaps-monorepo/pull/410), [#421](https://github.com/MetaMask/snaps-monorepo/pull/421))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.12.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.12.0

--- a/packages/plugin-browserify/package.json
+++ b/packages/plugin-browserify/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "dist/index.js",
   "files": [

--- a/packages/plugin-rollup/CHANGELOG.md
+++ b/packages/plugin-rollup/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0]
 ### Added
-- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-skunkworks/pull/731))
+- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-monorepo/pull/731))
 
 ## [0.20.0]
 ### Changed
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.1]
 ### Added
-- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-skunkworks/pull/615))
+- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-monorepo/pull/615))
 
 ## [0.19.0]
 ### Changed
@@ -36,11 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ## [0.17.0]
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
 
 ## [0.16.0]
 ### Changed
@@ -52,24 +52,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0]
 ### Fixed
-- Actually publish package contents ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- Actually publish package contents ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - Package contents were omitted from the previous version due to a build failure.
 
 ## [0.13.0]
 ### Added
-- Initial release ([#431](https://github.com/MetaMask/snaps-skunkworks/pull/431))
+- Initial release ([#431](https://github.com/MetaMask/snaps-monorepo/pull/431))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.13.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.13.0

--- a/packages/plugin-rollup/package.json
+++ b/packages/plugin-rollup/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "dist/index.js",
   "files": [

--- a/packages/plugin-webpack/CHANGELOG.md
+++ b/packages/plugin-webpack/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0]
 ### Added
-- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-skunkworks/pull/731))
+- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-monorepo/pull/731))
 
 ## [0.20.0]
 ### Changed
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.1]
 ### Added
-- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-skunkworks/pull/615))
+- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-monorepo/pull/615))
 
 ## [0.19.0]
 ### Changed
@@ -36,11 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ## [0.17.0]
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
 
 ## [0.16.0]
 ### Changed
@@ -48,11 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.0]
 ### Fixed
-- Fix some typing issues ([#462](https://github.com/MetaMask/snaps-skunkworks/pull/462))
+- Fix some typing issues ([#462](https://github.com/MetaMask/snaps-monorepo/pull/462))
 
 ## [0.14.0]
 ### Fixed
-- Actually publish package contents ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- Actually publish package contents ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - Package contents were omitted from the previous version due to a build failure.
 
 ## [0.13.0]
@@ -61,20 +61,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0]
 ### Added
-- Initial release ([#420](https://github.com/MetaMask/snaps-skunkworks/pull/420))
+- Initial release ([#420](https://github.com/MetaMask/snaps-monorepo/pull/420))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.12.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.12.0

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "dist/index.js",
   "files": [

--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.1]
 ### Fixed
-- The provider now works properly with bundlers ([#820](https://github.com/MetaMask/snaps-skunkworks/pull/820))
+- The provider now works properly with bundlers ([#820](https://github.com/MetaMask/snaps-monorepo/pull/820))
 
 ## [0.22.0]
 ### Added
-- Initial release ([#700](https://github.com/MetaMask/snaps-skunkworks/pull/700))
+- Initial release ([#700](https://github.com/MetaMask/snaps-monorepo/pull/700))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.22.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.22.0

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -3,7 +3,7 @@
   "version": "0.22.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "dist/index.js",
   "files": [

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -12,32 +12,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0]
 ### Added
-- Add `snap_dialog` method and deprecate `snap_confirm` ([#799](https://github.com/MetaMask/snaps-skunkworks/pull/799))
+- Add `snap_dialog` method and deprecate `snap_confirm` ([#799](https://github.com/MetaMask/snaps-monorepo/pull/799))
 
 ## [0.21.0]
 ### Added
-- Add `snap_getBip32PublicKey` RPC method ([#729](https://github.com/MetaMask/snaps-skunkworks/pull/729))
+- Add `snap_getBip32PublicKey` RPC method ([#729](https://github.com/MetaMask/snaps-monorepo/pull/729))
 
 ### Changed
-- Expose master fingerprints on BIP-32 and SLIP-10 nodes ([#773](https://github.com/MetaMask/snaps-skunkworks/pull/773))
+- Expose master fingerprints on BIP-32 and SLIP-10 nodes ([#773](https://github.com/MetaMask/snaps-monorepo/pull/773))
   - Accomplished by bumping `@metamask/key-tree` to `5.0.2`
-- Allow deriving child nodes with `getBip32Entropy` ([#751](https://github.com/MetaMask/snaps-skunkworks/pull/751))
+- Allow deriving child nodes with `getBip32Entropy` ([#751](https://github.com/MetaMask/snaps-monorepo/pull/751))
 
 ### Removed
-- **BREAKING:** Remove deprecated `snap_getBip44Entropy_*` method ([#717](https://github.com/MetaMask/snaps-skunkworks/pull/717))
+- **BREAKING:** Remove deprecated `snap_getBip44Entropy_*` method ([#717](https://github.com/MetaMask/snaps-monorepo/pull/717))
 
 ### Fixed
-- Fix race condition in `wallet_getSnaps` ([#756](https://github.com/MetaMask/snaps-skunkworks/pull/756))
-- Fix fingerprint derivation on BIP-32 and SLIP-10 nodes ([#773](https://github.com/MetaMask/snaps-skunkworks/pull/773))
+- Fix race condition in `wallet_getSnaps` ([#756](https://github.com/MetaMask/snaps-monorepo/pull/756))
+- Fix fingerprint derivation on BIP-32 and SLIP-10 nodes ([#773](https://github.com/MetaMask/snaps-monorepo/pull/773))
   - Accomplished by bumping `@metamask/key-tree` to `5.0.2`
 
 ## [0.20.0]
 ### Added
-- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-skunkworks/pull/642))
-- Add `snap_getBip44Entropy` RPC method and deprecate `snap_getBip44Entropy_*` ([#690](https://github.com/MetaMask/snaps-skunkworks/pull/690))
+- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-monorepo/pull/642))
+- Add `snap_getBip44Entropy` RPC method and deprecate `snap_getBip44Entropy_*` ([#690](https://github.com/MetaMask/snaps-monorepo/pull/690))
 
 ### Changed
-- **BREAKING:** Simplify manifest format for permission caveats ([#705](https://github.com/MetaMask/snaps-skunkworks/pull/705))
+- **BREAKING:** Simplify manifest format for permission caveats ([#705](https://github.com/MetaMask/snaps-monorepo/pull/705))
 
 ## [0.19.1]
 ### Changed
@@ -45,8 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.0]
 ### Added
-- **BREAKING:** Add `snap_getBip32Entropy` method ([#683](https://github.com/MetaMask/snaps-skunkworks/pull/683))
-- Add new validation and limit for storage ([#621](https://github.com/MetaMask/snaps-skunkworks/pull/621))
+- **BREAKING:** Add `snap_getBip32Entropy` method ([#683](https://github.com/MetaMask/snaps-monorepo/pull/683))
+- Add new validation and limit for storage ([#621](https://github.com/MetaMask/snaps-monorepo/pull/621))
 
 ## [0.18.1]
 ### Changed
@@ -54,12 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ## [0.17.0]
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
-- **BREAKING:** Replace `getRpcMessageHandler` action with `handleRpcRequest` ([#497](https://github.com/MetaMask/snaps-skunkworks/pull/497), [#557](https://github.com/MetaMask/snaps-skunkworks/pull/557))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
+- **BREAKING:** Replace `getRpcMessageHandler` action with `handleRpcRequest` ([#497](https://github.com/MetaMask/snaps-monorepo/pull/497), [#557](https://github.com/MetaMask/snaps-monorepo/pull/557))
 
 ## [0.16.0]
 ### Changed
@@ -71,15 +71,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0]
 ### Changed
-- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - This should not be breaking for consumers on any non-deprecated browser or Node.js version.
 
 ## [0.13.0]
 ### Added
-- **BREAKING:** Add in-app notifications ([#419](https://github.com/MetaMask/snaps-skunkworks/pull/419))
+- **BREAKING:** Add in-app notifications ([#419](https://github.com/MetaMask/snaps-monorepo/pull/419))
 
 ### Changed
-- **BREAKING:** Bump `@metamask/key-tree` to `4.0.0` ([#446](https://github.com/MetaMask/snaps-skunkworks/pull/446))
+- **BREAKING:** Bump `@metamask/key-tree` to `4.0.0` ([#446](https://github.com/MetaMask/snaps-monorepo/pull/446))
 
 ## [0.12.0]
 ### Changed
@@ -87,20 +87,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.1]
 ### Fixed
-- Fixed an issue with determining whether existing permissions satisfy requested permissions ([#402](https://github.com/MetaMask/snaps-skunkworks/pull/402))
+- Fixed an issue with determining whether existing permissions satisfy requested permissions ([#402](https://github.com/MetaMask/snaps-monorepo/pull/402))
 
 ## [0.11.0]
 ### Changed
-- **BREAKING:** Wait for unlock on some RPC methods ([#356](https://github.com/MetaMask/snaps-skunkworks/pull/356))
-- **BREAKING:** Use PermissionController:revokePermissionForAllSubjects ([#351](https://github.com/MetaMask/snaps-skunkworks/pull/351))
-- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-skunkworks/pull/360))
+- **BREAKING:** Wait for unlock on some RPC methods ([#356](https://github.com/MetaMask/snaps-monorepo/pull/356))
+- **BREAKING:** Use PermissionController:revokePermissionForAllSubjects ([#351](https://github.com/MetaMask/snaps-monorepo/pull/351))
+- Upgraded TypeScript version to minimum 4.4 ([#360](https://github.com/MetaMask/snaps-monorepo/pull/360))
 
 ### Fixed
-- **BREAKING:** Fix prompting for existing permissions ([#354](https://github.com/MetaMask/snaps-skunkworks/pull/354))
+- **BREAKING:** Fix prompting for existing permissions ([#354](https://github.com/MetaMask/snaps-monorepo/pull/354))
 
 ## [0.10.7]
 ### Changed
-- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-skunkworks/pull/331))
+- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-monorepo/pull/331))
 
 ## [0.10.6]
 ### Changed
@@ -112,19 +112,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.3]
 ### Changed
-- Throw when trying to invoke a non-installed Snap ([#286](https://github.com/MetaMask/snaps-skunkworks/pull/286))
+- Throw when trying to invoke a non-installed Snap ([#286](https://github.com/MetaMask/snaps-monorepo/pull/286))
 
 ## [0.10.0]
 ### Added
-- `snap_notify` RPC method ([#234](https://github.com/MetaMask/snaps-skunkworks/pull/234))
+- `snap_notify` RPC method ([#234](https://github.com/MetaMask/snaps-monorepo/pull/234))
 
 ### Changed
-- **BREAKING:** Enforce JSON-compatibility of snap state ([#233](https://github.com/MetaMask/snaps-skunkworks/pull/233))
+- **BREAKING:** Enforce JSON-compatibility of snap state ([#233](https://github.com/MetaMask/snaps-monorepo/pull/233))
   - This state was always supposed to be JSON-compatible, and this is now enforced.
 
 ## [0.9.0]
 ### Changed
-- `@metamask/controllers@^25.1.0` ([#207](https://github.com/MetaMask/snaps-skunkworks/pull/207))
+- `@metamask/controllers@^25.1.0` ([#207](https://github.com/MetaMask/snaps-monorepo/pull/207))
 
 ## [0.8.0]
 ### Changed
@@ -140,44 +140,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.2]
 ### Changed
-- **BREAKING:** Rename restricted method permission builder exports ([#171](https://github.com/MetaMask/snaps-skunkworks/pull/171))
+- **BREAKING:** Rename restricted method permission builder exports ([#171](https://github.com/MetaMask/snaps-monorepo/pull/171))
 
 ## [0.6.1]
 ### Fixed
-- Fix `snap_confirm` validation logic ([#168](https://github.com/MetaMask/snaps-skunkworks/pull/168))
+- Fix `snap_confirm` validation logic ([#168](https://github.com/MetaMask/snaps-monorepo/pull/168))
   - [0.6.0] contained a bug where the method would reject most valid parameter combinations.
 
 ## [0.6.0]
 ### Added
-- "Endowment" permissions ([#152](https://github.com/MetaMask/snaps-skunkworks/pull/152))
+- "Endowment" permissions ([#152](https://github.com/MetaMask/snaps-monorepo/pull/152))
 
 ### Changed
-- **BREAKING:** Support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-skunkworks/pull/140))
+- **BREAKING:** Support the new Snaps publishing specification ([#140](https://github.com/MetaMask/snaps-monorepo/pull/140))
   - This introduces several breaking changes to how Snaps are developed, hosted, and represented at runtime. See [the specification](https://github.com/MetaMask/specifications/blob/d4a5bf5d6990bb5b02a98bd3f95a24ffb28c701c/snaps/publishing.md) and the referenced pull request for details.
-- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-skunkworks/pull/147))
-- **BREAKING:** Update `snap_confirm` parameters ([#158](https://github.com/MetaMask/snaps-skunkworks/pull/158))
-- Improve types and documentation for `selectHooks` ([#149](https://github.com/MetaMask/snaps-skunkworks/pull/149))
+- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-monorepo/pull/147))
+- **BREAKING:** Update `snap_confirm` parameters ([#158](https://github.com/MetaMask/snaps-monorepo/pull/158))
+- Improve types and documentation for `selectHooks` ([#149](https://github.com/MetaMask/snaps-monorepo/pull/149))
 
 ### Fixed
-- Restricted Snap method `origin` handling ([#150](https://github.com/MetaMask/snaps-skunkworks/pull/150))
+- Restricted Snap method `origin` handling ([#150](https://github.com/MetaMask/snaps-monorepo/pull/150))
 
 ## [0.5.0]
 ### Added
-- Added `title` and `subtitle` to `snap_confirm` ([#145](https://github.com/MetaMask/snaps-skunkworks/pull/145))
+- Added `title` and `subtitle` to `snap_confirm` ([#145](https://github.com/MetaMask/snaps-monorepo/pull/145))
 
 ### Changed
-- **BREAKING:** Update restricted RPC methods per new `PermissionController` ([#143](https://github.com/MetaMask/snaps-skunkworks/pull/143))
-- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-skunkworks/pull/143))
-- Update restricted RPC methods per new permissions system ([#143](https://github.com/MetaMask/snaps-skunkworks/pull/143))
+- **BREAKING:** Update restricted RPC methods per new `PermissionController` ([#143](https://github.com/MetaMask/snaps-monorepo/pull/143))
+- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-monorepo/pull/143))
+- Update restricted RPC methods per new permissions system ([#143](https://github.com/MetaMask/snaps-monorepo/pull/143))
 
 ## [0.4.0]
 ### Changed
-- **BREAKING:** Consolidate Snap state management methods into single method ([#135](https://github.com/MetaMask/snaps-skunkworks/pull/135))
+- **BREAKING:** Consolidate Snap state management methods into single method ([#135](https://github.com/MetaMask/snaps-monorepo/pull/135))
   - `snap_manageState`
-- **BREAKING:** Replace RPC method and permission description properties with docstrings ([#130](https://github.com/MetaMask/snaps-skunkworks/pull/130))
+- **BREAKING:** Replace RPC method and permission description properties with docstrings ([#130](https://github.com/MetaMask/snaps-monorepo/pull/130))
 
 ### Removed
-- **BREAKING:** Remove `snap_manageAssets` ([#134](https://github.com/MetaMask/snaps-skunkworks/pull/134))
+- **BREAKING:** Remove `snap_manageAssets` ([#134](https://github.com/MetaMask/snaps-monorepo/pull/134))
 
 ## [0.3.1]
 ### Changed
@@ -185,69 +185,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0]
 ### Changed
-- **BREAKING:** Make `wallet_getBip44Entropy_*` implementation safer ([#115](https://github.com/MetaMask/snaps-skunkworks/pull/115))
+- **BREAKING:** Make `wallet_getBip44Entropy_*` implementation safer ([#115](https://github.com/MetaMask/snaps-monorepo/pull/115))
   - Implemented by means of using [`@metamask/key-tree@^3.0.0](https://github.com/MetaMask/key-tree/releases/tag/v3.0.0)
-- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-skunkworks/pull/119))
+- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-monorepo/pull/119))
 
 ## [0.2.2]
 ### Fixed
-- Package script issues ([#97](https://github.com/MetaMask/snaps-skunkworks/pull/97), [#98](https://github.com/MetaMask/snaps-skunkworks/pull/98))
+- Package script issues ([#97](https://github.com/MetaMask/snaps-monorepo/pull/97), [#98](https://github.com/MetaMask/snaps-monorepo/pull/98))
 
 ## [0.2.0]
 ### Changed
-- Update publish scripts ([#92](https://github.com/MetaMask/snaps-skunkworks/pull/92))
+- Update publish scripts ([#92](https://github.com/MetaMask/snaps-monorepo/pull/92))
 
 ## [0.1.0]
 ### Added
-- Readme file ([#71](https://github.com/MetaMask/snaps-skunkworks/pull/71))
+- Readme file ([#71](https://github.com/MetaMask/snaps-monorepo/pull/71))
 
 ### Changed
-- **BREAKING:** Rename package to `@metamask/rpc-methods` ([#73](https://github.com/MetaMask/snaps-skunkworks/pull/73))
+- **BREAKING:** Rename package to `@metamask/rpc-methods` ([#73](https://github.com/MetaMask/snaps-monorepo/pull/73))
 
 ## [0.0.6]
 ### Changed
-- **BREAKING:** Migrate `CommandEngine` message format to JSON-RPC ([#11](https://github.com/MetaMask/snaps-skunkworks/pull/11))
-- **BREAKING:** Use generic execution environment interface ([#19](https://github.com/MetaMask/snaps-skunkworks/pull/19))
+- **BREAKING:** Migrate `CommandEngine` message format to JSON-RPC ([#11](https://github.com/MetaMask/snaps-monorepo/pull/11))
+- **BREAKING:** Use generic execution environment interface ([#19](https://github.com/MetaMask/snaps-monorepo/pull/19))
 
 ## [0.0.5]
 ### Added
 - First semi-stable release.
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.1...v0.12.0
-[0.11.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.7...v0.11.0
-[0.10.7]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.6...v0.10.7
-[0.10.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.5...v0.10.6
-[0.10.5]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.3...v0.10.5
-[0.10.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.0...v0.10.3
-[0.10.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.3...v0.7.0
-[0.6.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.0...v0.2.2
-[0.2.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.6...v0.1.0
-[0.0.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.0.5
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.7...v0.11.0
+[0.10.7]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.6...v0.10.7
+[0.10.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.5...v0.10.6
+[0.10.5]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.3...v0.10.5
+[0.10.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.0...v0.10.3
+[0.10.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.0...v0.2.2
+[0.2.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.6...v0.1.0
+[0.0.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.0.5

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -4,7 +4,7 @@
   "description": "MetaMask Snap RPC method implementations.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -12,21 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0]
 ### Added
-- Added `SnapKeyring` types ([#728](https://github.com/MetaMask/snaps-skunkworks/pull/728))
+- Added `SnapKeyring` types ([#728](https://github.com/MetaMask/snaps-monorepo/pull/728))
 
 ## [0.21.0]
 ### Removed
-- **BREAKING:** Remove origin parameter from transaction insight payload ([#730](https://github.com/MetaMask/snaps-skunkworks/pull/730))
+- **BREAKING:** Remove origin parameter from transaction insight payload ([#730](https://github.com/MetaMask/snaps-monorepo/pull/730))
 
 ### Fixed
-- Fix missing dependencies ([#718](https://github.com/MetaMask/snaps-skunkworks/pull/718))
+- Fix missing dependencies ([#718](https://github.com/MetaMask/snaps-monorepo/pull/718))
 
 ## [0.20.0]
 ### Added
-- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-skunkworks/pull/642))
+- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-monorepo/pull/642))
 
 ### Removed
-- **BREAKING:** Move all internal types from `@metamask/snap-types` to `@metamask/snap-utils` ([#695](https://github.com/MetaMask/snaps-skunkworks/pull/695))
+- **BREAKING:** Move all internal types from `@metamask/snap-types` to `@metamask/snap-utils` ([#695](https://github.com/MetaMask/snaps-monorepo/pull/695))
   - Previously accessible types can now be accessed by importing `@metamask/snap-utils`
 
 ## [0.19.1]
@@ -43,29 +43,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ## [0.17.0]
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
 
 ### Removed
-- Remove `ErrorMessageEvent` and `ExecutionServiceMessenger` types ([#486](https://github.com/MetaMask/snaps-skunkworks/pull/486))
+- Remove `ErrorMessageEvent` and `ExecutionServiceMessenger` types ([#486](https://github.com/MetaMask/snaps-monorepo/pull/486))
   - These types are now available via `@metamask/snap-controllers`
 
 ## [0.16.0]
 ### Added
-- Add `OnRpcRequestHandler` type ([#534](https://github.com/MetaMask/snaps-skunkworks/pull/534), [#531](https://github.com/MetaMask/snaps-skunkworks/pull/531), [#538](https://github.com/MetaMask/snaps-skunkworks/pull/538), [#533](https://github.com/MetaMask/snaps-skunkworks/pull/533))
+- Add `OnRpcRequestHandler` type ([#534](https://github.com/MetaMask/snaps-monorepo/pull/534), [#531](https://github.com/MetaMask/snaps-monorepo/pull/531), [#538](https://github.com/MetaMask/snaps-monorepo/pull/538), [#533](https://github.com/MetaMask/snaps-monorepo/pull/533))
 
 ### Changed
-- **BREAKING:** Change `SnapRpcHandler` type to reflect new function signature ([#534](https://github.com/MetaMask/snaps-skunkworks/pull/534), [#533](https://github.com/MetaMask/snaps-skunkworks/pull/533), [#481](https://github.com/MetaMask/snaps-skunkworks/pull/481))
+- **BREAKING:** Change `SnapRpcHandler` type to reflect new function signature ([#534](https://github.com/MetaMask/snaps-monorepo/pull/534), [#533](https://github.com/MetaMask/snaps-monorepo/pull/533), [#481](https://github.com/MetaMask/snaps-monorepo/pull/481))
 
 ### Removed
-- **BREAKING:** Remove `wallet.registerRpcMessageHandler` [#481](https://github.com/MetaMask/snaps-skunkworks/pull/481)
+- **BREAKING:** Remove `wallet.registerRpcMessageHandler` [#481](https://github.com/MetaMask/snaps-monorepo/pull/481)
 
 ## [0.15.0]
 ### Added
-- Add type for `wallet` global ([#443](https://github.com/MetaMask/snaps-skunkworks/pull/443))
+- Add type for `wallet` global ([#443](https://github.com/MetaMask/snaps-monorepo/pull/443))
 
 ## [0.14.0]
 ### Changed
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0]
 ### Removed
-- **BREAKING:** Remove `UnresponsiveMessageEvent` ([#395](https://github.com/MetaMask/snaps-skunkworks/pull/395))
+- **BREAKING:** Remove `UnresponsiveMessageEvent` ([#395](https://github.com/MetaMask/snaps-monorepo/pull/395))
 
 ## [0.11.1]
 ### Changed
@@ -85,11 +85,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0]
 ### Changed
-- **BREAKING:** Use PermissionController:revokePermissionForAllSubjects ([#351](https://github.com/MetaMask/snaps-skunkworks/pull/351))
+- **BREAKING:** Use PermissionController:revokePermissionForAllSubjects ([#351](https://github.com/MetaMask/snaps-monorepo/pull/351))
 
 ## [0.10.7]
 ### Changed
-- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-skunkworks/pull/331))
+- **BREAKING:** Bump minimum Node version from 12 to 14 ([#331](https://github.com/MetaMask/snaps-monorepo/pull/331))
 
 ## [0.10.6]
 ### Changed
@@ -105,7 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.1]
 ### Fixed
-- Removed deprecated package ([#272](https://github.com/MetaMask/snaps-skunkworks/pull/272))
+- Removed deprecated package ([#272](https://github.com/MetaMask/snaps-monorepo/pull/272))
   - This package now uses the functionally equivalent `@metamask/providers` instead of the deprecated `@metamask/inpage-provider`.
 
 ## [0.10.0]
@@ -114,7 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0]
 ### Changed
-- `@metamask/controllers@^25.1.0` ([#207](https://github.com/MetaMask/snaps-skunkworks/pull/207))
+- `@metamask/controllers@^25.1.0` ([#207](https://github.com/MetaMask/snaps-monorepo/pull/207))
   - This may affect some types in this package.
 
 ## [0.8.0]
@@ -123,7 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0]
 ### Changed
-- **BREAKING:** Rename `ServiceMessenger` events to `ExecutionService` ([#188](https://github.com/MetaMask/snaps-skunkworks/pull/188))
+- **BREAKING:** Rename `ServiceMessenger` events to `ExecutionService` ([#188](https://github.com/MetaMask/snaps-monorepo/pull/188))
 
 ## [0.6.3]
 ### Changed
@@ -139,14 +139,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0]
 ### Added
-- `SnapExecutionData` type ([#155](https://github.com/MetaMask/snaps-skunkworks/pull/155))
+- `SnapExecutionData` type ([#155](https://github.com/MetaMask/snaps-monorepo/pull/155))
 
 ### Changed
-- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-skunkworks/pull/147))
+- **BREAKING:** Rename Snap `name` property to `id` ([#147](https://github.com/MetaMask/snaps-monorepo/pull/147))
 
 ## [0.5.0]
 ### Changed
-- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-skunkworks/pull/143))
+- **BREAKING:** Convert all TypeScript `interface` declarations to `type` equivalents ([#143](https://github.com/MetaMask/snaps-monorepo/pull/143))
 
 ## [0.4.0]
 ### Changed
@@ -158,27 +158,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0]
 ### Added
-- `UnresponsiveMessageEvent` ([#104](https://github.com/MetaMask/snaps-skunkworks/pull/104))
-- `ErrorMessageEvent`, `ServiceMessenger` ([#100](https://github.com/MetaMask/snaps-skunkworks/pull/100))
+- `UnresponsiveMessageEvent` ([#104](https://github.com/MetaMask/snaps-monorepo/pull/104))
+- `ErrorMessageEvent`, `ServiceMessenger` ([#100](https://github.com/MetaMask/snaps-monorepo/pull/100))
 
 ### Changed
-- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-skunkworks/pull/119))
+- **BREAKING:** Enforce consistent naming for Snaps-related functionality ([#119](https://github.com/MetaMask/snaps-monorepo/pull/119))
 
 ## [0.2.2]
 ### Fixed
-- Package script issues ([#97](https://github.com/MetaMask/snaps-skunkworks/pull/97), [#98](https://github.com/MetaMask/snaps-skunkworks/pull/98))
+- Package script issues ([#97](https://github.com/MetaMask/snaps-monorepo/pull/97), [#98](https://github.com/MetaMask/snaps-monorepo/pull/98))
 
 
 ## [0.2.0]
 ### Changed
-- Update publish scripts ([#92](https://github.com/MetaMask/snaps-skunkworks/pull/92))
+- Update publish scripts ([#92](https://github.com/MetaMask/snaps-monorepo/pull/92))
 
 ## [0.1.0]
 ### Added
-- Readme file ([#71](https://github.com/MetaMask/snaps-skunkworks/pull/71))
+- Readme file ([#71](https://github.com/MetaMask/snaps-monorepo/pull/71))
 
 ### Changed
-- **BREAKING:** Rename package to `@metamask/snap-types` ([#73](https://github.com/MetaMask/snaps-skunkworks/pull/73))
+- **BREAKING:** Rename package to `@metamask/snap-types` ([#73](https://github.com/MetaMask/snaps-monorepo/pull/73))
 
 ## [0.0.6]
 
@@ -186,42 +186,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.1...v0.12.0
-[0.11.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.7...v0.11.0
-[0.10.7]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.6...v0.10.7
-[0.10.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.5...v0.10.6
-[0.10.5]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.3...v0.10.5
-[0.10.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.1...v0.10.3
-[0.10.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.3...v0.7.0
-[0.6.3]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.2.0...v0.2.2
-[0.2.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.6...v0.1.0
-[0.0.6]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.0.5
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.7...v0.11.0
+[0.10.7]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.6...v0.10.7
+[0.10.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.5...v0.10.6
+[0.10.5]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.3...v0.10.5
+[0.10.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.1...v0.10.3
+[0.10.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.2.0...v0.2.2
+[0.2.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.6...v0.1.0
+[0.0.6]: https://github.com/MetaMask/snaps-monorepo/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.0.5

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,7 @@
   "description": "TypeScript types for developing MetaMask Snaps.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "main": "src/index.d.ts",
   "types": "src/index.d.ts",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -8,37 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.1]
 ### Fixed
-- Add browser entry point for `snap-utils` ([#820](https://github.com/MetaMask/snaps-skunkworks/pull/820))
+- Add browser entry point for `snap-utils` ([#820](https://github.com/MetaMask/snaps-monorepo/pull/820))
 
 ## [0.22.0]
 ### Added
-- Add functionality required for Snap Keyring support ([#700](https://github.com/MetaMask/snaps-skunkworks/pull/700), [#777](https://github.com/MetaMask/snaps-skunkworks/pull/777))
+- Add functionality required for Snap Keyring support ([#700](https://github.com/MetaMask/snaps-monorepo/pull/700), [#777](https://github.com/MetaMask/snaps-monorepo/pull/777))
 
 ## [0.21.0]
 ### Changed
-- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-skunkworks/pull/731))
+- Run eval and fix manifest in bundler plugins ([#731](https://github.com/MetaMask/snaps-monorepo/pull/731))
 
 ## [0.20.0]
 ### Added
-- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-skunkworks/pull/642))
-- Add internal types from `@metamask/snap-types` ([#695](https://github.com/MetaMask/snaps-skunkworks/pull/695))
+- **BREAKING:** Add Transaction Insight API ([#642](https://github.com/MetaMask/snaps-monorepo/pull/642))
+- Add internal types from `@metamask/snap-types` ([#695](https://github.com/MetaMask/snaps-monorepo/pull/695))
 
 ### Changed
-- **BREAKING:** Simplify manifest format for permission caveats ([#705](https://github.com/MetaMask/snaps-skunkworks/pull/705))
-- Reduce TypeScript compilation target for `snap-controllers` ([#708](https://github.com/MetaMask/snaps-skunkworks/pull/708))
+- **BREAKING:** Simplify manifest format for permission caveats ([#705](https://github.com/MetaMask/snaps-monorepo/pull/705))
+- Reduce TypeScript compilation target for `snap-controllers` ([#708](https://github.com/MetaMask/snaps-monorepo/pull/708))
 
 ## [0.19.1]
 ### Added
-- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-skunkworks/pull/615))
+- Generate source maps from modified code ([#615](https://github.com/MetaMask/snaps-monorepo/pull/615))
 
 ## [0.19.0]
 ### Changed
-- Move eval functionality to utils package ([#666](https://github.com/MetaMask/snaps-skunkworks/pull/666))
-- Move manifest handling functionality to utils ([#652](https://github.com/MetaMask/snaps-skunkworks/pull/652))
-- Move JSON schemas and controller utils to utils package ([#623](https://github.com/MetaMask/snaps-skunkworks/pull/623))
+- Move eval functionality to utils package ([#666](https://github.com/MetaMask/snaps-monorepo/pull/666))
+- Move manifest handling functionality to utils ([#652](https://github.com/MetaMask/snaps-monorepo/pull/652))
+- Move JSON schemas and controller utils to utils package ([#623](https://github.com/MetaMask/snaps-monorepo/pull/623))
 
 ### Fixed
-- Fixed missing AbortSignal in default endowments ([#682](https://github.com/MetaMask/snaps-skunkworks/pull/682))
+- Fixed missing AbortSignal in default endowments ([#682](https://github.com/MetaMask/snaps-monorepo/pull/682))
 
 ## [0.18.1]
 ### Changed
@@ -46,11 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0]
 ### Changed
-- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-skunkworks/pull/628))
+- Reduce TypeScript compilation target to ES2017 ([#628](https://github.com/MetaMask/snaps-monorepo/pull/628))
 
 ## [0.17.0]
 ### Changed
-- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-skunkworks/pull/601))
+- **BREAKING:** Bump minimum Node version to 16 ([#601](https://github.com/MetaMask/snaps-monorepo/pull/601))
 
 ## [0.16.0]
 ### Changed
@@ -58,11 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.0]
 ### Fixed
-- Fix an issue where comment stripping would break for large files ([#468](https://github.com/MetaMask/snaps-skunkworks/pull/468))
+- Fix an issue where comment stripping would break for large files ([#468](https://github.com/MetaMask/snaps-monorepo/pull/468))
 
 ## [0.14.0]
 ### Changed
-- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-skunkworks/pull/449))
+- **BREAKING:** Increase TypeScript compilation target to ES2020 ([#449](https://github.com/MetaMask/snaps-monorepo/pull/449))
   - This should not be breaking for consumers on any non-deprecated browser or Node.js version.
 
 ## [0.13.0]
@@ -71,20 +71,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0]
 ### Added
-- Initial release ([#410](https://github.com/MetaMask/snaps-skunkworks/pull/410), [#421](https://github.com/MetaMask/snaps-skunkworks/pull/421))
+- Initial release ([#410](https://github.com/MetaMask/snaps-monorepo/pull/410), [#421](https://github.com/MetaMask/snaps-monorepo/pull/421))
 
-[Unreleased]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.1...HEAD
-[0.22.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.22.0...v0.22.1
-[0.22.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.20.0...v0.21.0
-[0.20.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.13.0...v0.14.0
-[0.13.0]: https://github.com/MetaMask/snaps-skunkworks/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/MetaMask/snaps-skunkworks/releases/tag/v0.12.0
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.22.0...v0.22.1
+[0.22.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/MetaMask/snaps-monorepo/releases/tag/v0.12.0

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.22.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/snaps-skunkworks.git"
+    "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "exports": {
     ".": {

--- a/packages/utils/src/default-endowments.ts
+++ b/packages/utils/src/default-endowments.ts
@@ -20,8 +20,8 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'setInterval',
   'clearInterval',
   // Used by fetch, but also as API for some packages that don't do network connections
-  // https://github.com/MetaMask/snaps-skunkworks/issues/662
-  // https://github.com/MetaMask/snaps-skunkworks/discussions/678
+  // https://github.com/MetaMask/snaps-monorepo/issues/662
+  // https://github.com/MetaMask/snaps-monorepo/discussions/678
   'AbortController',
   'AbortSignal',
 ]);

--- a/packages/utils/src/post-process.ts
+++ b/packages/utils/src/post-process.ts
@@ -318,7 +318,7 @@ export function postProcessBundle(
       // `import()` statements.
       // For reference:
       // - https://github.com/endojs/endo/blob/70cc86eb400655e922413b99c38818d7b2e79da0/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md
-      // - https://github.com/MetaMask/snaps-skunkworks/issues/505
+      // - https://github.com/MetaMask/snaps-monorepo/issues/505
       const [replacementQuasis, replacementExpressions] = node.quasis.reduce<
         [TemplateElement[], Expression[]]
       >(
@@ -367,7 +367,7 @@ export function postProcessBundle(
       // `import()` statements.
       // For reference:
       // - https://github.com/endojs/endo/blob/70cc86eb400655e922413b99c38818d7b2e79da0/packages/ses/error-codes/SES_HTML_COMMENT_REJECTED.md
-      // - https://github.com/MetaMask/snaps-skunkworks/issues/505
+      // - https://github.com/MetaMask/snaps-monorepo/issues/505
       const tokens = breakTokens(node.value);
 
       // Only update the node if the string literal was broken up.


### PR DESCRIPTION
Replaced all occurrences of `snaps-skunkworks` with `snaps-monorepo`. This is necessary to make tools like `auto-changelog` work.