### PR TITLE
BREAKING: Refactor `SnapController.installSnaps()`

### DIFF
--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -4,10 +4,10 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 89.03,
+      branches: 89.13,
       functions: 96.44,
-      lines: 97.06,
-      statements: 97.06,
+      lines: 97.13,
+      statements: 97.13,
     },
   },
   projects: [


### PR DESCRIPTION
This PR changes `installSnaps()` to throw errors instead of returning errors.

WIP - we may need to figure out roll backs before we continue on this.

Fixes #893