### PR TITLE
Add `Math` endowment factory

### DIFF
--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -5,10 +5,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 89.88,
-      functions: 90.09,
-      lines: 87.81,
-      statements: 87.81,
+      branches: 90.11,
+      functions: 90.26,
+      lines: 88.14,
+      statements: 88.14,
     },
   },
   testEnvironment: '<rootDir>/jest.environment.js',

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -100,7 +100,6 @@ describe('Endowment utils', () => {
     it('handles multiple endowments, factory and non-factory', () => {
       const mockWallet = { foo: Symbol('bar') };
       const { endowments } = createEndowments(mockWallet as any, [
-        'Buffer',
         'console',
         'Uint8Array',
         'Math',
@@ -111,7 +110,6 @@ describe('Endowment utils', () => {
 
       expect(endowments).toMatchObject({
         wallet: mockWallet,
-        Buffer,
         console,
         Uint8Array,
         Math: expect.any(Object),
@@ -121,7 +119,6 @@ describe('Endowment utils', () => {
       });
 
       expect(endowments.wallet).toBe(mockWallet);
-      expect(endowments.Buffer).toBe(Buffer);
       expect(endowments.console).toBe(console);
       expect(endowments.Uint8Array).toBe(Uint8Array);
       expect(endowments.WebAssembly).toBe(WebAssembly);

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -29,16 +29,16 @@ describe('Endowment utils', () => {
     it('handles unattenuated endowments', () => {
       const mockWallet = { foo: Symbol('bar') };
       const { endowments } = createEndowments(mockWallet as any, [
-        'Math',
+        'Uint8Array',
         'Date',
       ]);
 
       expect(endowments).toStrictEqual({
         wallet: mockWallet,
-        Math,
+        Uint8Array,
         Date,
       });
-      expect(endowments.Math).toBe(Math);
+      expect(endowments.Uint8Array).toBe(Uint8Array);
       expect(endowments.Date).toBe(Date);
     });
 
@@ -49,11 +49,9 @@ describe('Endowment utils', () => {
       };
       Object.assign(globalThis, { mockEndowment });
       const { endowments } = createEndowments(mockWallet as any, [
-        'Math',
         'Date',
         'mockEndowment',
       ]);
-      expect(endowments.Math).toBe(Math);
       expect(endowments.Date).toBe(Date);
       expect(endowments.mockEndowment).toBeDefined();
     });
@@ -104,6 +102,7 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(mockWallet as any, [
         'Buffer',
         'console',
+        'Uint8Array',
         'Math',
         'setTimeout',
         'clearTimeout',
@@ -114,7 +113,8 @@ describe('Endowment utils', () => {
         wallet: mockWallet,
         Buffer,
         console,
-        Math,
+        Uint8Array,
+        Math: expect.any(Object),
         setTimeout: expect.any(Function),
         clearTimeout: expect.any(Function),
         WebAssembly,
@@ -123,11 +123,12 @@ describe('Endowment utils', () => {
       expect(endowments.wallet).toBe(mockWallet);
       expect(endowments.Buffer).toBe(Buffer);
       expect(endowments.console).toBe(console);
-      expect(endowments.Math).toBe(Math);
+      expect(endowments.Uint8Array).toBe(Uint8Array);
       expect(endowments.WebAssembly).toBe(WebAssembly);
 
       expect(endowments.clearTimeout).not.toBe(clearTimeout);
       expect(endowments.setTimeout).not.toBe(setTimeout);
+      expect(endowments.Math).not.toBe(Math);
     });
 
     it('throws for unknown endowments', () => {

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -5,6 +5,7 @@ import interval from './interval';
 import network from './network';
 import timeout from './timeout';
 import crypto from './crypto';
+import math from './math';
 
 type EndowmentFactoryResult = {
   /**
@@ -24,7 +25,7 @@ type EndowmentFactoryResult = {
  * the same factory function, but we only call each factory once for each snap.
  * See {@link createEndowments} for details.
  */
-const endowmentFactories = [timeout, interval, network, crypto].reduce(
+const endowmentFactories = [timeout, interval, network, crypto, math].reduce(
   (factories, builder) => {
     builder.names.forEach((name) => {
       factories.set(name, builder.factory);

--- a/packages/snaps-execution-environments/src/common/endowments/math.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.test.ts
@@ -1,0 +1,23 @@
+import { rootRealmGlobal } from '../globalObject';
+import math from './math';
+
+describe('Math endowment', () => {
+  it('has expected properties', () => {
+    expect(math).toMatchObject({
+      names: ['Math'],
+      factory: expect.any(Function),
+    });
+  });
+
+  it('returns Math from rootRealmGlobal', () => {
+    const { Math } = math.factory();
+    expect(Math.abs).toStrictEqual(rootRealmGlobal.Math.abs);
+  });
+
+  it('throws when Math.random is called', () => {
+    const { Math } = math.factory();
+    expect(() => Math.random()).toThrow(
+      '`Math.random` is not supported. Use `crypto.getRandomValues` instead.',
+    );
+  });
+});

--- a/packages/snaps-execution-environments/src/common/endowments/math.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.test.ts
@@ -27,5 +27,13 @@ describe('Math endowment', () => {
       expect(Math.random()).toStrictEqual(expect.any(Number));
       expect(randomSpy).not.toHaveBeenCalled();
     });
+
+    it('returns an number in the range [0, 1)', () => {
+      const { Math } = math.factory();
+      const value = Math.random();
+
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    });
   });
 });

--- a/packages/snaps-execution-environments/src/common/endowments/math.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.test.ts
@@ -14,10 +14,18 @@ describe('Math endowment', () => {
     expect(Math.abs).toStrictEqual(rootRealmGlobal.Math.abs);
   });
 
-  it('throws when Math.random is called', () => {
-    const { Math } = math.factory();
-    expect(() => Math.random()).toThrow(
-      '`Math.random` is not supported. Use `crypto.getRandomValues` instead.',
-    );
+  describe('random', () => {
+    it('does not return the original Math.random', () => {
+      const { Math } = math.factory();
+      expect(Math.random).not.toStrictEqual(rootRealmGlobal.Math.random);
+    });
+
+    it('returns a random number without calling the original Math.random', () => {
+      const { Math } = math.factory();
+      const randomSpy = jest.spyOn(rootRealmGlobal.Math, 'random');
+
+      expect(Math.random()).toStrictEqual(expect.any(Number));
+      expect(randomSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/snaps-execution-environments/src/common/endowments/math.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.ts
@@ -1,0 +1,43 @@
+import { rootRealmGlobal } from '../globalObject';
+
+/**
+ * Create a {@link Math} object, with the same properties as the global
+ * {@link Math} object, but with the {@link Math.random} method replaced with
+ * one that throws an error.
+ *
+ * @returns The {@link Math} object with the {@link Math.random} method
+ * replaced.
+ */
+function createMath() {
+  // `Math` does not work with `Object.keys`, `Object.entries`, etc., so we
+  // need to create a new object with the same properties.
+  const keys = Object.getOwnPropertyNames(
+    rootRealmGlobal.Math,
+  ) as (keyof typeof Math)[];
+
+  const math = keys.reduce<Math>((target, key) => {
+    if (key === 'random') {
+      return target;
+    }
+
+    return { ...target, [key]: rootRealmGlobal.Math[key] };
+  }, {} as Math);
+
+  return {
+    Math: {
+      ...math,
+      random: () => {
+        throw new Error(
+          '`Math.random` is not supported. Use `crypto.getRandomValues` instead.',
+        );
+      },
+    },
+  };
+}
+
+const endowmentModule = {
+  names: ['Math'] as const,
+  factory: createMath,
+};
+
+export default endowmentModule;

--- a/packages/snaps-execution-environments/src/common/endowments/math.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.ts
@@ -2,8 +2,7 @@ import { rootRealmGlobal } from '../globalObject';
 
 /**
  * Create a {@link Math} object, with the same properties as the global
- * {@link Math} object, but with the {@link Math.random} method replaced with
- * one that throws an error.
+ * {@link Math} object, but with the {@link Math.random} method replaced.
  *
  * @returns The {@link Math} object with the {@link Math.random} method
  * replaced.
@@ -27,9 +26,23 @@ function createMath() {
     Math: {
       ...math,
       random: () => {
-        throw new Error(
-          '`Math.random` is not supported. Use `crypto.getRandomValues` instead.',
-        );
+        // NOTE: This is not intended to be a secure replacement for the weak
+        // random number generator used by `Math.random`. It is only intended to
+        // prevent side chain attacks of `Math.random` by replacing it with an
+        // alternative implementation that is not vulnerable to the same
+        // attacks.
+        //
+        // This does not mean that this implementation is secure. It is not
+        // intended to be used in a security context, and this implementation
+        // may change at any time.
+        //
+        // To securely generate random numbers, use a cryptographically secure
+        // random number generator, such as the one provided by the Web Crypto
+        // API:
+        //
+        // - https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey
+        // - https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+        return crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
       },
     },
   };

--- a/packages/snaps-execution-environments/src/common/endowments/math.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.ts
@@ -28,7 +28,7 @@ function createMath() {
       random: () => {
         // NOTE: This is not intended to be a secure replacement for the weak
         // random number generator used by `Math.random`. It is only intended to
-        // prevent side chain attacks of `Math.random` by replacing it with an
+        // prevent side channel attacks of `Math.random` by replacing it with an
         // alternative implementation that is not vulnerable to the same
         // attacks.
         //


### PR DESCRIPTION
Closes #948.

This adds an endowment factory for `Math`, which replaces the implementation of `Math.random`.