### PR TITLE
Improve keyring endowment error messaging

### DIFF
--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     global: {
       branches: 86,
       functions: 95.33,
-      lines: 94.88,
+      lines: 94.89,
       statements: 94.98,
     },
   },

--- a/packages/controllers/jest.config.js
+++ b/packages/controllers/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 86,
+      branches: 85.97,
       functions: 95.33,
-      lines: 94.89,
-      statements: 94.98,
+      lines: 94.88,
+      statements: 94.97,
     },
   },
   projects: [

--- a/packages/controllers/src/snaps/endowments/keyring.test.ts
+++ b/packages/controllers/src/snaps/endowments/keyring.test.ts
@@ -181,7 +181,9 @@ describe('keyringCaveatSpecifications', () => {
             namespaces: undefined,
           },
         }),
-      ).toThrow('Expected a valid namespaces object.');
+      ).toThrow(
+        'Invalid namespaces object: Expected an object, but received: undefined.',
+      );
     });
   });
 });

--- a/packages/controllers/src/snaps/endowments/keyring.ts
+++ b/packages/controllers/src/snaps/endowments/keyring.ts
@@ -1,7 +1,7 @@
 import {
-  isNamespacesObject,
   Namespaces,
   SnapCaveatType,
+  validateNamespacesObject,
 } from '@metamask/snap-utils';
 import {
   Caveat,
@@ -92,9 +92,10 @@ function validateCaveatNamespace(caveat: Caveat<string, any>): void {
     });
   }
 
-  if (!isNamespacesObject(value.namespaces)) {
+  const [error] = validateNamespacesObject(value.namespaces);
+  if (error) {
     throw ethErrors.rpc.invalidParams({
-      message: 'Expected a valid namespaces object.',
+      message: `Invalid namespaces object: ${error.message}.`,
     });
   }
 }

--- a/packages/controllers/src/snaps/endowments/keyring.ts
+++ b/packages/controllers/src/snaps/endowments/keyring.ts
@@ -1,7 +1,7 @@
 import {
+  assertIsNamespacesObject,
   Namespaces,
   SnapCaveatType,
-  validateNamespacesObject,
 } from '@metamask/snap-utils';
 import {
   Caveat,
@@ -92,12 +92,7 @@ function validateCaveatNamespace(caveat: Caveat<string, any>): void {
     });
   }
 
-  const [error] = validateNamespacesObject(value.namespaces);
-  if (error) {
-    throw ethErrors.rpc.invalidParams({
-      message: `Invalid namespaces object: ${error.message}.`,
-    });
-  }
+  assertIsNamespacesObject(value.namespaces, ethErrors.rpc.invalidParams);
 }
 
 /**

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -16,9 +16,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 86.54,
-      functions: 97.22,
-      lines: 96.84,
-      statements: 96.9,
+      functions: 97.19,
+      lines: 96.82,
+      statements: 96.89,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -16,9 +16,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 86.05,
-      functions: 97.14,
-      lines: 96.79,
-      statements: 96.86,
+      functions: 97.16,
+      lines: 96.8,
+      statements: 96.87,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -15,10 +15,10 @@ module.exports = {
   coverageReporters: ['clover', 'json', 'lcov', 'text', 'json-summary'],
   coverageThreshold: {
     global: {
-      branches: 86.05,
-      functions: 97.16,
-      lines: 96.8,
-      statements: 96.87,
+      branches: 86.54,
+      functions: 97.22,
+      lines: 96.84,
+      statements: 96.9,
     },
   },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],

--- a/packages/utils/src/assert.test.ts
+++ b/packages/utils/src/assert.test.ts
@@ -25,4 +25,36 @@ describe('assertStruct', () => {
       'Invalid event: At path: name -- Expected a string, but received: undefined',
     );
   });
+
+  it('throws with a custom error class', () => {
+    class CustomError extends Error {
+      constructor({ message }: { message: string }) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+
+    expect(() =>
+      assertStruct({ data: 'foo' }, EventStruct, 'Invalid event', CustomError),
+    ).toThrow(
+      new CustomError({
+        message:
+          'Invalid event: At path: name -- Expected a string, but received: undefined',
+      }),
+    );
+  });
+
+  it('throws with a custom error function', () => {
+    const CustomError = ({ message }: { message: string }) =>
+      new Error(message);
+
+    expect(() =>
+      assertStruct({ data: 'foo' }, EventStruct, 'Invalid event', CustomError),
+    ).toThrow(
+      CustomError({
+        message:
+          'Invalid event: At path: name -- Expected a string, but received: undefined',
+      }),
+    );
+  });
 });

--- a/packages/utils/src/assert.test.ts
+++ b/packages/utils/src/assert.test.ts
@@ -10,11 +10,11 @@ describe('assertStruct', () => {
 
   it('throws meaningful error messages for an invalid value', () => {
     expect(() => assertStruct({ data: 'foo' }, EventStruct)).toThrow(
-      'Assertion failed: At path: name -- Expected a string, but received: undefined',
+      'Assertion failed: At path: name -- Expected a string, but received: undefined.',
     );
 
     expect(() => assertStruct({ name: 1, data: 'foo' }, EventStruct)).toThrow(
-      'Assertion failed: At path: name -- Expected a string, but received: 1',
+      'Assertion failed: At path: name -- Expected a string, but received: 1.',
     );
   });
 
@@ -22,7 +22,7 @@ describe('assertStruct', () => {
     expect(() =>
       assertStruct({ data: 'foo' }, EventStruct, 'Invalid event'),
     ).toThrow(
-      'Invalid event: At path: name -- Expected a string, but received: undefined',
+      'Invalid event: At path: name -- Expected a string, but received: undefined.',
     );
   });
 
@@ -39,7 +39,7 @@ describe('assertStruct', () => {
     ).toThrow(
       new CustomError({
         message:
-          'Invalid event: At path: name -- Expected a string, but received: undefined',
+          'Invalid event: At path: name -- Expected a string, but received: undefined.',
       }),
     );
   });
@@ -53,7 +53,7 @@ describe('assertStruct', () => {
     ).toThrow(
       CustomError({
         message:
-          'Invalid event: At path: name -- Expected a string, but received: undefined',
+          'Invalid event: At path: name -- Expected a string, but received: undefined.',
       }),
     );
   });

--- a/packages/utils/src/assert.ts
+++ b/packages/utils/src/assert.ts
@@ -18,18 +18,6 @@ function isConstructable(
 }
 
 /**
- * Check if a value is not a constructor.
- *
- * @param fn - The value to check.
- * @returns `true` if the value is not a constructor, or `false` otherwise.
- */
-function isNotConstructable(
-  fn: AssertionErrorConstructor,
-): fn is (args: { message: string }) => Error {
-  return !isConstructable(fn);
-}
-
-/**
  * Assert a value against a Superstruct struct.
  *
  * @param value - The value to validate.
@@ -53,16 +41,10 @@ export function assertStruct<T, S>(
       throw new ErrorWrapper({
         message: `${errorPrefix}: ${error.message}.`,
       });
-    }
-
-    if (isNotConstructable(ErrorWrapper)) {
+    } else {
       throw ErrorWrapper({
         message: `${errorPrefix}: ${error.message}.`,
       });
     }
-
-    // This should never happen, but TypeScript doesn't know that.
-    /* istanbul ignore next */
-    throw error;
   }
 }

--- a/packages/utils/src/assert.ts
+++ b/packages/utils/src/assert.ts
@@ -1,6 +1,34 @@
 import { AssertionError } from '@metamask/utils';
 import { Struct, assert as assertSuperstruct } from 'superstruct';
 
+export type AssertionErrorConstructor =
+  | (new (args: { message: string }) => Error)
+  | ((args: { message: string }) => Error);
+
+/**
+ * Check if a value is a constructor.
+ *
+ * @param fn - The value to check.
+ * @returns `true` if the value is a constructor, or `false` otherwise.
+ */
+function isConstructable(
+  fn: AssertionErrorConstructor,
+): fn is new (args: { message: string }) => Error {
+  return Boolean(typeof fn?.prototype?.constructor?.name === 'string');
+}
+
+/**
+ * Check if a value is not a constructor.
+ *
+ * @param fn - The value to check.
+ * @returns `true` if the value is not a constructor, or `false` otherwise.
+ */
+function isNotConstructable(
+  fn: AssertionErrorConstructor,
+): fn is (args: { message: string }) => Error {
+  return !isConstructable(fn);
+}
+
 /**
  * Assert a value against a Superstruct struct.
  *
@@ -8,18 +36,33 @@ import { Struct, assert as assertSuperstruct } from 'superstruct';
  * @param struct - The struct to validate against.
  * @param errorPrefix - A prefix to add to the error message. Defaults to
  * "Assertion failed".
+ * @param ErrorWrapper - The error class to throw if the assertion fails.
+ * Defaults to {@link AssertionError}.
  * @throws If the value is not valid.
  */
 export function assertStruct<T, S>(
   value: unknown,
   struct: Struct<T, S>,
   errorPrefix = 'Assertion failed',
+  ErrorWrapper: AssertionErrorConstructor = AssertionError,
 ): asserts value is T {
   try {
     assertSuperstruct(value, struct);
   } catch (error) {
-    throw new AssertionError({
-      message: `${errorPrefix}: ${error.message}`,
-    });
+    if (isConstructable(ErrorWrapper)) {
+      throw new ErrorWrapper({
+        message: `${errorPrefix}: ${error.message}.`,
+      });
+    }
+
+    if (isNotConstructable(ErrorWrapper)) {
+      throw ErrorWrapper({
+        message: `${errorPrefix}: ${error.message}.`,
+      });
+    }
+
+    // This should never happen, but TypeScript doesn't know that.
+    /* istanbul ignore next */
+    throw error;
   }
 }

--- a/packages/utils/src/namespace.test.ts
+++ b/packages/utils/src/namespace.test.ts
@@ -1,4 +1,3 @@
-import { StructError } from 'superstruct';
 import {
   getChain,
   getNamespace,
@@ -8,6 +7,7 @@ import {
 import {
   assertIsConnectArguments,
   assertIsMultiChainRequest,
+  assertIsNamespacesObject,
   assertIsSession,
   isAccountId,
   isAccountIdArray,
@@ -19,7 +19,6 @@ import {
   isNamespacesObject,
   parseAccountId,
   parseChainId,
-  validateNamespacesObject,
 } from './namespace';
 
 describe('parseChainId', () => {
@@ -648,14 +647,14 @@ describe('isNamespacesObject', () => {
   });
 });
 
-describe('validateNamespacesObject', () => {
+describe('assertIsNamespacesObject', () => {
   it.each([
     {},
     { eip155: getNamespace() },
     { bip122: getNamespace() },
     { eip155: getNamespace(), bip122: getNamespace() },
-  ])('returns the object for a valid namespaces object', (object) => {
-    expect(validateNamespacesObject(object)).toStrictEqual([undefined, object]);
+  ])('does not throw for a valid namespaces object', (object) => {
+    expect(() => assertIsNamespacesObject(object)).not.toThrow();
   });
 
   it.each([
@@ -678,10 +677,9 @@ describe('validateNamespacesObject', () => {
     { a: getNamespace() },
     { eip155: getNamespace(), a: getNamespace() },
     { foobarbaz: getNamespace() },
-  ])('returns an error for an invalid namespaces object', (object) => {
-    expect(validateNamespacesObject(object)).toStrictEqual([
-      expect.any(StructError),
-      undefined,
-    ]);
+  ])('throws for an invalid namespaces object', (object) => {
+    expect(() => assertIsNamespacesObject(object)).toThrow(
+      'Invalid namespaces object:',
+    );
   });
 });

--- a/packages/utils/src/namespace.test.ts
+++ b/packages/utils/src/namespace.test.ts
@@ -1,3 +1,4 @@
+import { StructError } from 'superstruct';
 import {
   getChain,
   getNamespace,
@@ -18,6 +19,7 @@ import {
   isNamespacesObject,
   parseAccountId,
   parseChainId,
+  validateNamespacesObject,
 } from './namespace';
 
 describe('parseChainId', () => {
@@ -643,5 +645,43 @@ describe('isNamespacesObject', () => {
     { foobarbaz: getNamespace() },
   ])('returns false for an invalid namespaces object', (object) => {
     expect(isNamespacesObject(object)).toBe(false);
+  });
+});
+
+describe('validateNamespacesObject', () => {
+  it.each([
+    {},
+    { eip155: getNamespace() },
+    { bip122: getNamespace() },
+    { eip155: getNamespace(), bip122: getNamespace() },
+  ])('returns the object for a valid namespaces object', (object) => {
+    expect(validateNamespacesObject(object)).toStrictEqual([undefined, object]);
+  });
+
+  it.each([
+    true,
+    false,
+    null,
+    undefined,
+    1,
+    'foo',
+    { eip155: {} },
+    { eip155: [], bip122: [] },
+    { eip155: true, bip122: true },
+    { eip155: false, bip122: false },
+    { eip155: null, bip122: null },
+    { eip155: undefined, bip122: undefined },
+    { eip155: 1, bip122: 1 },
+    { eip155: 'foo', bip122: 'foo' },
+    { eip155: { methods: [] }, bip122: { methods: [] } },
+    { eip155: { chains: ['foo'] }, bip122: { chains: ['foo'] } },
+    { a: getNamespace() },
+    { eip155: getNamespace(), a: getNamespace() },
+    { foobarbaz: getNamespace() },
+  ])('returns an error for an invalid namespaces object', (object) => {
+    expect(validateNamespacesObject(object)).toStrictEqual([
+      expect.any(StructError),
+      undefined,
+    ]);
   });
 });

--- a/packages/utils/src/namespace.ts
+++ b/packages/utils/src/namespace.ts
@@ -12,8 +12,10 @@ import {
   assign,
   partial,
   pick,
+  validate,
 } from 'superstruct';
 import { JsonRpcRequestStruct } from '@metamask/utils';
+import { StructError } from 'superstruct/lib/error';
 import { assertStruct } from './assert';
 
 export const CHAIN_ID_REGEX =
@@ -275,4 +277,20 @@ export function isNamespace(value: unknown): value is Namespace {
  */
 export function isNamespacesObject(value: unknown): value is Namespaces {
   return is(value, NamespacesStruct);
+}
+
+/**
+ * Check if a value is an object containing {@link Namespaces}s. This behaves
+ * the same as {@link isNamespacesObject}, but rather than returning a boolean,
+ * it returns a tuple containing an error message if the value is not valid, or
+ * the validated value if it is.
+ *
+ * @param value - The value to validate.
+ * @returns A tuple containing an error message if the value is not valid, or
+ * the validated value if it is.
+ */
+export function validateNamespacesObject(
+  value: unknown,
+): [StructError, undefined] | [undefined, Namespaces] {
+  return validate(value, NamespacesStruct);
 }

--- a/packages/utils/src/namespace.ts
+++ b/packages/utils/src/namespace.ts
@@ -12,11 +12,9 @@ import {
   assign,
   partial,
   pick,
-  validate,
 } from 'superstruct';
 import { JsonRpcRequestStruct } from '@metamask/utils';
-import { StructError } from 'superstruct/lib/error';
-import { assertStruct } from './assert';
+import { AssertionErrorConstructor, assertStruct } from './assert';
 
 export const CHAIN_ID_REGEX =
   /^(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-a-zA-Z0-9]{1,32})$/u;
@@ -280,17 +278,21 @@ export function isNamespacesObject(value: unknown): value is Namespaces {
 }
 
 /**
- * Check if a value is an object containing {@link Namespaces}s. This behaves
- * the same as {@link isNamespacesObject}, but rather than returning a boolean,
- * it returns a tuple containing an error message if the value is not valid, or
- * the validated value if it is.
+ * Assert that the given value is a {@link Namespaces} object.
  *
- * @param value - The value to validate.
- * @returns A tuple containing an error message if the value is not valid, or
- * the validated value if it is.
+ * @param value - The value to check.
+ * @param ErrorWrapper - The error wrapper to use. Defaults to
+ * {@link AssertionError}.
+ * @throws If the value is not a valid {@link Namespaces} object.
  */
-export function validateNamespacesObject(
+export function assertIsNamespacesObject(
   value: unknown,
-): [StructError, undefined] | [undefined, Namespaces] {
-  return validate(value, NamespacesStruct);
+  ErrorWrapper?: AssertionErrorConstructor,
+): asserts value is Namespaces {
+  assertStruct(
+    value,
+    NamespacesStruct,
+    'Invalid namespaces object',
+    ErrorWrapper,
+  );
 }


### PR DESCRIPTION
Previously, if a Snap would specify an invalid keyring namespace object, we would throw an error like:

```
Expected a valid namespaces object.
```

This does not explain exactly what the issue is. This changes it to throw more descriptive errors, i.e., the errors thrown by Superstruct, but wrapped in a JSON-RPC error. For example:

```
Invalid namespaces object: Expected an object, but received: undefined.
```