### PR TITLE
Make `@babel/types` a regular dependency

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.18.6",
+    "@babel/types": "^7.18.7",
     "@metamask/snap-types": "^0.22.2",
     "@metamask/utils": "^3.1.0",
     "@noble/hashes": "^1.1.3",
@@ -68,7 +69,6 @@
     "superstruct": "^0.16.5"
   },
   "devDependencies": {
-    "@babel/types": "^7.18.7",
     "@json-schema-tools/transpiler": "^1.10.2",
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^2.6.0",


### PR DESCRIPTION
We use `@babel/types` for bundle post processing, but currently it's listed as `devDependency`, meaning it's not installed when installing `@metamask/snap-utils`. I've moved it to the regular dependencies to fix this issue.

Closes #850.