### PR TITLE
BREAKING: Bump `@metamask/key-tree` to 6.0.0

### DIFF
--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@metamask/controllers": "^32.0.2",
-    "@metamask/key-tree": "^5.0.2",
+    "@metamask/key-tree": "^6.0.0",
     "@metamask/snap-utils": "^0.22.3",
     "@metamask/types": "^1.1.0",
     "@metamask/utils": "^3.3.0",

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -295,14 +295,14 @@ describe('getBip32EntropyImplementation', () => {
         }),
       ).toMatchInlineSnapshot(`
         {
-          "chainCode": "c4d424c253ca0eab92de6d8c819a37889e15a11bbf1cb6a48ffca2faef1f4d4d",
+          "chainCode": "0xc4d424c253ca0eab92de6d8c819a37889e15a11bbf1cb6a48ffca2faef1f4d4d",
           "curve": "secp256k1",
           "depth": 2,
           "index": 2147483708,
           "masterFingerprint": 1404659567,
           "parentFingerprint": 1829122711,
-          "privateKey": "ca8d3571710e2b08628926f0ec14983aded0fd039518c59522c004e0e7eb4f5a",
-          "publicKey": "041e31e8432aab932fe18b5f9798b7252394ff0b943920b40c50a79301062df5ece2b884a45c456241e35000137e6dbd92c9119ccd5f46cc92ba9568ca661b994b",
+          "privateKey": "0xca8d3571710e2b08628926f0ec14983aded0fd039518c59522c004e0e7eb4f5a",
+          "publicKey": "0x041e31e8432aab932fe18b5f9798b7252394ff0b943920b40c50a79301062df5ece2b884a45c456241e35000137e6dbd92c9119ccd5f46cc92ba9568ca661b994b",
         }
       `);
     });
@@ -323,14 +323,14 @@ describe('getBip32EntropyImplementation', () => {
         }),
       ).toMatchInlineSnapshot(`
         {
-          "chainCode": "6265b647bc0e70480f29856be102fe866ea6a8ec9e2926c198c2e9c4cd268a43",
+          "chainCode": "0x6265b647bc0e70480f29856be102fe866ea6a8ec9e2926c198c2e9c4cd268a43",
           "curve": "secp256k1",
           "depth": 5,
           "index": 1,
           "masterFingerprint": 1404659567,
           "parentFingerprint": 942995271,
-          "privateKey": "4adb19cafa5fdf467215fa30b56a50facac2dee40a7015063c6a7a0f1f4e2576",
-          "publicKey": "04b21938e18aec1e2e7478988ccae5b556597d771c8e46ac2c8ea2a4a1a80619679230a109cd30e8af15856b15799e38991e45e55f406a8a24d5605ba0757da53c",
+          "privateKey": "0x4adb19cafa5fdf467215fa30b56a50facac2dee40a7015063c6a7a0f1f4e2576",
+          "publicKey": "0x04b21938e18aec1e2e7478988ccae5b556597d771c8e46ac2c8ea2a4a1a80619679230a109cd30e8af15856b15799e38991e45e55f406a8a24d5605ba0757da53c",
         }
       `);
     });

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -130,7 +130,7 @@ describe('getBip32PublicKeyImplementation', () => {
           },
         }),
       ).toMatchInlineSnapshot(
-        `"04b21938e18aec1e2e7478988ccae5b556597d771c8e46ac2c8ea2a4a1a80619679230a109cd30e8af15856b15799e38991e45e55f406a8a24d5605ba0757da53c"`,
+        `"0x04b21938e18aec1e2e7478988ccae5b556597d771c8e46ac2c8ea2a4a1a80619679230a109cd30e8af15856b15799e38991e45e55f406a8a24d5605ba0757da53c"`,
       );
     });
 
@@ -153,7 +153,7 @@ describe('getBip32PublicKeyImplementation', () => {
           },
         }),
       ).toMatchInlineSnapshot(
-        `"03a797bad3e493c256dc3064a8dd9f214f246e3ef954c767d8c6548040eee645b7"`,
+        `"0x03a797bad3e493c256dc3064a8dd9f214f246e3ef954c767d8c6548040eee645b7"`,
       );
     });
   });

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -160,7 +160,7 @@ export function getBip32PublicKeyImplementation({
     });
 
     if (params.compressed) {
-      return node.compressedPublicKeyBuffer.toString('hex');
+      return node.compressedPublicKey;
     }
 
     return node.publicKey;

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -230,15 +230,15 @@ describe('getBip44EntropyImplementation', () => {
         }),
       ).toMatchInlineSnapshot(`
         {
-          "chainCode": "50ccfa58a885b48b5eed09486b3948e8454f34856fb81da5d7b8519d7997abd1",
+          "chainCode": "0x50ccfa58a885b48b5eed09486b3948e8454f34856fb81da5d7b8519d7997abd1",
           "coin_type": 1,
           "depth": 2,
           "index": 2147483649,
           "masterFingerprint": 1404659567,
           "parentFingerprint": 1829122711,
           "path": "m / bip32:44' / bip32:1'",
-          "privateKey": "c73cedb996e7294f032766853a8b7ba11ab4ce9755fc052f2f7b9000044c99af",
-          "publicKey": "048e129862c1de5ca86468add43b001d32fd34b8113de716ecd63fa355b7f1165f0e76f5dc6095100f9fdaa76ddf28aa3f21406ac5fda7c71ffbedb45634fe2ceb",
+          "privateKey": "0xc73cedb996e7294f032766853a8b7ba11ab4ce9755fc052f2f7b9000044c99af",
+          "publicKey": "0x048e129862c1de5ca86468add43b001d32fd34b8113de716ecd63fa355b7f1165f0e76f5dc6095100f9fdaa76ddf28aa3f21406ac5fda7c71ffbedb45634fe2ceb",
         }
       `);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2799,16 +2799,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/key-tree@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@metamask/key-tree@npm:5.0.2"
+"@metamask/key-tree@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/key-tree@npm:6.0.0"
   dependencies:
+    "@metamask/utils": ^3.3.0
     "@noble/ed25519": ^1.6.0
     "@noble/hashes": ^1.0.0
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
     "@scure/bip39": ^1.0.0
-  checksum: 5df428ca2b71674d71ea181bf92142adc0790a9fca41e4c295fe5357abde3f025a883e559e045f0125953850b84d6c66eb97aa5c50cec6dcb41f883f806febf3
+  checksum: 124e1c8195c7a50b8f1fbdc1762c79e024efa3feee921142c64c547963e94ca746f508d41286b57ea0decafa0923ec835c59da3ec4be88b2cb44c4b844a241ac
   languageName: node
   linkType: hard
 
@@ -2947,7 +2948,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^9.0.0
     "@metamask/eslint-config-nodejs": ^9.0.0
     "@metamask/eslint-config-typescript": ^9.0.1
-    "@metamask/key-tree": ^5.0.2
+    "@metamask/key-tree": ^6.0.0
     "@metamask/snap-utils": ^0.22.3
     "@metamask/types": ^1.1.0
     "@metamask/utils": ^3.3.0


### PR DESCRIPTION
`@metmask/key-tree@6.0.0` has a few improvements:

- All hexadecimal values always start with `0x`.
- The package does not use `Buffer` anymore.

This is breaking when working with `[...]Buffer` fields, as these have been renamed to `[...]Bytes`, and are now `Uint8Array`s rather than `Buffer`s. It does not affect typical usage using `getBIP44AddressKeyDeriver`.