### PR TITLE
Stop including source code in state

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 85.74,
-      functions: 95.3,
-      lines: 94.83,
-      statements: 94.92,
+      branches: 86,
+      functions: 95.33,
+      lines: 94.88,
+      statements: 94.98,
     },
   },
   projects: [

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -22,6 +22,7 @@ import { createEngineStream } from 'json-rpc-middleware-stream';
 import pump from 'pump';
 import {
   getSnapManifest,
+  getPersistedSnapObject,
   getSnapObject,
   MOCK_ORIGIN,
   MOCK_SNAP_ID,
@@ -29,7 +30,6 @@ import {
   getMockSnapData,
   DEFAULT_SNAP_BUNDLE,
   MOCK_LOCAL_SNAP_ID,
-  DEFAULT_SNAP_SHASUM,
 } from '@metamask/snap-utils/test-utils';
 import { NodeThreadExecutionService, setupMultiplex } from '../services';
 import { delay } from '../utils';
@@ -66,9 +66,6 @@ jest.mock('./utils/npm', () => ({
 }));
 
 fetchMock.enableMocks();
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const omitSourceCode = ({ sourceCode, ...rest }: any): any => rest;
 
 describe('SnapController', () => {
   it('creates a snap controller and execution service', async () => {
@@ -279,7 +276,7 @@ describe('SnapController', () => {
       getSnapControllerOptions({
         state: {
           snaps: {
-            'npm:foo': getSnapObject({
+            'npm:foo': getPersistedSnapObject({
               permissionName: 'fooperm',
               version: '0.0.1',
               sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -581,7 +578,7 @@ describe('SnapController', () => {
       new Promise<void>((resolve) => {
         messenger.subscribe('SnapController:snapAdded', (snap) => {
           expect(snap).toStrictEqual(
-            omitSourceCode(getSnapObject({ status: SnapStatus.Installing })),
+            getSnapObject({ status: SnapStatus.Installing }),
           );
           resolve();
         });
@@ -669,7 +666,7 @@ describe('SnapController', () => {
       getSnapControllerOptions({ messenger }),
     );
 
-    const snap = await controller.add({
+    await controller.add({
       origin: MOCK_ORIGIN,
       id: MOCK_SNAP_ID,
       manifest: getSnapManifest(),
@@ -689,7 +686,9 @@ describe('SnapController', () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const newSnap = controller.get(MOCK_SNAP_ID)!;
 
-    expect(newSnap).toStrictEqual(omitSourceCode(snap));
+    expect(newSnap).toStrictEqual(
+      getSnapObject({ status: SnapStatus.Installing }),
+    );
     expect(addSpy).not.toHaveBeenCalled();
     expect(authorizeSpy).not.toHaveBeenCalled();
     expect(messengerCallMock).toHaveBeenCalledTimes(1);
@@ -770,7 +769,7 @@ describe('SnapController', () => {
       new Promise<void>((resolve) => {
         messenger.subscribe('SnapController:snapAdded', (snap) => {
           expect(snap).toStrictEqual(
-            omitSourceCode(getSnapObject({ status: SnapStatus.Installing })),
+            getSnapObject({ status: SnapStatus.Installing }),
           );
           resolve();
         });
@@ -1389,7 +1388,7 @@ describe('SnapController', () => {
     });
 
     it('handlers throw if the request has an invalid "jsonrpc" property', async () => {
-      const fakeSnap = getSnapObject({ status: SnapStatus.Running });
+      const fakeSnap = getPersistedSnapObject({ status: SnapStatus.Running });
       const snapId = fakeSnap.id;
       const snapController = getSnapController(
         getSnapControllerOptions({
@@ -1421,7 +1420,7 @@ describe('SnapController', () => {
 
     it('handlers will throw if there are too many pending requests before a snap has started', async () => {
       const messenger = getSnapControllerMessenger();
-      const fakeSnap = getSnapObject({ status: SnapStatus.Stopped });
+      const fakeSnap = getPersistedSnapObject({ status: SnapStatus.Stopped });
       const snapId = fakeSnap.id;
       const snapController = getSnapController(
         getSnapControllerOptions({
@@ -1620,7 +1619,7 @@ describe('SnapController', () => {
   describe('installSnaps', () => {
     it('returns existing non-local snaps without reinstalling them', async () => {
       const messenger = getSnapControllerMessenger();
-      const snapObject = getSnapObject();
+      const snapObject = getPersistedSnapObject();
       const truncatedSnap = getTruncatedSnap();
 
       const snapController = getSnapController(
@@ -1660,7 +1659,7 @@ describe('SnapController', () => {
 
     it('reinstalls local snaps even if they are already installed (already stopped)', async () => {
       const messenger = getSnapControllerMessenger();
-      const snapObject = getSnapObject({
+      const snapObject = getPersistedSnapObject({
         id: MOCK_LOCAL_SNAP_ID,
       });
       const truncatedSnap = getTruncatedSnap({
@@ -1970,7 +1969,7 @@ describe('SnapController', () => {
       const fetchSnapMock = jest
         .spyOn(snapController as any, '_fetchSnap')
         .mockImplementationOnce(() => {
-          return getSnapObject({ manifest });
+          return getPersistedSnapObject({ manifest });
         });
 
       const result = await snapController.installSnaps(MOCK_ORIGIN, {
@@ -2059,7 +2058,7 @@ describe('SnapController', () => {
       jest
         .spyOn(snapController as any, '_fetchSnap')
         .mockImplementationOnce(() => {
-          return getSnapObject({ manifest });
+          return getPersistedSnapObject({ manifest });
         });
 
       await snapController.installSnaps(MOCK_ORIGIN, {
@@ -2132,7 +2131,7 @@ describe('SnapController', () => {
       jest
         .spyOn(snapController as any, '_fetchSnap')
         .mockImplementationOnce(() => {
-          return getSnapObject({ manifest });
+          return getPersistedSnapObject({ manifest });
         });
 
       await snapController.installSnaps(MOCK_ORIGIN, {
@@ -2205,7 +2204,7 @@ describe('SnapController', () => {
           messenger,
           state: {
             snaps: {
-              [MOCK_SNAP_ID]: getSnapObject(),
+              [MOCK_SNAP_ID]: getPersistedSnapObject(),
             },
           },
         }),
@@ -2227,7 +2226,7 @@ describe('SnapController', () => {
       jest
         .spyOn(snapController as any, '_fetchSnap')
         .mockImplementationOnce(() => {
-          return getSnapObject({ manifest });
+          return getPersistedSnapObject({ manifest });
         });
 
       await snapController.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
@@ -2538,7 +2537,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           state: {
             snaps: {
-              [MOCK_SNAP_ID]: getSnapObject(),
+              [MOCK_SNAP_ID]: getPersistedSnapObject(),
             },
           },
         }),
@@ -2560,7 +2559,7 @@ describe('SnapController', () => {
           checkBlockList: checkBlockListSpy,
           state: {
             snaps: {
-              [MOCK_SNAP_ID]: getSnapObject(),
+              [MOCK_SNAP_ID]: getPersistedSnapObject(),
             },
           },
         }),
@@ -3190,10 +3189,8 @@ describe('SnapController', () => {
         id: MOCK_SNAP_ID,
       });
       expect(result).toStrictEqual(
-        getSnapObject({
-          sourceCode: DEFAULT_SNAP_BUNDLE,
+        getPersistedSnapObject({
           status: SnapStatus.Installing,
-          manifest: getSnapManifest({ shasum: DEFAULT_SNAP_SHASUM }),
         }),
       );
     });
@@ -3213,11 +3210,9 @@ describe('SnapController', () => {
       // Fetch is called 3 times, for fetching the manifest, the sourcecode and icon (icon just has the default response for now)
       expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(result).toStrictEqual(
-        getSnapObject({
+        getPersistedSnapObject({
           id,
-          sourceCode: DEFAULT_SNAP_BUNDLE,
           status: SnapStatus.Installing,
-          manifest: getSnapManifest(),
           permissionName: 'wallet_snap_local:https://localhost:8081',
         }),
       );
@@ -3230,7 +3225,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           state: {
             snaps: {
-              [MOCK_SNAP_ID]: { ...getSnapObject(), enabled: false },
+              [MOCK_SNAP_ID]: getPersistedSnapObject({ enabled: false }),
             },
           },
         }),
@@ -3254,11 +3249,10 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           state: {
             snaps: {
-              [MOCK_SNAP_ID]: {
-                ...getSnapObject(),
-                blocked: true,
+              [MOCK_SNAP_ID]: getPersistedSnapObject({
                 enabled: false,
-              },
+                blocked: true,
+              }),
             },
           },
         }),
@@ -3276,7 +3270,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           state: {
             snaps: {
-              [MOCK_SNAP_ID]: { ...getSnapObject(), enabled: true },
+              [MOCK_SNAP_ID]: getPersistedSnapObject(),
             },
           },
         }),
@@ -3293,7 +3287,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           state: {
             snaps: {
-              [MOCK_SNAP_ID]: { ...getSnapObject(), enabled: true },
+              [MOCK_SNAP_ID]: getPersistedSnapObject(),
             },
           },
         }),
@@ -3619,16 +3613,7 @@ describe('SnapController', () => {
           }),
         );
 
-        const fooSnapObject = {
-          initialPermissions: {},
-          permissionName: 'wallet_snap_npm:fooSnap',
-          version: '1.0.0',
-          sourceCode: DEFAULT_SNAP_BUNDLE,
-          id: 'npm:fooSnap',
-          manifest: getSnapManifest(),
-          enabled: true,
-          status: SnapStatus.Installing,
-        };
+        const fooSnapObject = getPersistedSnapObject();
 
         const addSpy = jest.spyOn(snapController, 'add');
         const fetchSnapMock = jest
@@ -3641,14 +3626,14 @@ describe('SnapController', () => {
 
         await messenger.call('SnapController:add', {
           origin: MOCK_ORIGIN,
-          id: 'npm:fooSnap',
+          id: MOCK_SNAP_ID,
         });
 
         expect(addSpy).toHaveBeenCalledTimes(1);
         expect(fetchSnapMock).toHaveBeenCalledTimes(1);
         expect(Object.keys(snapController.state.snaps)).toHaveLength(1);
-        expect(snapController.state.snaps['npm:fooSnap']).toMatchObject(
-          omitSourceCode(fooSnapObject),
+        expect(snapController.state.snaps[MOCK_SNAP_ID]).toMatchObject(
+          getSnapObject({ status: SnapStatus.Installing }),
         );
       });
     });
@@ -3656,55 +3641,36 @@ describe('SnapController', () => {
     describe('SnapController:get', () => {
       it('gets a snap', async () => {
         const messenger = getSnapControllerMessenger(undefined, false);
-        const fooSnapObject = getSnapObject({
-          permissionName: 'fooperm',
-          version: '0.0.1',
-          sourceCode: DEFAULT_SNAP_BUNDLE,
-          id: 'npm:fooSnap',
-          manifest: getSnapManifest(),
-          enabled: true,
-          status: SnapStatus.Installing,
-        });
 
         const snapController = getSnapController(
           getSnapControllerOptions({
             messenger,
             state: {
               snaps: {
-                'npm:fooSnap': fooSnapObject,
+                [MOCK_SNAP_ID]: getPersistedSnapObject(),
               },
             },
           }),
         );
 
         const getSpy = jest.spyOn(snapController, 'get');
-        const result = messenger.call('SnapController:get', 'npm:fooSnap');
+        const result = messenger.call('SnapController:get', MOCK_SNAP_ID);
 
         expect(getSpy).toHaveBeenCalledTimes(1);
-        expect(result).toMatchObject(omitSourceCode(fooSnapObject));
+        expect(result).toMatchObject(getSnapObject());
       });
     });
 
     describe('SnapController:handleRequest', () => {
       it('handles a snap RPC request', async () => {
         const messenger = getSnapControllerMessenger(undefined, false);
-        const fooSnapObject = getSnapObject({
-          initialPermissions: {},
-          permissionName: 'fooperm',
-          version: '0.0.1',
-          sourceCode: DEFAULT_SNAP_BUNDLE,
-          id: 'npm:fooSnap',
-          manifest: getSnapManifest(),
-          enabled: true,
-          status: SnapStatus.Running,
-        });
 
         const snapController = getSnapController(
           getSnapControllerOptions({
             messenger,
             state: {
               snaps: {
-                'npm:fooSnap': fooSnapObject,
+                [MOCK_SNAP_ID]: getPersistedSnapObject(),
               },
             },
           }),
@@ -3716,7 +3682,7 @@ describe('SnapController', () => {
 
         expect(
           await messenger.call('SnapController:handleRequest', {
-            snapId: 'npm:fooSnap',
+            snapId: MOCK_SNAP_ID,
             handler: HandlerType.OnRpcRequest,
             origin: 'foo',
             request: {},
@@ -3728,23 +3694,13 @@ describe('SnapController', () => {
 
     it('handles a transaction insight request', async () => {
       const messenger = getSnapControllerMessenger(undefined, false);
-      const fooSnapObject = getSnapObject({
-        initialPermissions: {},
-        permissionName: 'fooperm',
-        version: '0.0.1',
-        sourceCode: DEFAULT_SNAP_BUNDLE,
-        id: 'npm:fooSnap',
-        manifest: getSnapManifest(),
-        enabled: true,
-        status: SnapStatus.Running,
-      });
 
       const snapController = getSnapController(
         getSnapControllerOptions({
           messenger,
           state: {
             snaps: {
-              'npm:fooSnap': fooSnapObject,
+              [MOCK_SNAP_ID]: getPersistedSnapObject(),
             },
           },
         }),
@@ -3756,7 +3712,7 @@ describe('SnapController', () => {
 
       expect(
         await messenger.call('SnapController:handleRequest', {
-          snapId: 'npm:fooSnap',
+          snapId: MOCK_SNAP_ID,
           handler: HandlerType.OnTransaction,
           origin: 'foo',
           request: {},
@@ -3807,7 +3763,7 @@ describe('SnapController', () => {
           state: {
             snapStates: { [MOCK_SNAP_ID]: 'foo' },
             snaps: {
-              [MOCK_SNAP_ID]: getSnapObject({
+              [MOCK_SNAP_ID]: getPersistedSnapObject({
                 status: SnapStatus.Installing,
               }),
             },
@@ -3834,7 +3790,7 @@ describe('SnapController', () => {
           messenger,
           state: {
             snaps: {
-              'npm:fooSnap': getSnapObject({
+              'npm:fooSnap': getPersistedSnapObject({
                 permissionName: 'fooperm',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3865,7 +3821,7 @@ describe('SnapController', () => {
           messenger,
           state: {
             snaps: {
-              'npm:fooSnap': getSnapObject({
+              'npm:fooSnap': getPersistedSnapObject({
                 permissionName: 'fooperm',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3906,7 +3862,7 @@ describe('SnapController', () => {
           messenger,
           state: {
             snaps: {
-              'npm:fooSnap': getSnapObject({
+              'npm:fooSnap': getPersistedSnapObject({
                 permissionName: 'fooperm',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3915,7 +3871,7 @@ describe('SnapController', () => {
                 enabled: true,
                 status: SnapStatus.Installing,
               }),
-              'npm:fooSnap2': getSnapObject({
+              'npm:fooSnap2': getPersistedSnapObject({
                 permissionName: 'fooperm2',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3973,7 +3929,7 @@ describe('SnapController', () => {
           state: {
             snapStates: { [MOCK_SNAP_ID]: 'foo' },
             snaps: {
-              [MOCK_SNAP_ID]: getSnapObject({
+              [MOCK_SNAP_ID]: getPersistedSnapObject({
                 status: SnapStatus.Installing,
               }),
             },

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -67,6 +67,9 @@ jest.mock('./utils/npm', () => ({
 
 fetchMock.enableMocks();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const omitSourceCode = ({ sourceCode, ...rest }: any): any => rest;
+
 describe('SnapController', () => {
   it('creates a snap controller and execution service', async () => {
     const [snapController, service] = getSnapControllerWithEES();
@@ -578,7 +581,7 @@ describe('SnapController', () => {
       new Promise<void>((resolve) => {
         messenger.subscribe('SnapController:snapAdded', (snap) => {
           expect(snap).toStrictEqual(
-            getSnapObject({ status: SnapStatus.Installing }),
+            omitSourceCode(getSnapObject({ status: SnapStatus.Installing })),
           );
           resolve();
         });
@@ -686,8 +689,7 @@ describe('SnapController', () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const newSnap = controller.get(MOCK_SNAP_ID)!;
 
-    // Notice usage of toBe - we're checking if it's actually the same object, not an equal one
-    expect(newSnap).toBe(snap);
+    expect(newSnap).toStrictEqual(omitSourceCode(snap));
     expect(addSpy).not.toHaveBeenCalled();
     expect(authorizeSpy).not.toHaveBeenCalled();
     expect(messengerCallMock).toHaveBeenCalledTimes(1);
@@ -768,7 +770,7 @@ describe('SnapController', () => {
       new Promise<void>((resolve) => {
         messenger.subscribe('SnapController:snapAdded', (snap) => {
           expect(snap).toStrictEqual(
-            getSnapObject({ status: SnapStatus.Installing }),
+            omitSourceCode(getSnapObject({ status: SnapStatus.Installing })),
           );
           resolve();
         });
@@ -3646,7 +3648,7 @@ describe('SnapController', () => {
         expect(fetchSnapMock).toHaveBeenCalledTimes(1);
         expect(Object.keys(snapController.state.snaps)).toHaveLength(1);
         expect(snapController.state.snaps['npm:fooSnap']).toMatchObject(
-          fooSnapObject,
+          omitSourceCode(fooSnapObject),
         );
       });
     });
@@ -3679,7 +3681,7 @@ describe('SnapController', () => {
         const result = messenger.call('SnapController:get', 'npm:fooSnap');
 
         expect(getSpy).toHaveBeenCalledTimes(1);
-        expect(result).toMatchObject(fooSnapObject);
+        expect(result).toMatchObject(omitSourceCode(fooSnapObject));
       });
     });
 

--- a/packages/utils/src/snaps.ts
+++ b/packages/utils/src/snaps.ts
@@ -62,6 +62,13 @@ export type VersionHistory = {
   date: number;
 };
 
+export type PersistedSnap = Snap & {
+  /**
+   * The source code of the Snap.
+   */
+  sourceCode: string;
+};
+
 /**
  * A Snap as it exists in {@link SnapController} state.
  */
@@ -101,11 +108,6 @@ export type Snap = {
    * The name of the permission used to invoke the Snap.
    */
   permissionName: string;
-
-  /**
-   * The source code of the Snap.
-   */
-  sourceCode: string;
 
   /**
    * The current status of the Snap, e.g. whether it's running or stopped.

--- a/packages/utils/src/test-utils/snap.ts
+++ b/packages/utils/src/test-utils/snap.ts
@@ -1,4 +1,9 @@
-import { getSnapSourceShasum, Snap, SnapStatus, TruncatedSnap } from '../snaps';
+import {
+  getSnapSourceShasum,
+  PersistedSnap,
+  SnapStatus,
+  TruncatedSnap,
+} from '../snaps';
 import { getSnapManifest } from './manifest';
 
 /**
@@ -34,7 +39,7 @@ export const getSnapObject = ({
   versionHistory = [
     { origin: MOCK_ORIGIN, version: '1.0.0', date: expect.any(Number) },
   ],
-}: Partial<Snap> = {}): Snap => {
+}: Partial<PersistedSnap> = {}): PersistedSnap => {
   return {
     blocked,
     initialPermissions,

--- a/packages/utils/src/test-utils/snap.ts
+++ b/packages/utils/src/test-utils/snap.ts
@@ -1,6 +1,7 @@
 import {
   getSnapSourceShasum,
   PersistedSnap,
+  Snap,
   SnapStatus,
   TruncatedSnap,
 } from '../snaps';
@@ -26,7 +27,7 @@ export const MOCK_SNAP_ID = 'npm:@metamask/example-snap';
 export const MOCK_LOCAL_SNAP_ID = 'local:@metamask/example-snap';
 export const MOCK_ORIGIN = 'example.com';
 
-export const getSnapObject = ({
+export const getPersistedSnapObject = ({
   blocked = false,
   enabled = true,
   id = MOCK_SNAP_ID,
@@ -50,6 +51,32 @@ export const getSnapObject = ({
     status,
     enabled,
     sourceCode,
+    versionHistory,
+  } as const;
+};
+
+export const getSnapObject = ({
+  blocked = false,
+  enabled = true,
+  id = MOCK_SNAP_ID,
+  initialPermissions = getSnapManifest().initialPermissions,
+  manifest = getSnapManifest(),
+  permissionName = `wallet_snap_${id}`,
+  status = SnapStatus.Stopped,
+  version = getSnapManifest().version,
+  versionHistory = [
+    { origin: MOCK_ORIGIN, version: '1.0.0', date: expect.any(Number) },
+  ],
+}: Partial<Snap> = {}): Snap => {
+  return {
+    blocked,
+    initialPermissions,
+    id,
+    permissionName,
+    version,
+    manifest,
+    status,
+    enabled,
     versionHistory,
   } as const;
 };
@@ -115,7 +142,7 @@ export const getMockSnapData = ({
     shasum: DEFAULT_SNAP_SHASUM,
     sourceCode,
     manifest,
-    stateObject: getSnapObject({
+    stateObject: getPersistedSnapObject({
       blocked,
       enabled,
       id,


### PR DESCRIPTION
Stops storing the snap source code in the state of the controller, since this causes the source code to be piped to the extension UI every 200ms. With this PR, the source code is instead kept alongside other runtime data, being loaded when the controller spins up and persisted when it spins down.

This will also make it easier for us to store the sourceCode in another format in the near future.

Fixes #859 
