### PR TITLE
Make `SnapController.add()` private

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 85.97,
-      functions: 95.33,
-      lines: 94.88,
-      statements: 94.97,
+      branches: 84.93,
+      functions: 95.34,
+      lines: 94.57,
+      statements: 94.67,
     },
   },
   projects: [

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 84.93,
+      branches: 84.47,
       functions: 95.34,
       lines: 94.57,
       statements: 94.67,

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -397,7 +397,7 @@ describe('SnapController', () => {
       }),
     );
 
-    const snap = await snapController.getExpect(MOCK_SNAP_ID);
+    const snap = snapController.getExpect(MOCK_SNAP_ID);
     await snapController.startSnap(snap.id);
 
     await snapController.handleRequest({

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -268,15 +268,15 @@ describe('SnapController', () => {
     const firstSnapController = getSnapController(
       getSnapControllerOptions({
         state: {
-          snaps: {
-            'npm:foo': getPersistedSnapObject({
+          snaps: getPersistedSnapsState(
+            getPersistedSnapObject({
               permissionName: 'fooperm',
               version: '0.0.1',
               sourceCode: DEFAULT_SNAP_BUNDLE,
               id: 'npm:foo',
               status: SnapStatus.Installing,
             }),
-          },
+          ),
         },
       }),
     );
@@ -2116,9 +2116,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject(),
-            },
+            snaps: getPersistedSnapsState(),
           },
         }),
       );
@@ -2445,9 +2443,7 @@ describe('SnapController', () => {
       const controller = getSnapController(
         getSnapControllerOptions({
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject(),
-            },
+            snaps: getPersistedSnapsState(),
           },
         }),
       );
@@ -2467,9 +2463,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           checkBlockList: checkBlockListSpy,
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject(),
-            },
+            snaps: getPersistedSnapsState(),
           },
         }),
       );
@@ -3129,9 +3123,9 @@ describe('SnapController', () => {
       const snapController = getSnapController(
         getSnapControllerOptions({
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject({ enabled: false }),
-            },
+            snaps: getPersistedSnapsState(
+              getPersistedSnapObject({ enabled: false }),
+            ),
           },
         }),
       );
@@ -3153,12 +3147,9 @@ describe('SnapController', () => {
       const snapController = getSnapController(
         getSnapControllerOptions({
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject({
-                enabled: false,
-                blocked: true,
-              }),
-            },
+            snaps: getPersistedSnapsState(
+              getPersistedSnapObject({ enabled: false, blocked: true }),
+            ),
           },
         }),
       );
@@ -3174,9 +3165,7 @@ describe('SnapController', () => {
       const snapController = getSnapController(
         getSnapControllerOptions({
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject(),
-            },
+            snaps: getPersistedSnapsState(),
           },
         }),
       );
@@ -3191,9 +3180,7 @@ describe('SnapController', () => {
       const snapController = getSnapController(
         getSnapControllerOptions({
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject(),
-            },
+            snaps: getPersistedSnapsState(),
           },
         }),
       );
@@ -3282,10 +3269,10 @@ describe('SnapController', () => {
           messenger,
           checkBlockList: checkBlockListSpy,
           state: {
-            snaps: {
-              [mockSnapA.id]: mockSnapA.stateObject,
-              [mockSnapB.id]: mockSnapB.stateObject,
-            },
+            snaps: getPersistedSnapsState(
+              mockSnapA.stateObject,
+              mockSnapB.stateObject,
+            ),
           },
         }),
       );
@@ -3340,9 +3327,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           checkBlockList: checkBlockListSpy,
           state: {
-            snaps: {
-              [mockSnap.id]: mockSnap.stateObject,
-            },
+            snaps: getPersistedSnapsState(mockSnap.stateObject),
           },
         }),
       );
@@ -3384,10 +3369,10 @@ describe('SnapController', () => {
           messenger,
           checkBlockList: checkBlockListSpy,
           state: {
-            snaps: {
-              [mockSnapA.id]: mockSnapA.stateObject,
-              [mockSnapB.id]: mockSnapB.stateObject,
-            },
+            snaps: getPersistedSnapsState(
+              mockSnapA.stateObject,
+              mockSnapB.stateObject,
+            ),
           },
         }),
       );
@@ -3435,9 +3420,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           checkBlockList: checkBlockListSpy,
           state: {
-            snaps: {
-              [mockSnap.id]: mockSnap.stateObject,
-            },
+            snaps: getPersistedSnapsState(mockSnap.stateObject),
           },
         }),
       );
@@ -3477,9 +3460,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           checkBlockList: checkBlockListSpy,
           state: {
-            snaps: {
-              [mockSnap.id]: mockSnap.stateObject,
-            },
+            snaps: getPersistedSnapsState(mockSnap.stateObject),
           },
         }),
       );
@@ -3517,9 +3498,7 @@ describe('SnapController', () => {
           getSnapControllerOptions({
             messenger,
             state: {
-              snaps: {
-                [MOCK_SNAP_ID]: getPersistedSnapObject(),
-              },
+              snaps: getPersistedSnapsState(),
             },
           }),
         );
@@ -3540,9 +3519,7 @@ describe('SnapController', () => {
           getSnapControllerOptions({
             messenger,
             state: {
-              snaps: {
-                [MOCK_SNAP_ID]: getPersistedSnapObject(),
-              },
+              snaps: getPersistedSnapsState(),
             },
           }),
         );
@@ -3570,9 +3547,7 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           state: {
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject(),
-            },
+            snaps: getPersistedSnapsState(),
           },
         }),
       );
@@ -3633,11 +3608,9 @@ describe('SnapController', () => {
           messenger,
           state: {
             snapStates: { [MOCK_SNAP_ID]: 'foo' },
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject({
-                status: SnapStatus.Installing,
-              }),
-            },
+            snaps: getPersistedSnapsState(
+              getPersistedSnapObject({ status: SnapStatus.Installing }),
+            ),
           },
         }),
       );
@@ -3660,8 +3633,8 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           state: {
-            snaps: {
-              'npm:fooSnap': getPersistedSnapObject({
+            snaps: getPersistedSnapsState(
+              getPersistedSnapObject({
                 permissionName: 'fooperm',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3670,7 +3643,7 @@ describe('SnapController', () => {
                 enabled: true,
                 status: SnapStatus.Installing,
               }),
-            },
+            ),
           },
         }),
       );
@@ -3691,8 +3664,8 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           state: {
-            snaps: {
-              'npm:fooSnap': getPersistedSnapObject({
+            snaps: getPersistedSnapsState(
+              getPersistedSnapObject({
                 permissionName: 'fooperm',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3701,7 +3674,7 @@ describe('SnapController', () => {
                 enabled: true,
                 status: SnapStatus.Installing,
               }),
-            },
+            ),
           },
         }),
       );
@@ -3732,8 +3705,8 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           state: {
-            snaps: {
-              'npm:fooSnap': getPersistedSnapObject({
+            snaps: getPersistedSnapsState(
+              getPersistedSnapObject({
                 permissionName: 'fooperm',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3742,7 +3715,7 @@ describe('SnapController', () => {
                 enabled: true,
                 status: SnapStatus.Installing,
               }),
-              'npm:fooSnap2': getPersistedSnapObject({
+              getPersistedSnapObject({
                 permissionName: 'fooperm2',
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
@@ -3751,7 +3724,7 @@ describe('SnapController', () => {
                 enabled: true,
                 status: SnapStatus.Installing,
               }),
-            },
+            ),
           },
         }),
       );
@@ -3799,11 +3772,11 @@ describe('SnapController', () => {
           messenger,
           state: {
             snapStates: { [MOCK_SNAP_ID]: 'foo' },
-            snaps: {
-              [MOCK_SNAP_ID]: getPersistedSnapObject({
+            snaps: getPersistedSnapsState(
+              getPersistedSnapObject({
                 status: SnapStatus.Installing,
               }),
-            },
+            ),
           },
         }),
       );
@@ -3850,14 +3823,12 @@ describe('SnapController', () => {
           getSnapControllerOptions({
             messenger,
             state: {
-              snaps: {
-                [mockSnap.id]: mockSnap.stateObject,
-              },
+              snaps: getPersistedSnapsState(mockSnap.stateObject),
             },
           }),
         );
 
-        await messenger.call('SnapController:enable', mockSnap.id);
+        messenger.call('SnapController:enable', mockSnap.id);
         expect(snapController.state.snaps[mockSnap.id].enabled).toBe(true);
       });
     });
@@ -3875,9 +3846,7 @@ describe('SnapController', () => {
           getSnapControllerOptions({
             messenger,
             state: {
-              snaps: {
-                [mockSnap.id]: mockSnap.stateObject,
-              },
+              snaps: getPersistedSnapsState(mockSnap.stateObject),
             },
           }),
         );
@@ -3900,9 +3869,7 @@ describe('SnapController', () => {
           getSnapControllerOptions({
             messenger,
             state: {
-              snaps: {
-                [mockSnap.id]: mockSnap.stateObject,
-              },
+              snaps: getPersistedSnapsState(mockSnap.stateObject),
             },
           }),
         );
@@ -3955,9 +3922,7 @@ describe('SnapController', () => {
           getSnapControllerOptions({
             messenger,
             state: {
-              snaps: {
-                [mockSnap.id]: mockSnap.stateObject,
-              },
+              snaps: getPersistedSnapsState(mockSnap.stateObject),
             },
           }),
         );
@@ -3984,9 +3949,7 @@ describe('SnapController', () => {
           getSnapControllerOptions({
             messenger,
             state: {
-              snaps: {
-                [mockSnap.id]: mockSnap.stateObject,
-              },
+              snaps: getPersistedSnapsState(mockSnap.stateObject),
             },
           }),
         );

--- a/packages/controllers/src/snaps/SnapController.test.ts
+++ b/packages/controllers/src/snaps/SnapController.test.ts
@@ -3081,40 +3081,33 @@ describe('SnapController', () => {
 
   describe('_fetchSnap', () => {
     it('can fetch NPM snaps', async () => {
-      const controller: any = getSnapController();
+      const controller = getSnapController();
 
-      const result = await controller._add({
-        origin: MOCK_ORIGIN,
-        id: MOCK_SNAP_ID,
+      const result = await controller.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
       });
-      expect(result).toStrictEqual(
-        getPersistedSnapObject({
-          status: SnapStatus.Installing,
-        }),
-      );
+      expect(result).toStrictEqual({ [MOCK_SNAP_ID]: getTruncatedSnap() });
     });
 
     it('can fetch local snaps', async () => {
-      const controller: any = getSnapController();
+      const controller = getSnapController();
 
       fetchMock
         .mockResponseOnce(JSON.stringify(getSnapManifest()))
         .mockResponseOnce(DEFAULT_SNAP_BUNDLE);
 
       const id = 'local:https://localhost:8081';
-      const result = await controller._add({
-        origin: MOCK_ORIGIN,
-        id,
+      const result = await controller.installSnaps(MOCK_ORIGIN, {
+        [id]: {},
       });
       // Fetch is called 3 times, for fetching the manifest, the sourcecode and icon (icon just has the default response for now)
       expect(fetchMock).toHaveBeenCalledTimes(3);
-      expect(result).toStrictEqual(
-        getPersistedSnapObject({
+      expect(result).toStrictEqual({
+        [id]: getTruncatedSnap({
           id,
-          status: SnapStatus.Installing,
           permissionName: 'wallet_snap_local:https://localhost:8081',
         }),
-      );
+      });
     });
   });
 

--- a/packages/controllers/src/snaps/SnapController.ts
+++ b/packages/controllers/src/snaps/SnapController.ts
@@ -201,14 +201,6 @@ export type PersistedSnapControllerState = SnapControllerState & {
 // Controller Messenger Actions
 
 /**
- * Adds the specified Snap to state. Used during installation.
- */
-export type AddSnap = {
-  type: `${typeof controllerName}:add`;
-  handler: SnapController['add'];
-};
-
-/**
  * Gets the specified Snap from state.
  */
 export type GetSnap = {
@@ -310,7 +302,6 @@ export type RemoveSnapError = {
 };
 
 export type SnapControllerActions =
-  | AddSnap
   | ClearSnapState
   | GetSnap
   | GetSnapState
@@ -798,11 +789,6 @@ export class SnapController extends BaseController<
    * actions.
    */
   private registerMessageHandlers(): void {
-    this.messagingSystem.registerActionHandler(
-      `${controllerName}:add`,
-      (...args) => this.add(...args),
-    );
-
     this.messagingSystem.registerActionHandler(
       `${controllerName}:clearSnapState`,
       (...args) => this.clearSnapState(...args),
@@ -1627,7 +1613,7 @@ export class SnapController extends BaseController<
     }
 
     try {
-      const { sourceCode } = await this.add({
+      const { sourceCode } = await this._add({
         origin,
         id: snapId,
         versionRange,
@@ -1780,7 +1766,7 @@ export class SnapController extends BaseController<
    * version.
    * @returns The resulting snap object.
    */
-  async add(args: AddSnapArgs): Promise<PersistedSnap> {
+  private async _add(args: AddSnapArgs): Promise<PersistedSnap> {
     const { id: snapId } = args;
     validateSnapId(snapId);
 

--- a/packages/controllers/src/test-utils/controller.ts
+++ b/packages/controllers/src/test-utils/controller.ts
@@ -1,8 +1,10 @@
 import { ControllerMessenger } from '@metamask/controllers';
+import { getPersistedSnapObject } from '@metamask/snap-utils/test-utils';
 import {
   AllowedActions,
   AllowedEvents,
   CheckSnapBlockListArg,
+  PersistedSnapControllerState,
   SnapController,
   SnapControllerActions,
   SnapControllerEvents,
@@ -52,7 +54,6 @@ export const getSnapControllerMessenger = (
       'PermissionController:getPermissions',
       'PermissionController:grantPermissions',
       'PermissionController:revokeAllPermissions',
-      'SnapController:add',
       'SnapController:get',
       'SnapController:handleRequest',
       'SnapController:getSnapState',
@@ -147,6 +148,7 @@ export const getSnapControllerWithEESOptions = (
   const originalCall = snapControllerMessenger.call.bind(
     snapControllerMessenger,
   );
+
   jest
     .spyOn(snapControllerMessenger, 'call')
     .mockImplementation((method, ...args) => {
@@ -159,6 +161,7 @@ export const getSnapControllerWithEESOptions = (
       }
       return originalCall(method, ...args);
     });
+
   return {
     environmentEndowmentPermissions: [],
     closeAllConnections: jest.fn(),
@@ -185,4 +188,16 @@ export const getSnapControllerWithEES = (
     service ?? getNodeEES(getNodeEESMessenger(options.rootMessenger));
   const controller = new SnapController(options);
   return [controller, _service] as const;
+};
+
+export const getPersistedSnapsState = (
+  ...snaps: PersistedSnapControllerState['snaps'][string][]
+): PersistedSnapControllerState['snaps'] => {
+  return (snaps.length > 0 ? snaps : [getPersistedSnapObject()]).reduce(
+    (snapsState, snapObject) => {
+      snapsState[snapObject.id] = snapObject;
+      return snapsState;
+    },
+    {} as PersistedSnapControllerState['snaps'],
+  );
 };

--- a/packages/controllers/src/test-utils/multichain.ts
+++ b/packages/controllers/src/test-utils/multichain.ts
@@ -3,6 +3,7 @@ import {
   MOCK_ORIGIN,
   MOCK_SNAP_ID,
   getSnapManifest,
+  getPersistedSnapObject,
 } from '@metamask/snap-utils/test-utils';
 import { SnapEndowments } from '..';
 import { MultiChainController } from '../multichain';
@@ -57,11 +58,14 @@ export const getMultiChainController = () => {
   };
 };
 
-export const getMultiChainControllerWithEES = () => {
-  const rootMessenger = getControllerMessenger();
-  const snapControllerOptions = getSnapControllerWithEESOptions({
-    rootMessenger,
-  });
+export const getMultiChainControllerWithEES = (
+  options = {
+    snapControllerOptions: getSnapControllerWithEESOptions(),
+  },
+) => {
+  const { snapControllerOptions } = options;
+  const { rootMessenger } = snapControllerOptions;
+
   const [snapController, executionService] = getSnapControllerWithEES(
     snapControllerOptions,
   );
@@ -154,8 +158,7 @@ class Keyring {
 }
 module.exports.keyring = new Keyring();`;
 
-export const MOCK_KEYRING_SNAP = {
-  origin: MOCK_ORIGIN,
+export const PERSISTED_MOCK_KEYRING_SNAP = getPersistedSnapObject({
   id: MOCK_SNAP_ID,
   sourceCode: MOCK_KEYRING_BUNDLE,
   manifest: getSnapManifest({
@@ -166,7 +169,7 @@ export const MOCK_KEYRING_SNAP = {
       },
     },
   }),
-};
+});
 
 export const MOCK_KEYRING_PERMISSION = {
   caveats: [{ type: 'snapKeyring', value: { namespaces: MOCK_NAMESPACES } }],


### PR DESCRIPTION
This PR turns `SnapController.add()` into a private method `_add()` and removes its associated action. Due to the extensive use of this method in tests, a new `SnapController` persisted state factory is added to our test utilities and used instead of `add()`. Overall unit tests coverage has decreased slightly due to the removal of tested code.