### PR TITLE
BREAKING: Add JSON-RPC handler permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
       "prettier --write"
     ]
   },
+  "resolutions": {
+    "@metamask/controllers": "portal:/Users/morten/Development/MetaMask/controllers"
+  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
       "prettier --write"
     ]
   },
-  "resolutions": {
-    "@metamask/controllers": "portal:/Users/morten/Development/MetaMask/controllers"
-  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -7,8 +7,8 @@ module.exports = deepmerge(baseConfig, {
     global: {
       branches: 88.74,
       functions: 97.6,
-      lines: 96.74,
-      statements: 96.74,
+      lines: 97.1,
+      statements: 97.1,
     },
   },
   projects: [

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -41,6 +41,7 @@
     "@metamask/snaps-execution-environments": "^0.24.1",
     "@metamask/snaps-types": "^0.24.1",
     "@metamask/snaps-utils": "^0.24.1",
+    "@metamask/subject-metadata-controller": "^1.0.0",
     "@metamask/utils": "^3.3.1",
     "@xstate/fsm": "^2.0.0",
     "concat-stream": "^2.0.0",

--- a/packages/snaps-controllers/src/multichain/MultiChainController.test.ts
+++ b/packages/snaps-controllers/src/multichain/MultiChainController.test.ts
@@ -55,7 +55,7 @@ describe('MultiChainController', () => {
           },
         },
       });
-      expect(rootMessenger.call).toHaveBeenCalledTimes(11);
+      expect(rootMessenger.call).toHaveBeenCalledTimes(12);
 
       snapController.destroy();
       await executionService.terminateAllSnaps();
@@ -99,7 +99,7 @@ describe('MultiChainController', () => {
         MOCK_SNAP_ID,
       );
 
-      expect(rootMessenger.call).toHaveBeenCalledTimes(21);
+      expect(rootMessenger.call).toHaveBeenCalledTimes(23);
 
       snapController.destroy();
       await executionService.terminateAllSnaps();
@@ -153,7 +153,7 @@ describe('MultiChainController', () => {
         },
       });
 
-      expect(rootMessenger.call).toHaveBeenCalledTimes(9);
+      expect(rootMessenger.call).toHaveBeenCalledTimes(10);
 
       snapController.destroy();
       await executionService.terminateAllSnaps();
@@ -255,9 +255,9 @@ describe('MultiChainController', () => {
         },
       });
 
-      expect(rootMessenger.call).toHaveBeenCalledTimes(17);
+      expect(rootMessenger.call).toHaveBeenCalledTimes(19);
       expect(rootMessenger.call).toHaveBeenNthCalledWith(
-        15,
+        17,
         'ApprovalController:addRequest',
         {
           id: expect.any(String),
@@ -326,7 +326,7 @@ describe('MultiChainController', () => {
       ).rejects.toThrow(
         'No installed snaps found for any requested namespace.',
       );
-      expect(rootMessenger.call).toHaveBeenCalledTimes(9);
+      expect(rootMessenger.call).toHaveBeenCalledTimes(10);
 
       snapController.destroy();
       await executionService.terminateAllSnaps();
@@ -359,7 +359,7 @@ describe('MultiChainController', () => {
       });
 
       expect(result).toEqual(['eip155:1:foo']);
-      expect(rootMessenger.call).toHaveBeenCalledTimes(15);
+      expect(rootMessenger.call).toHaveBeenCalledTimes(17);
 
       snapController.destroy();
       await executionService.terminateAllSnaps();

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -1331,15 +1331,7 @@ describe('SnapController', () => {
       });
       const [snapController, service] = getSnapControllerWithEES(options);
 
-      const mockMessageHandler = jest.fn();
-      const spyOnMessengerCall = jest
-        .spyOn(options.messenger, 'call')
-        .mockImplementation((method, ..._args: unknown[]) => {
-          if (method === 'ExecutionService:handleRpcRequest') {
-            return mockMessageHandler as any;
-          }
-          return true;
-        });
+      const spyOnMessengerCall = jest.spyOn(options.messenger, 'call');
 
       await snapController.handleRequest({
         snapId,

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -1325,13 +1325,7 @@ describe('SnapController', () => {
       const options = getSnapControllerWithEESOptions({
         rootMessenger,
         state: {
-          snaps: {
-            [MOCK_SNAP_ID]: {
-              enabled: true,
-              id: MOCK_SNAP_ID,
-              status: SnapStatus.Running,
-            } as any,
-          },
+          snaps: getPersistedSnapsState(),
         },
       });
       const [snapController, service] = getSnapControllerWithEES(options);
@@ -1355,7 +1349,7 @@ describe('SnapController', () => {
         },
       });
 
-      expect(rootMessenger.call).toHaveBeenCalledTimes(3);
+      expect(rootMessenger.call).toHaveBeenCalledTimes(7);
       expect(rootMessenger.call).toHaveBeenCalledWith(
         'ExecutionService:handleRpcRequest',
         MOCK_SNAP_ID,

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -1353,7 +1353,7 @@ describe('SnapController', () => {
         },
       });
 
-      expect(spyOnMessengerCall).toHaveBeenCalledTimes(2);
+      expect(spyOnMessengerCall).toHaveBeenCalledTimes(3);
       expect(spyOnMessengerCall).toHaveBeenCalledWith(
         'ExecutionService:handleRpcRequest',
         snapId,

--- a/packages/snaps-controllers/src/snaps/endowments/enum.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/enum.ts
@@ -5,4 +5,5 @@ export enum SnapEndowments {
   Keyring = 'endowment:keyring',
   Cronjob = 'endowment:cronjob',
   EthereumProvider = 'endowment:ethereum-provider',
+  Rpc = 'endowment:rpc',
 }

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -1,6 +1,7 @@
 import { PermissionConstraint } from '@metamask/permission-controller';
+import { HandlerType } from '@metamask/snaps-utils';
 import { Json } from '@metamask/utils';
-import { HandlerType } from '@metamask/snap-utils';
+
 import {
   cronjobCaveatSpecifications,
   cronjobEndowmentBuilder,
@@ -15,15 +16,15 @@ import {
 import { longRunningEndowmentBuilder } from './long-running';
 import { networkAccessEndowmentBuilder } from './network-access';
 import {
-  getTransactionInsightCaveatMapper,
-  transactionInsightCaveatSpecifications,
-  transactionInsightEndowmentBuilder,
-} from './transaction-insight';
-import {
   getRpcCaveatMapper,
   rpcCaveatSpecifications,
   rpcEndowmentBuilder,
 } from './rpc';
+import {
+  getTransactionInsightCaveatMapper,
+  transactionInsightCaveatSpecifications,
+  transactionInsightEndowmentBuilder,
+} from './transaction-insight';
 
 export const endowmentPermissionBuilders = {
   [networkAccessEndowmentBuilder.targetKey]: networkAccessEndowmentBuilder,

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -1,6 +1,6 @@
 import { PermissionConstraint } from '@metamask/permission-controller';
 import { Json } from '@metamask/utils';
-
+import { HandlerType } from '@metamask/snap-utils';
 import {
   cronjobCaveatSpecifications,
   cronjobEndowmentBuilder,
@@ -53,6 +53,13 @@ export const endowmentCaveatMappers: Record<
   [transactionInsightEndowmentBuilder.targetKey]:
     getTransactionInsightCaveatMapper,
   [rpcEndowmentBuilder.targetKey]: getRpcCaveatMapper,
+};
+
+export const handlerEndowments = {
+  [HandlerType.OnRpcRequest]: rpcEndowmentBuilder.targetKey,
+  [HandlerType.SnapKeyring]: keyringEndowmentBuilder.targetKey,
+  [HandlerType.OnTransaction]: transactionInsightEndowmentBuilder.targetKey,
+  [HandlerType.OnCronjob]: cronjobEndowmentBuilder.targetKey,
 };
 
 export * from './enum';

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -56,7 +56,7 @@ export const endowmentCaveatMappers: Record<
   [rpcEndowmentBuilder.targetKey]: getRpcCaveatMapper,
 };
 
-export const handlerEndowments = {
+export const handlerEndowments: Record<HandlerType, string> = {
   [HandlerType.OnRpcRequest]: rpcEndowmentBuilder.targetKey,
   [HandlerType.SnapKeyring]: keyringEndowmentBuilder.targetKey,
   [HandlerType.OnTransaction]: transactionInsightEndowmentBuilder.targetKey,

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -19,6 +19,11 @@ import {
   transactionInsightCaveatSpecifications,
   transactionInsightEndowmentBuilder,
 } from './transaction-insight';
+import {
+  getRpcCaveatMapper,
+  rpcCaveatSpecifications,
+  rpcEndowmentBuilder,
+} from './rpc';
 
 export const endowmentPermissionBuilders = {
   [networkAccessEndowmentBuilder.targetKey]: networkAccessEndowmentBuilder,
@@ -29,12 +34,14 @@ export const endowmentPermissionBuilders = {
   [cronjobEndowmentBuilder.targetKey]: cronjobEndowmentBuilder,
   [ethereumProviderEndowmentBuilder.targetKey]:
     ethereumProviderEndowmentBuilder,
+  [rpcEndowmentBuilder.targetKey]: rpcEndowmentBuilder,
 } as const;
 
 export const endowmentCaveatSpecifications = {
   ...keyringCaveatSpecifications,
   ...cronjobCaveatSpecifications,
   ...transactionInsightCaveatSpecifications,
+  ...rpcCaveatSpecifications,
 };
 
 export const endowmentCaveatMappers: Record<
@@ -45,6 +52,7 @@ export const endowmentCaveatMappers: Record<
   [cronjobEndowmentBuilder.targetKey]: getCronjobCaveatMapper,
   [transactionInsightEndowmentBuilder.targetKey]:
     getTransactionInsightCaveatMapper,
+  [rpcEndowmentBuilder.targetKey]: getRpcCaveatMapper,
 };
 
 export * from './enum';

--- a/packages/snaps-controllers/src/snaps/endowments/rpc.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/rpc.test.ts
@@ -1,0 +1,129 @@
+import { PermissionType } from '@metamask/permission-controller';
+import { SnapCaveatType } from '@metamask/snaps-utils';
+
+import { SnapEndowments } from '.';
+import {
+  getRpcCaveatMapper,
+  getRpcCaveatOrigins,
+  rpcCaveatSpecifications,
+  rpcEndowmentBuilder,
+} from './rpc';
+
+describe('endowment:rpc', () => {
+  it('builds the expected permission specification', () => {
+    const specification = rpcEndowmentBuilder.specificationBuilder({});
+    expect(specification).toStrictEqual({
+      permissionType: PermissionType.Endowment,
+      targetKey: SnapEndowments.Rpc,
+      endowmentGetter: expect.any(Function),
+      allowedCaveats: [SnapCaveatType.RpcOrigin],
+      validator: expect.any(Function),
+    });
+
+    expect(specification.endowmentGetter()).toBeUndefined();
+  });
+
+  describe('validator', () => {
+    it('throws if the caveat is not a single "transactionOrigin"', () => {
+      const specification = rpcEndowmentBuilder.specificationBuilder({});
+
+      expect(() =>
+        specification.validator({
+          // @ts-expect-error Missing other required permission types.
+          caveats: undefined,
+        }),
+      ).toThrow('Expected a single "rpcOrigin" caveat.');
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [{ type: 'foo', value: 'bar' }],
+        }),
+      ).toThrow('Expected a single "rpcOrigin" caveat.');
+
+      expect(() =>
+        // @ts-expect-error Missing other required permission types.
+        specification.validator({
+          caveats: [
+            { type: 'rpcOrigin', value: { snaps: true, dapps: false } },
+            { type: 'rpcOrigin', value: { snaps: true, dapps: false } },
+          ],
+        }),
+      ).toThrow('Expected a single "rpcOrigin" caveat.');
+    });
+  });
+});
+
+describe('getRpcCaveatMapper', () => {
+  it('maps a value to a caveat', () => {
+    expect(getRpcCaveatMapper({ snaps: true, dapps: false })).toStrictEqual({
+      caveats: [
+        {
+          type: SnapCaveatType.RpcOrigin,
+          value: { snaps: true, dapps: false },
+        },
+      ],
+    });
+  });
+});
+
+describe('getRpcCaveatOrigins', () => {
+  it('returns the origins from the caveat', () => {
+    expect(
+      // @ts-expect-error Missing other required permission types.
+      getRpcCaveatOrigins({
+        caveats: [
+          {
+            type: SnapCaveatType.RpcOrigin,
+            value: { snaps: true, dapps: false },
+          },
+        ],
+      }),
+    ).toStrictEqual({ snaps: true, dapps: false });
+  });
+
+  it('throws if the caveat is not a single "rpcOrigin"', () => {
+    expect(() =>
+      // @ts-expect-error Missing other required permission types.
+      getRpcCaveatOrigins({
+        caveats: [{ type: 'foo', value: 'bar' }],
+      }),
+    ).toThrow('Assertion failed.');
+
+    expect(() =>
+      // @ts-expect-error Missing other required permission types.
+      getRpcCaveatOrigins({
+        caveats: [
+          { type: 'rpcOrigin', value: { snaps: true, dapps: false } },
+          { type: 'rpcOrigin', value: { snaps: true, dapps: false } },
+        ],
+      }),
+    ).toThrow('Assertion failed.');
+  });
+});
+
+describe('rpcCaveatSpecifications', () => {
+  describe('validator', () => {
+    it('throws if the caveat values are invalid', () => {
+      expect(() =>
+        rpcCaveatSpecifications[SnapCaveatType.RpcOrigin].validator?.(
+          // @ts-expect-error Missing value type.
+          {
+            type: SnapCaveatType.TransactionOrigin,
+          },
+        ),
+      ).toThrow('Invalid JSON-RPC origins: Expected a plain object.');
+
+      expect(() =>
+        rpcCaveatSpecifications[SnapCaveatType.RpcOrigin].validator?.({
+          type: SnapCaveatType.TransactionOrigin,
+          value: {
+            foo: 'bar',
+          },
+        }),
+      ).toThrow(
+        'Invalid JSON-RPC origins: At path: foo -- Expected a value of type `never`, but received: `"bar"`.',
+      );
+    });
+  });
+});

--- a/packages/snaps-controllers/src/snaps/endowments/rpc.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/rpc.test.ts
@@ -24,7 +24,7 @@ describe('endowment:rpc', () => {
   });
 
   describe('validator', () => {
-    it('throws if the caveat is not a single "transactionOrigin"', () => {
+    it('throws if the caveat is not a single "rpcOrigin"', () => {
       const specification = rpcEndowmentBuilder.specificationBuilder({});
 
       expect(() =>

--- a/packages/snaps-controllers/src/snaps/endowments/rpc.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/rpc.ts
@@ -1,0 +1,148 @@
+import {
+  assertIsRpcOrigins,
+  RpcOrigins,
+  SnapCaveatType,
+} from '@metamask/snap-utils';
+import {
+  Caveat,
+  CaveatSpecificationConstraint,
+  EndowmentGetterParams,
+  PermissionConstraint,
+  PermissionSpecificationBuilder,
+  PermissionType,
+  PermissionValidatorConstraint,
+  ValidPermissionSpecification,
+} from '@metamask/controllers';
+import {
+  hasProperty,
+  isPlainObject,
+  Json,
+  NonEmptyArray,
+  assert,
+} from '@metamask/utils';
+import { ethErrors } from 'eth-rpc-errors';
+import { SnapEndowments } from './enum';
+
+const targetKey = SnapEndowments.Rpc;
+
+type RpcSpecification = ValidPermissionSpecification<{
+  permissionType: PermissionType.Endowment;
+  targetKey: typeof targetKey;
+  endowmentGetter: (_options?: any) => undefined;
+  allowedCaveats: Readonly<NonEmptyArray<string>> | null;
+  validator: PermissionValidatorConstraint;
+}>;
+
+type RpcSpecificationBuilderOptions = {
+  // Empty for now.
+};
+
+/**
+ * The specification builder for the JSON-RPC endowment permission.
+ *
+ * @returns The specification for the JSON-RPC endowment permission.
+ */
+const specificationBuilder: PermissionSpecificationBuilder<
+  PermissionType.Endowment,
+  RpcSpecificationBuilderOptions,
+  RpcSpecification
+> = (): RpcSpecification => {
+  return {
+    permissionType: PermissionType.Endowment,
+    targetKey,
+    allowedCaveats: [SnapCaveatType.RpcOrigin],
+    endowmentGetter: (_getterOptions?: EndowmentGetterParams) => undefined,
+    validator: ({ caveats }) => {
+      if (
+        caveats?.length !== 1 ||
+        caveats[0].type !== SnapCaveatType.RpcOrigin
+      ) {
+        throw ethErrors.rpc.invalidParams({
+          message: `Expected a single "${SnapCaveatType.RpcOrigin}" caveat.`,
+        });
+      }
+    },
+  };
+};
+
+export const rpcEndowmentBuilder = Object.freeze({
+  targetKey,
+  specificationBuilder,
+} as const);
+
+/**
+ * Validate the value of a caveat. This does not validate the type of the
+ * caveat itself, only the value of the caveat.
+ *
+ * @param caveat - The caveat to validate.
+ * @throws If the caveat value is invalid.
+ */
+function validateCaveatOrigins(caveat: Caveat<string, any>) {
+  if (!hasProperty(caveat, 'value') || !isPlainObject(caveat.value)) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Expected a plain object.',
+    });
+  }
+
+  const { value } = caveat;
+
+  if (!hasProperty(value, 'origins') || !isPlainObject(value)) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Expected a plain object.',
+    });
+  }
+
+  assertIsRpcOrigins(value.origins, ethErrors.rpc.invalidParams);
+}
+
+/**
+ * Map a raw value from the `initialPermissions` to a caveat specification.
+ * Note that this function does not do any validation, that's handled by the
+ * PermissionsController when the permission is requested.
+ *
+ * @param value - The raw value from the `initialPermissions`.
+ * @returns The caveat specification.
+ */
+export function getRpcCaveatMapper(
+  value: Json,
+): Pick<PermissionConstraint, 'caveats'> {
+  return {
+    caveats: [
+      {
+        type: SnapCaveatType.RpcOrigin,
+        value,
+      },
+    ],
+  };
+}
+
+/**
+ * Getter function to get the {@link RpcOrigins} caveat value from a permission.
+ *
+ * @param permission - The permission to get the caveat value from.
+ * @returns The caveat value.
+ * @throws If the permission does not have a valid {@link RpcOrigins} caveat.
+ */
+export function getRpcCaveatOrigins(
+  permission?: PermissionConstraint,
+): RpcOrigins | null {
+  if (!permission?.caveats) {
+    return null;
+  }
+
+  assert(permission.caveats.length === 1);
+  assert(permission.caveats[0].type === SnapCaveatType.RpcOrigin);
+
+  const caveat = permission.caveats[0] as Caveat<string, RpcOrigins>;
+  return caveat.value;
+}
+
+export const rpcCaveatSpecifications: Record<
+  SnapCaveatType.RpcOrigin,
+  CaveatSpecificationConstraint
+> = {
+  [SnapCaveatType.RpcOrigin]: Object.freeze({
+    type: SnapCaveatType.RpcOrigin,
+    validator: (caveat: Caveat<string, any>) => validateCaveatOrigins(caveat),
+  }),
+};

--- a/packages/snaps-controllers/src/snaps/endowments/rpc.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/rpc.ts
@@ -1,9 +1,4 @@
 import {
-  assertIsRpcOrigins,
-  RpcOrigins,
-  SnapCaveatType,
-} from '@metamask/snap-utils';
-import {
   Caveat,
   CaveatSpecificationConstraint,
   EndowmentGetterParams,
@@ -12,7 +7,12 @@ import {
   PermissionType,
   PermissionValidatorConstraint,
   ValidPermissionSpecification,
-} from '@metamask/controllers';
+} from '@metamask/permission-controller';
+import {
+  assertIsRpcOrigins,
+  RpcOrigins,
+  SnapCaveatType,
+} from '@metamask/snaps-utils';
 import {
   hasProperty,
   isPlainObject,
@@ -21,6 +21,7 @@ import {
   assert,
 } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
+
 import { SnapEndowments } from './enum';
 
 const targetKey = SnapEndowments.Rpc;

--- a/packages/snaps-controllers/src/snaps/endowments/rpc.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/rpc.ts
@@ -81,19 +81,12 @@ export const rpcEndowmentBuilder = Object.freeze({
 function validateCaveatOrigins(caveat: Caveat<string, any>) {
   if (!hasProperty(caveat, 'value') || !isPlainObject(caveat.value)) {
     throw ethErrors.rpc.invalidParams({
-      message: 'Expected a plain object.',
+      message: 'Invalid JSON-RPC origins: Expected a plain object.',
     });
   }
 
   const { value } = caveat;
-
-  if (!hasProperty(value, 'origins') || !isPlainObject(value)) {
-    throw ethErrors.rpc.invalidParams({
-      message: 'Expected a plain object.',
-    });
-  }
-
-  assertIsRpcOrigins(value.origins, ethErrors.rpc.invalidParams);
+  assertIsRpcOrigins(value, ethErrors.rpc.invalidParams);
 }
 
 /**
@@ -127,10 +120,7 @@ export function getRpcCaveatMapper(
 export function getRpcCaveatOrigins(
   permission?: PermissionConstraint,
 ): RpcOrigins | null {
-  if (!permission?.caveats) {
-    return null;
-  }
-
+  assert(permission?.caveats);
   assert(permission.caveats.length === 1);
   assert(permission.caveats[0].type === SnapCaveatType.RpcOrigin);
 

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -8,6 +8,7 @@ import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   getPersistedSnapObject,
   getTruncatedSnap,
+  MOCK_ORIGIN,
   MOCK_SNAP_ID,
 } from '@metamask/snaps-utils/test-utils';
 import {
@@ -75,9 +76,17 @@ export class MockControllerMessenger<
   }
 }
 
-export const MOCK_SUBJECT_METADATA: SubjectMetadata = {
+export const MOCK_SNAP_SUBJECT_METADATA: SubjectMetadata = {
   origin: MOCK_SNAP_ID,
   subjectType: SubjectType.Snap,
+  name: 'foo',
+  extensionId: 'bar',
+  iconUrl: 'baz',
+};
+
+export const MOCK_DAPP_SUBJECT_METADATA: SubjectMetadata = {
+  origin: MOCK_ORIGIN,
+  subjectType: SubjectType.Website,
   name: 'foo',
   extensionId: 'bar',
   iconUrl: 'baz',
@@ -86,6 +95,16 @@ export const MOCK_SUBJECT_METADATA: SubjectMetadata = {
 export const MOCK_RPC_ORIGINS_PERMISSION: PermissionConstraint = {
   caveats: [
     { type: SnapCaveatType.RpcOrigin, value: { snaps: true, dapps: false } },
+  ],
+  date: 1664187844588,
+  id: 'izn0WGUO8cvq_jqvLQuQP',
+  invoker: MOCK_SNAP_ID,
+  parentCapability: SnapEndowments.Rpc,
+};
+
+export const MOCK_DAPPS_RPC_ORIGINS_PERMISSION: PermissionConstraint = {
+  caveats: [
+    { type: SnapCaveatType.RpcOrigin, value: { snaps: false, dapps: true } },
   ],
   date: 1664187844588,
   id: 'izn0WGUO8cvq_jqvLQuQP',
@@ -153,7 +172,7 @@ export const getControllerMessenger = () => {
 
   messenger.registerActionHandler(
     'SubjectMetadataController:getSubjectMetadata',
-    () => MOCK_SUBJECT_METADATA,
+    () => MOCK_SNAP_SUBJECT_METADATA,
   );
 
   messenger.registerActionHandler('ExecutionService:executeSnap', asyncNoOp);

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -130,6 +130,11 @@ export const getControllerMessenger = () => {
   );
 
   messenger.registerActionHandler(
+    'PermissionController:revokePermissions',
+    () => ({}),
+  );
+
+  messenger.registerActionHandler(
     'PermissionController:revokeAllPermissions',
     () => ({}),
   );
@@ -141,7 +146,14 @@ export const getControllerMessenger = () => {
 
   messenger.registerActionHandler(
     'PermissionController:getPermissions',
-    () => ({}),
+    () => ({
+      [SnapEndowments.Rpc]: MOCK_RPC_ORIGINS_PERMISSION,
+    }),
+  );
+
+  messenger.registerActionHandler(
+    'SubjectMetadataController:getSubjectMetadata',
+    () => MOCK_SUBJECT_METADATA,
   );
 
   messenger.registerActionHandler('ExecutionService:executeSnap', asyncNoOp);
@@ -186,6 +198,7 @@ export const getSnapControllerMessenger = (
       'PermissionController:hasPermissions',
       'PermissionController:getPermissions',
       'PermissionController:grantPermissions',
+      'PermissionController:revokePermissions',
       'PermissionController:revokeAllPermissions',
       'PermissionController:revokePermissionForAllSubjects',
       'SnapController:get',

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -13,6 +13,7 @@ import {
   AllowedActions,
   AllowedEvents,
   CheckSnapBlockListArg,
+  handlerEndowments,
   PersistedSnapControllerState,
   SnapController,
   SnapControllerActions,

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -3,17 +3,23 @@ import {
   ControllerMessenger,
   EventConstraint,
 } from '@metamask/base-controller';
+import { PermissionConstraint } from '@metamask/permission-controller';
+import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   getPersistedSnapObject,
   getTruncatedSnap,
+  MOCK_SNAP_ID,
 } from '@metamask/snaps-utils/test-utils';
+import {
+  SubjectMetadata,
+  SubjectType,
+} from '@metamask/subject-metadata-controller';
 
 import { CronjobControllerActions, CronjobControllerEvents } from '../cronjob';
 import {
   AllowedActions,
   AllowedEvents,
   CheckSnapBlockListArg,
-  handlerEndowments,
   PersistedSnapControllerState,
   SnapController,
   SnapControllerActions,
@@ -68,6 +74,24 @@ export class MockControllerMessenger<
     super.registerActionHandler(actionType, handler);
   }
 }
+
+export const MOCK_SUBJECT_METADATA: SubjectMetadata = {
+  origin: MOCK_SNAP_ID,
+  subjectType: SubjectType.Snap,
+  name: 'foo',
+  extensionId: 'bar',
+  iconUrl: 'baz',
+};
+
+export const MOCK_RPC_ORIGINS_PERMISSION: PermissionConstraint = {
+  caveats: [
+    { type: SnapCaveatType.RpcOrigin, value: { snaps: true, dapps: false } },
+  ],
+  date: 1664187844588,
+  id: 'izn0WGUO8cvq_jqvLQuQP',
+  invoker: MOCK_SNAP_ID,
+  parentCapability: SnapEndowments.Rpc,
+};
 
 export const getControllerMessenger = () => {
   const messenger = new MockControllerMessenger<
@@ -180,6 +204,7 @@ export const getSnapControllerMessenger = (
       'SnapController:removeSnapError',
       'SnapController:incrementActiveReferences',
       'SnapController:decrementActiveReferences',
+      'SubjectMetadataController:getSubjectMetadata',
     ],
   });
 

--- a/packages/snaps-utils/src/caveats.ts
+++ b/packages/snaps-utils/src/caveats.ts
@@ -23,4 +23,9 @@ export enum SnapCaveatType {
    * Caveat specifying access to the transaction origin, used by `endowment:transaction-insight`.
    */
   TransactionOrigin = 'transactionOrigin',
+
+  /**
+   * The origins that a Snap can receive JSON-RPC messages from.
+   */
+  RpcOrigin = 'rpcOrigin',
 }

--- a/packages/snaps-utils/src/json-rpc.test.ts
+++ b/packages/snaps-utils/src/json-rpc.test.ts
@@ -1,4 +1,39 @@
-import { assertIsJsonRpcSuccess } from './json-rpc';
+import { assertIsJsonRpcSuccess, assertIsRpcOrigins } from './json-rpc';
+
+describe('assertIsRpcOrigins', () => {
+  it.each([{ dapps: true }, { snaps: true }, { dapps: true, snaps: true }])(
+    'does not throw for %p',
+    (origins) => {
+      expect(() => assertIsRpcOrigins(origins)).not.toThrow();
+    },
+  );
+
+  it.each([
+    true,
+    false,
+    null,
+    undefined,
+    0,
+    1,
+    '',
+    'foo',
+    [],
+    ['foo'],
+    {},
+    { foo: true },
+    { dapps: false, snaps: false },
+  ])('throws for %p', (origins) => {
+    expect(() => assertIsRpcOrigins(origins)).toThrow(
+      'Invalid JSON-RPC origins:',
+    );
+  });
+
+  it('throws if neither value is true', () => {
+    expect(() => assertIsRpcOrigins({ dapps: false, snaps: false })).toThrow(
+      'Invalid JSON-RPC origins: Must specify at least one JSON-RPC origin.',
+    );
+  });
+});
 
 describe('assertIsJsonRpcSuccess', () => {
   it.each([

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -3,9 +3,10 @@ import {
   isJsonRpcSuccess,
   Json,
   JsonRpcSuccess,
+  AssertionErrorConstructor,
+  assertStruct,
 } from '@metamask/utils';
 import { boolean, Infer, object, optional, refine } from 'superstruct';
-import { AssertionErrorConstructor, assertStruct } from './assert';
 
 export const RpcOriginsStruct = refine(
   object({

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -13,7 +13,7 @@ export const RpcOriginsStruct = refine(
     dapps: optional(boolean()),
     snaps: optional(boolean()),
   }),
-  'RPC endpoints',
+  'RPC origins',
   (value) => {
     if (!Object.values(value).some(Boolean)) {
       throw new Error('Must specify at least one JSON-RPC origin');

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -35,6 +35,7 @@ export type RpcOrigins = Infer<typeof RpcOriginsStruct>;
  */
 export function assertIsRpcOrigins(
   value: unknown,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   ErrorWrapper?: AssertionErrorConstructor,
 ): asserts value is RpcOrigins {
   assertStruct(

--- a/packages/snaps-utils/src/json-rpc.ts
+++ b/packages/snaps-utils/src/json-rpc.ts
@@ -4,6 +4,45 @@ import {
   Json,
   JsonRpcSuccess,
 } from '@metamask/utils';
+import { boolean, Infer, object, optional, refine } from 'superstruct';
+import { AssertionErrorConstructor, assertStruct } from './assert';
+
+export const RpcOriginsStruct = refine(
+  object({
+    dapps: optional(boolean()),
+    snaps: optional(boolean()),
+  }),
+  'RPC endpoints',
+  (value) => {
+    if (!Object.values(value).some(Boolean)) {
+      throw new Error('Must specify at least one JSON-RPC origin');
+    }
+
+    return true;
+  },
+);
+
+export type RpcOrigins = Infer<typeof RpcOriginsStruct>;
+
+/**
+ * Asserts that the given value is a valid {@link RpcOrigins} object.
+ *
+ * @param value - The value to assert.
+ * @param ErrorWrapper - An optional error wrapper to use. Defaults to
+ * {@link AssertionError}.
+ * @throws If the value is not a valid {@link RpcOrigins} object.
+ */
+export function assertIsRpcOrigins(
+  value: unknown,
+  ErrorWrapper?: AssertionErrorConstructor,
+): asserts value is RpcOrigins {
+  assertStruct(
+    value,
+    RpcOriginsStruct,
+    'Invalid JSON-RPC origins',
+    ErrorWrapper,
+  );
+}
 
 /**
  * Assert that the given value is a successful JSON-RPC response. If the value

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -19,6 +19,7 @@ import {
 } from 'superstruct';
 
 import { CronjobSpecificationArrayStruct } from '../cronjob';
+import { RpcOriginsStruct } from '../json-rpc';
 import { NamespacesStruct } from '../namespace';
 import { NameStruct, NpmSnapFileNames } from '../types';
 import { VersionStruct } from '../versions';
@@ -156,6 +157,7 @@ export const PermissionsStruct = type({
   'endowment:cronjob': optional(
     object({ jobs: CronjobSpecificationArrayStruct }),
   ),
+  'endowment:rpc': optional(RpcOriginsStruct),
   snap_confirm: optional(object({})),
   snap_manageState: optional(object({})),
   snap_notify: optional(object({})),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,7 +2488,7 @@ __metadata:
   linkType: hard
 
 "@metamask/controller-utils@npm:~1.0.0":
-  version: 0.0.0-use.local
+  version: 1.0.0
   resolution: "@metamask/controller-utils@npm:1.0.0"
   dependencies:
     eth-ens-namehash: ^2.0.8
@@ -2499,7 +2499,7 @@ __metadata:
     isomorphic-fetch: ^3.0.0
   checksum: 76e0629ba97b0b704f2f08e346fc27cf404630a64088504dbbad3d4124afe7a6c9bf3627e999ab9a1f1c183a444978ecc288b6df3ab30b47b5398a1da848ebbf
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@metamask/eslint-config-jest@npm:^11.0.0":
   version: 11.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,7 +2488,7 @@ __metadata:
   linkType: hard
 
 "@metamask/controller-utils@npm:~1.0.0":
-  version: 1.0.0
+  version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@npm:1.0.0"
   dependencies:
     eth-ens-namehash: ^2.0.8
@@ -2499,7 +2499,7 @@ __metadata:
     isomorphic-fetch: ^3.0.0
   checksum: 76e0629ba97b0b704f2f08e346fc27cf404630a64088504dbbad3d4124afe7a6c9bf3627e999ab9a1f1c183a444978ecc288b6df3ab30b47b5398a1da848ebbf
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@metamask/eslint-config-jest@npm:^11.0.0":
   version: 11.0.0
@@ -2612,7 +2612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/permission-controller@npm:^1.0.0":
+"@metamask/permission-controller@npm:^1.0.0, @metamask/permission-controller@npm:~1.0.0":
   version: 1.0.0
   resolution: "@metamask/permission-controller@npm:1.0.0"
   dependencies:
@@ -2830,6 +2830,7 @@ __metadata:
     "@metamask/snaps-execution-environments": ^0.24.1
     "@metamask/snaps-types": ^0.24.1
     "@metamask/snaps-utils": ^0.24.1
+    "@metamask/subject-metadata-controller": ^1.0.0
     "@metamask/template-snap": ^0.7.0
     "@metamask/utils": ^3.3.1
     "@peculiar/webcrypto": ^1.3.3
@@ -3112,6 +3113,18 @@ __metadata:
     webpack-sources: ^3.2.3
   languageName: unknown
   linkType: soft
+
+"@metamask/subject-metadata-controller@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@metamask/subject-metadata-controller@npm:1.0.0"
+  dependencies:
+    "@metamask/base-controller": ~1.0.0
+    "@metamask/permission-controller": ~1.0.0
+    "@metamask/types": ^1.1.0
+    immer: ^9.0.6
+  checksum: 5a9ce9c5a99f4f35ea721b7a3da284e785da4f29f063ef7aa8505e56ba59616377eab7c4628899abc5d5f28a26b642a525728b8775931f705e075929577df593
+  languageName: node
+  linkType: hard
 
 "@metamask/template-snap@npm:^0.7.0":
   version: 0.7.0


### PR DESCRIPTION
This adds a new permission `endowment:rpc`, which Snaps need in order to use the `onRpcRequest` handler. It takes an object in order to specify if the Snap can receive JSON-RPC requests from other Snaps, Dapps, or both.

```ts
{
  initialPermissions: {
    'endowment:rpc': {
      snaps: true,
      dapps: false, // Default value
    }
  }
}
```

Closes #855.