### PR TITLE
Export `MultiChainProvider` types

### DIFF
--- a/packages/provider/src/MultiChainProvider.ts
+++ b/packages/provider/src/MultiChainProvider.ts
@@ -16,8 +16,6 @@ import { JsonRpcRequest } from '@metamask/utils';
 import type { SnapProvider } from '@metamask/snap-types';
 import { Provider } from './Provider';
 
-export { ChainId, ConnectArguments, RequestArguments, Session };
-
 declare global {
   // Declaration merging doesn't work with types, so we have to use an interface
   // here.

--- a/packages/provider/src/MultiChainProvider.ts
+++ b/packages/provider/src/MultiChainProvider.ts
@@ -16,6 +16,8 @@ import { JsonRpcRequest } from '@metamask/utils';
 import type { SnapProvider } from '@metamask/snap-types';
 import { Provider } from './Provider';
 
+export { ChainId, ConnectArguments, RequestArguments, Session };
+
 declare global {
   // Declaration merging doesn't work with types, so we have to use an interface
   // here.

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,2 +1,8 @@
 export * from './MultiChainProvider';
 export * from './Provider';
+export {
+  ChainId,
+  ConnectArguments,
+  RequestArguments,
+  Session,
+} from '@metamask/snap-utils';


### PR DESCRIPTION
Re-exports types used in the MultiChainProvider for easier access by consumers.

Fixes #819