### PR TITLE
Stop assuming wrapped responses from MetaMask provider

### DIFF
--- a/packages/provider/src/MultiChainProvider.test.ts
+++ b/packages/provider/src/MultiChainProvider.test.ts
@@ -160,6 +160,23 @@ describe('MultiChainProvider', () => {
       expect(provider.isConnected).toBe(false);
       expect(listener).not.toHaveBeenCalled();
     });
+
+    it('throws on errors', async () => {
+      const request = ethereum.request as jest.MockedFunction<
+        typeof ethereum.request
+      >;
+
+      request.mockImplementation(async () => {
+        throw new Error('foo');
+      });
+
+      const provider = new MultiChainProvider();
+
+      const { approval } = await provider.connect({ requiredNamespaces: {} });
+      expect(provider.isConnected).toBe(false);
+
+      await expect(approval()).rejects.toThrow('foo');
+    });
   });
 
   describe('request', () => {
@@ -282,6 +299,27 @@ describe('MultiChainProvider', () => {
       const secondId = (request.mock.calls[2][0].params as { id: string }).id;
 
       expect(firstId).not.toBe(secondId);
+    });
+
+    it('throws on errors', async () => {
+      const provider = await getProvider();
+
+      const request = ethereum.request as jest.MockedFunction<
+        typeof ethereum.request
+      >;
+
+      request.mockImplementation(async () => {
+        throw new Error('foo');
+      });
+
+      await expect(
+        provider.request({
+          chainId: 'eip155:1',
+          request: {
+            method: 'eth_accounts',
+          },
+        }),
+      ).rejects.toThrow('foo');
     });
   });
 

--- a/packages/provider/src/MultiChainProvider.test.ts
+++ b/packages/provider/src/MultiChainProvider.test.ts
@@ -33,12 +33,8 @@ async function getProvider(
   >;
 
   request.mockImplementation(async () => ({
-    jsonrpc: '2.0',
-    id: 1,
-    result: {
-      namespaces: {
-        eip155: getSessionNamespace(),
-      },
+    namespaces: {
+      eip155: getSessionNamespace(),
     },
   }));
 
@@ -69,12 +65,8 @@ describe('MultiChainProvider', () => {
       >;
 
       request.mockImplementation(async () => ({
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          namespaces: {
-            eip155: getSessionNamespace(),
-          },
+        namespaces: {
+          eip155: getSessionNamespace(),
         },
       }));
 
@@ -93,12 +85,8 @@ describe('MultiChainProvider', () => {
       >;
 
       request.mockImplementation(async () => ({
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          namespaces: {
-            eip155: getSessionNamespace(),
-          },
+        namespaces: {
+          eip155: getSessionNamespace(),
         },
       }));
 
@@ -152,12 +140,8 @@ describe('MultiChainProvider', () => {
       >;
 
       request.mockImplementation(async () => ({
-        jsonrpc: '2.0',
-        id: 1,
-        result: {
-          namespaces: {
-            eip155: 'foo',
-          },
+        namespaces: {
+          eip155: 'foo',
         },
       }));
 
@@ -175,28 +159,6 @@ describe('MultiChainProvider', () => {
 
       expect(provider.isConnected).toBe(false);
       expect(listener).not.toHaveBeenCalled();
-    });
-
-    it('throws on JSON-RPC error response', async () => {
-      const request = ethereum.request as jest.MockedFunction<
-        typeof ethereum.request
-      >;
-
-      request.mockImplementation(async () => ({
-        jsonrpc: '2.0',
-        id: 1,
-        error: {
-          code: -1,
-          message: 'foo',
-        },
-      }));
-
-      const provider = new MultiChainProvider();
-
-      const { approval } = await provider.connect({ requiredNamespaces: {} });
-      expect(provider.isConnected).toBe(false);
-
-      await expect(approval()).rejects.toThrow('JSON-RPC request failed: foo');
     });
   });
 
@@ -244,11 +206,7 @@ describe('MultiChainProvider', () => {
         typeof ethereum.request
       >;
 
-      request.mockImplementation(async () => ({
-        jsonrpc: '2.0',
-        id: 1,
-        result: 'foo',
-      }));
+      request.mockImplementation(async () => 'foo');
 
       const result = await provider.request({
         chainId: 'eip155:1',
@@ -324,32 +282,6 @@ describe('MultiChainProvider', () => {
       const secondId = (request.mock.calls[2][0].params as { id: string }).id;
 
       expect(firstId).not.toBe(secondId);
-    });
-
-    it('throws on JSON-RPC errors', async () => {
-      const provider = await getProvider();
-
-      const request = ethereum.request as jest.MockedFunction<
-        typeof ethereum.request
-      >;
-
-      request.mockImplementation(async () => ({
-        jsonrpc: '2.0',
-        id: 1,
-        error: {
-          code: -1,
-          message: 'foo',
-        },
-      }));
-
-      await expect(
-        provider.request({
-          chainId: 'eip155:1',
-          request: {
-            method: 'eth_accounts',
-          },
-        }),
-      ).rejects.toThrow('JSON-RPC request failed: foo');
     });
   });
 

--- a/packages/provider/src/MultiChainProvider.ts
+++ b/packages/provider/src/MultiChainProvider.ts
@@ -2,7 +2,6 @@ import SafeEventEmitter from '@metamask/safe-event-emitter';
 import { nanoid } from 'nanoid';
 import {
   assertIsConnectArguments,
-  assertIsJsonRpcSuccess,
   assertIsMetaMaskNotification,
   assertIsMultiChainRequest,
   assertIsSession,
@@ -97,12 +96,11 @@ export class MultiChainProvider extends SafeEventEmitter implements Provider {
           params: { requiredNamespaces },
         });
 
-        assertIsJsonRpcSuccess(response);
-        assertIsSession(response.result);
+        assertIsSession(response);
 
         this.#isConnected = true;
 
-        const session = response.result;
+        const session = response;
         this.emit('session_update', { params: session });
         return session;
       },
@@ -129,16 +127,13 @@ export class MultiChainProvider extends SafeEventEmitter implements Provider {
 
     assertIsMultiChainRequest(args);
 
-    const response = await this.#rpcRequest({
+    return this.#rpcRequest({
       method: 'caip_request',
       params: {
         chainId: args.chainId,
         request: { method: args.request.method, params: args.request.params },
       },
     });
-
-    assertIsJsonRpcSuccess(response);
-    return response.result;
   }
 
   /**

--- a/packages/provider/src/MultiChainProvider.ts
+++ b/packages/provider/src/MultiChainProvider.ts
@@ -91,16 +91,15 @@ export class MultiChainProvider extends SafeEventEmitter implements Provider {
         );
 
         this.#isConnected = false;
-        const response = await this.#rpcRequest({
+        const session = await this.#rpcRequest({
           method: 'metamask_handshake',
           params: { requiredNamespaces },
         });
 
-        assertIsSession(response);
+        assertIsSession(session);
 
         this.#isConnected = true;
 
-        const session = response;
         this.emit('session_update', { params: session });
         return session;
       },


### PR DESCRIPTION
This fixes an issue that breaks the `MultiChainProvider`. Previously it would assume that the responses from MetaMask would be wrapped in the JSON-RPC wrapper, but that is not the case. This PR stops assuming that the responses are wrapped and treats the return value as a direct return value.