### PR TITLE
Fix Webpack plugin issue with existing files

### DIFF
--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@metamask/snap-utils": "^0.22.3",
+    "@metamask/utils": "^3.2.0",
     "webpack-sources": "^3.2.3"
   },
   "devDependencies": {

--- a/packages/plugin-webpack/src/plugin.ts
+++ b/packages/plugin-webpack/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   PostProcessOptions,
   SourceMap,
 } from '@metamask/snap-utils';
+import { assert } from '@metamask/utils';
 import { Compiler, WebpackError } from 'webpack';
 import { RawSource, SourceMapSource } from 'webpack-sources';
 
@@ -86,9 +87,7 @@ export default class SnapsWebpackPlugin {
         .getAssets()
         .find((asset) => asset.name.endsWith('.js'));
 
-      if (!file) {
-        return;
-      }
+      assert(file);
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const outputPath = compilation.outputOptions.path!;
@@ -103,9 +102,10 @@ export default class SnapsWebpackPlugin {
         const { errors, warnings } = await checkManifest(
           pathUtils.dirname(this.options.manifestPath),
           this.options.writeManifest,
-          (
-            await promisify(compiler.outputFileSystem.readFile)(filePath)
-          )?.toString(),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          (await promisify(compiler.outputFileSystem.readFile)(
+            filePath,
+          ))!.toString(),
         );
 
         if (!this.options.writeManifest && errors.length > 0) {

--- a/packages/plugin-webpack/src/plugin.ts
+++ b/packages/plugin-webpack/src/plugin.ts
@@ -1,5 +1,5 @@
 import pathUtils from 'path';
-import { promises as fs } from 'fs';
+import { promisify } from 'util';
 import {
   checkManifest,
   evalBundle,
@@ -103,7 +103,9 @@ export default class SnapsWebpackPlugin {
         const { errors, warnings } = await checkManifest(
           pathUtils.dirname(this.options.manifestPath),
           this.options.writeManifest,
-          await fs.readFile(filePath, 'utf8'),
+          (
+            await promisify(compiler.outputFileSystem.readFile)(filePath)
+          )?.toString(),
         );
 
         if (!this.options.writeManifest && errors.length > 0) {

--- a/packages/plugin-webpack/src/plugin.ts
+++ b/packages/plugin-webpack/src/plugin.ts
@@ -89,8 +89,8 @@ export default class SnapsWebpackPlugin {
 
       assert(file);
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const outputPath = compilation.outputOptions.path!;
+      assert(compilation.outputOptions.path);
+      const outputPath = compilation.outputOptions.path;
 
       const filePath = pathUtils.join(outputPath, file.name);
 
@@ -99,13 +99,14 @@ export default class SnapsWebpackPlugin {
       }
 
       if (this.options.manifestPath) {
+        const content = await promisify(compiler.outputFileSystem.readFile)(
+          filePath,
+        );
+        assert(content);
         const { errors, warnings } = await checkManifest(
           pathUtils.dirname(this.options.manifestPath),
           this.options.writeManifest,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          (await promisify(compiler.outputFileSystem.readFile)(
-            filePath,
-          ))!.toString(),
+          content.toString(),
         );
 
         if (!this.options.writeManifest && errors.length > 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3301,6 +3301,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
     "@metamask/snap-utils": ^0.22.3
+    "@metamask/utils": ^3.2.0
     "@types/jest": ^27.5.1
     "@types/webpack-sources": ^3.2.0
     eslint: ^7.30.0


### PR DESCRIPTION
Fixes an issue where already built files would be ignored by the Webpack plugin. This was fixed by using another hook to capture the emit (`afterEmit`), since the previous hook would not be called if the output file already existed.

Fixes #811 
