### PR TITLE
Stop including snap state in controller state

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 84.67,
+      branches: 84.8,
       functions: 95.8,
       lines: 94.93,
       statements: 95.03,

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -10,8 +10,8 @@ module.exports = {
     global: {
       branches: 84.8,
       functions: 95.8,
-      lines: 94.93,
-      statements: 95.03,
+      lines: 94.94,
+      statements: 95.04,
     },
   },
   projects: [

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 84.63,
+      branches: 84.67,
       functions: 95.8,
       lines: 94.93,
       statements: 95.03,

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -3660,17 +3660,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           state: {
-            snaps: getPersistedSnapsState(
-              getPersistedSnapObject({
-                permissionName: 'fooperm',
-                version: '0.0.1',
-                sourceCode: DEFAULT_SNAP_BUNDLE,
-                id: 'npm:fooSnap',
-                manifest: getSnapManifest(),
-                enabled: true,
-                status: SnapStatus.Installing,
-              }),
-            ),
+            snaps: getPersistedSnapsState(),
           },
         }),
       );
@@ -3681,16 +3671,16 @@ describe('SnapController', () => {
       };
       await messenger.call(
         'SnapController:updateSnapState',
-        'npm:fooSnap',
+        MOCK_SNAP_ID,
         state,
       );
 
       expect(updateSnapStateSpy).toHaveBeenCalledTimes(1);
       expect(
         // @ts-expect-error Accessing private property
-        snapController._snapsRuntimeData.get('npm:fooSnap').state,
+        snapController._snapsRuntimeData.get(MOCK_SNAP_ID).state,
       ).toStrictEqual(
-        await passworder.encrypt('stateEncryption:npm:fooSnap', state),
+        await passworder.encrypt(`stateEncryption:${MOCK_SNAP_ID}`, state),
       );
     });
 
@@ -3702,23 +3692,9 @@ describe('SnapController', () => {
           messenger,
           state: {
             snaps: getPersistedSnapsState(
+              getPersistedSnapObject(),
               getPersistedSnapObject({
-                permissionName: 'fooperm',
-                version: '0.0.1',
-                sourceCode: DEFAULT_SNAP_BUNDLE,
-                id: 'npm:fooSnap',
-                manifest: getSnapManifest(),
-                enabled: true,
-                status: SnapStatus.Installing,
-              }),
-              getPersistedSnapObject({
-                permissionName: 'fooperm2',
-                version: '0.0.1',
-                sourceCode: DEFAULT_SNAP_BUNDLE,
-                id: 'npm:fooSnap2',
-                manifest: getSnapManifest(),
-                enabled: true,
-                status: SnapStatus.Installing,
+                id: MOCK_LOCAL_SNAP_ID,
               }),
             ),
           },
@@ -3731,31 +3707,34 @@ describe('SnapController', () => {
       };
       await messenger.call(
         'SnapController:updateSnapState',
-        'npm:fooSnap',
+        MOCK_SNAP_ID,
         state,
       );
 
       await messenger.call(
         'SnapController:updateSnapState',
-        'npm:fooSnap2',
+        MOCK_LOCAL_SNAP_ID,
         state,
       );
 
       expect(updateSnapStateSpy).toHaveBeenCalledTimes(2);
       const snapState1 =
         // @ts-expect-error Accessing private property
-        snapController._snapsRuntimeData.get('npm:fooSnap').state;
+        snapController._snapsRuntimeData.get(MOCK_SNAP_ID).state;
 
       const snapState2 =
         // @ts-expect-error Accessing private property
-        snapController._snapsRuntimeData.get('npm:fooSnap2').state;
+        snapController._snapsRuntimeData.get(MOCK_LOCAL_SNAP_ID).state;
 
       expect(snapState1).toStrictEqual(
-        await passworder.encrypt('stateEncryption:npm:fooSnap', state),
+        await passworder.encrypt(`stateEncryption:${MOCK_SNAP_ID}`, state),
       );
 
       expect(snapState2).toStrictEqual(
-        await passworder.encrypt('stateEncryption:npm:fooSnap2', state),
+        await passworder.encrypt(
+          `stateEncryption:${MOCK_LOCAL_SNAP_ID}`,
+          state,
+        ),
       );
 
       expect(snapState1).not.toStrictEqual(snapState2);

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -193,7 +193,7 @@ type StoredSnaps = Record<SnapId, Snap>;
 
 export type SnapControllerState = {
   snaps: StoredSnaps;
-  // This type needs to be defined but is always empty in practice..
+  // This type needs to be defined but is always empty in practice.
   // eslint-disable-next-line @typescript-eslint/ban-types
   snapStates: {};
   snapErrors: {
@@ -732,7 +732,7 @@ export class SnapController extends BaseController<
     Object.keys(filteredState.snaps).forEach((id) =>
       this.setupRuntime(id, {
         sourceCode: loadedSourceCode[id],
-        state: state?.snapStates?.[id] as string,
+        state: state?.snapStates?.[id] ?? null,
       }),
     );
   }

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -193,8 +193,9 @@ type StoredSnaps = Record<SnapId, Snap>;
 
 export type SnapControllerState = {
   snaps: StoredSnaps;
-  // TODO: This type needs to be defined but is always empty in practice..
-  snapStates: Record<string, Json>;
+  // This type needs to be defined but is always empty in practice..
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  snapStates: {};
   snapErrors: {
     [internalID: string]: SnapError & { internalID: string };
   };
@@ -202,6 +203,7 @@ export type SnapControllerState = {
 
 export type PersistedSnapControllerState = SnapControllerState & {
   snaps: Record<SnapId, PersistedSnap>;
+  snapStates: Record<SnapId, string>;
 };
 
 // Controller Messenger Actions


### PR DESCRIPTION
Stops including snap state in controller state so it isn't piped to the extension UI. Instead it is stored with runtime information.