### PR TITLE
BREAKING: Refactor RPC method params and add tests

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -5,10 +5,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 82.85,
-      functions: 80.85,
-      lines: 59.77,
-      statements: 59.77,
+      branches: 88.63,
+      functions: 86.53,
+      lines: 79.23,
+      statements: 79.23,
     },
   },
   testTimeout: 2500,

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -7,8 +7,8 @@ module.exports = deepmerge(baseConfig, {
     global: {
       branches: 87.01,
       functions: 87.03,
-      lines: 79,
-      statements: 79,
+      lines: 78.96,
+      statements: 78.96,
     },
   },
   testTimeout: 2500,

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -5,10 +5,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 88.63,
-      functions: 86.53,
-      lines: 79.23,
-      statements: 79.23,
+      branches: 87.01,
+      functions: 87.03,
+      lines: 79,
+      statements: 79,
     },
   },
   testTimeout: 2500,

--- a/packages/rpc-methods/src/permitted/invokeSnapSugar.test.ts
+++ b/packages/rpc-methods/src/permitted/invokeSnapSugar.test.ts
@@ -1,0 +1,90 @@
+import {
+  JsonRpcEngineEndCallback,
+  JsonRpcEngineNextCallback,
+  JsonRpcRequest,
+} from '@metamask/types';
+import { ethErrors } from 'eth-rpc-errors';
+import { getValidatedParams, invokeSnapSugar } from './invokeSnapSugar';
+
+describe('wallet_invokeSnap', () => {
+  describe('invokeSnapSugar', () => {
+    it('invokes snap with next()', () => {
+      const req: JsonRpcRequest<unknown> = {
+        id: 'some-id',
+        jsonrpc: '2.0',
+        method: 'wallet_invokeSnap',
+        params: {
+          snapId: 'npm:@metamask/example-snap',
+          request: { method: 'hello' },
+        },
+      };
+      const _res: unknown = {};
+      const next: JsonRpcEngineNextCallback = jest
+        .fn()
+        .mockResolvedValueOnce(true);
+      const end: JsonRpcEngineEndCallback = jest.fn();
+
+      invokeSnapSugar(req, _res, next, end);
+
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('ends with an error if params are invalid', () => {
+      const req: JsonRpcRequest<unknown> = {
+        id: 'some-id',
+        jsonrpc: '2.0',
+        method: 'wallet_invokeSnap',
+        params: {
+          snapId: undefined,
+          request: [],
+        },
+      };
+      const _res: unknown = {};
+      const next: JsonRpcEngineNextCallback = jest
+        .fn()
+        .mockResolvedValueOnce(true);
+      const end: JsonRpcEngineEndCallback = jest.fn();
+
+      invokeSnapSugar(req, _res, next, end);
+
+      expect(end).toHaveBeenCalledWith(
+        ethErrors.rpc.invalidParams({
+          message: 'Must specify a valid snap ID.',
+        }),
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getValidatedParams', () => {
+    it('throws an error if the params is not an object', () => {
+      expect(() => getValidatedParams([])).toThrow(
+        'Expected params to be a single object.',
+      );
+    });
+
+    it('throws an error if the snap ID is missing from params object', () => {
+      expect(() =>
+        getValidatedParams({ snapId: undefined, request: {} }),
+      ).toThrow('Must specify a valid snap ID.');
+    });
+
+    it('throws an error if the request is not a plain object', () => {
+      expect(() =>
+        getValidatedParams({ snapId: 'snap-id', request: [] }),
+      ).toThrow('Expected request to be a single object.');
+    });
+
+    it('returns valid parameters', () => {
+      expect(
+        getValidatedParams({
+          snapId: 'npm:@metamask/example-snap',
+          request: { method: 'hello' },
+        }),
+      ).toStrictEqual({
+        snapId: 'npm:@metamask/example-snap',
+        request: { method: 'hello' },
+      });
+    });
+  });
+});

--- a/packages/rpc-methods/src/restricted/invokeSnap.test.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.test.ts
@@ -48,7 +48,7 @@ describe('implementation', () => {
     await implementation({
       context: { origin: MOCK_ORIGIN },
       method: `wallet_snap_${MOCK_SNAP_ID}`,
-      params: [{ method: 'foo', params: {} }],
+      params: { method: 'foo', params: {} },
     });
 
     expect(hooks.getSnap).toHaveBeenCalledTimes(1);
@@ -73,7 +73,7 @@ describe('implementation', () => {
       implementation({
         context: { origin: MOCK_ORIGIN },
         method: `wallet_snap_${MOCK_SNAP_ID}`,
-        params: [{ method: 'foo', params: {} }],
+        params: { method: 'foo', params: {} },
       }),
     ).rejects.toThrow(
       `The snap "${MOCK_SNAP_ID}" is not installed. This is a bug, please report it.`,
@@ -92,7 +92,7 @@ describe('implementation', () => {
       implementation({
         context: { origin: MOCK_ORIGIN },
         method: `wallet_snap_${MOCK_SNAP_ID}`,
-        params: [{}],
+        params: {},
       }),
     ).rejects.toThrow(
       'Must specify a valid JSON-RPC request object as single parameter.',

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -92,12 +92,11 @@ export function getInvokeSnapImplementation({
   handleSnapRpcRequest,
 }: InvokeSnapMethodHooks) {
   return async function invokeSnap(
-    options: RestrictedMethodOptions<[Record<string, Json>]>,
+    options: RestrictedMethodOptions<Record<string, Json>>,
   ): Promise<Json> {
-    const { params = [], method, context } = options;
-    const rawRequest = params[0];
+    const { params = {}, method, context } = options;
 
-    const request = { jsonrpc: '2.0', id: nanoid(), ...rawRequest };
+    const request = { jsonrpc: '2.0', id: nanoid(), ...params };
 
     if (!isJsonRpcRequest(request)) {
       throw ethErrors.rpc.invalidParams({

--- a/packages/rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/rpc-methods/src/restricted/manageState.test.ts
@@ -1,0 +1,296 @@
+import {
+  getManageStateImplementation,
+  getValidatedParams,
+  ManageStateOperation,
+  specificationBuilder,
+  STORAGE_SIZE_LIMIT,
+} from './manageState';
+
+describe('snap_manageState', () => {
+  const MOCK_SMALLER_STORAGE_SIZE_LIMIT = 10; // In bytes
+  describe('specification', () => {
+    it('builds specification', () => {
+      const methodHooks = {
+        clearSnapState: jest.fn(),
+        getSnapState: jest.fn(),
+        updateSnapState: jest.fn(),
+      };
+
+      expect(
+        specificationBuilder({
+          allowedCaveats: null,
+          methodHooks,
+        }),
+      ).toStrictEqual({
+        allowedCaveats: null,
+        methodImplementation: expect.anything(),
+        permissionType: 'RestrictedMethod',
+        targetKey: 'snap_manageState',
+      });
+    });
+  });
+
+  describe('getManageStateImplementation', () => {
+    it('gets snap state', async () => {
+      const mockSnapState = {
+        some: {
+          data: 'for a snap state',
+        },
+      };
+      const clearSnapState = jest.fn().mockResolvedValueOnce(true);
+      const getSnapState = jest.fn().mockResolvedValueOnce(mockSnapState);
+      const updateSnapState = jest.fn().mockResolvedValueOnce(true);
+
+      const manageStateImplementation = getManageStateImplementation({
+        clearSnapState,
+        getSnapState,
+        updateSnapState,
+      });
+
+      const result = await manageStateImplementation({
+        context: { origin: 'snap-origin' },
+        method: 'snap_manageState',
+        params: { operation: ManageStateOperation.getState },
+      });
+
+      expect(getSnapState).toHaveBeenCalledWith('snap-origin');
+      expect(result).toStrictEqual(mockSnapState);
+    });
+
+    it('clears snap state', async () => {
+      const clearSnapState = jest.fn().mockResolvedValueOnce(true);
+      const getSnapState = jest.fn().mockResolvedValueOnce(true);
+      const updateSnapState = jest.fn().mockResolvedValueOnce(true);
+
+      const manageStateImplementation = getManageStateImplementation({
+        clearSnapState,
+        getSnapState,
+        updateSnapState,
+      });
+
+      await manageStateImplementation({
+        context: { origin: 'snap-origin' },
+        method: 'snap_manageState',
+        params: { operation: ManageStateOperation.clearState },
+      });
+
+      expect(clearSnapState).toHaveBeenCalledWith('snap-origin');
+    });
+
+    it('updates snap state', async () => {
+      const clearSnapState = jest.fn().mockResolvedValueOnce(true);
+      const getSnapState = jest.fn().mockResolvedValueOnce(true);
+      const updateSnapState = jest.fn().mockResolvedValueOnce(true);
+
+      const manageStateImplementation = getManageStateImplementation({
+        clearSnapState,
+        getSnapState,
+        updateSnapState,
+      });
+      const newState = { data: 'updated data' };
+
+      await manageStateImplementation({
+        context: { origin: 'snap-origin' },
+        method: 'snap_manageState',
+        params: {
+          operation: ManageStateOperation.updateState,
+          newState,
+        },
+      });
+
+      expect(updateSnapState).toHaveBeenCalledWith('snap-origin', newState);
+    });
+
+    it('throws an error on update if the new state is not plain object', async () => {
+      const clearSnapState = jest.fn().mockResolvedValueOnce(true);
+      const getSnapState = jest.fn().mockResolvedValueOnce(true);
+      const updateSnapState = jest.fn().mockResolvedValueOnce(true);
+
+      const manageStateImplementation = getManageStateImplementation({
+        clearSnapState,
+        getSnapState,
+        updateSnapState,
+      });
+      const newState = (a: unknown) => {
+        return a;
+      };
+
+      await expect(
+        manageStateImplementation({
+          context: { origin: 'snap-origin' },
+          method: 'snap_manageState',
+          params: {
+            operation: ManageStateOperation.updateState,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error - invalid type for testing purposes
+            newState,
+          },
+        }),
+      ).rejects.toThrow(
+        'Invalid snap_manageState "updateState" parameter: The new state must be a plain object.',
+      );
+
+      expect(updateSnapState).not.toHaveBeenCalledWith('snap-origin', newState);
+    });
+
+    it('throws an error on update if the new state is not valid json serializable object', async () => {
+      const clearSnapState = jest.fn().mockResolvedValueOnce(true);
+      const getSnapState = jest.fn().mockResolvedValueOnce(true);
+      const updateSnapState = jest.fn().mockResolvedValueOnce(true);
+
+      const manageStateImplementation = getManageStateImplementation({
+        clearSnapState,
+        getSnapState,
+        updateSnapState,
+      });
+      const newState = {
+        something: {
+          something: {
+            invalidJson: () => 'a',
+          },
+        },
+      };
+
+      await expect(
+        manageStateImplementation({
+          context: { origin: 'snap-origin' },
+          method: 'snap_manageState',
+          params: {
+            operation: ManageStateOperation.updateState,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error - invalid type for testing purposes
+            newState,
+          },
+        }),
+      ).rejects.toThrow(
+        'Invalid snap_manageState "updateState" parameter: The new state must be JSON serializable.',
+      );
+
+      expect(updateSnapState).not.toHaveBeenCalledWith('snap-origin', newState);
+    });
+  });
+
+  describe('getValidatedParams', () => {
+    it('throws an error if the params is not an object', () => {
+      expect(() =>
+        getValidatedParams([], 'snap_manageState', STORAGE_SIZE_LIMIT),
+      ).toThrow('Expected params to be a single object.');
+    });
+
+    it('throws an error if the operation type is missing from params object', () => {
+      expect(() =>
+        getValidatedParams(
+          { operation: undefined },
+          'snap_manageState',
+          STORAGE_SIZE_LIMIT,
+        ),
+      ).toThrow('Must specify a valid manage state "operation".');
+    });
+
+    it('throws an error if the operation type is not valid', () => {
+      expect(() =>
+        getValidatedParams(
+          { operation: 'unspecifiedOperation' },
+          'snap_manageState',
+          STORAGE_SIZE_LIMIT,
+        ),
+      ).toThrow('Must specify a valid manage state "operation".');
+    });
+
+    it('returns valid parameters for get operation', () => {
+      expect(
+        getValidatedParams(
+          { operation: 'get' },
+          'snap_manageState',
+          STORAGE_SIZE_LIMIT,
+        ),
+      ).toStrictEqual({
+        operation: 'get',
+      });
+    });
+
+    it('returns valid parameters for clear operation', () => {
+      expect(
+        getValidatedParams(
+          { operation: 'clear' },
+          'snap_manageState',
+          STORAGE_SIZE_LIMIT,
+        ),
+      ).toStrictEqual({
+        operation: 'clear',
+      });
+    });
+
+    it('returns valid parameters for update operation', () => {
+      expect(
+        getValidatedParams(
+          {
+            operation: 'update',
+            newState: { data: 'updated data' },
+          },
+          'snap_manageState',
+          STORAGE_SIZE_LIMIT,
+        ),
+      ).toStrictEqual({
+        operation: 'update',
+        newState: { data: 'updated data' },
+      });
+    });
+
+    it('throws an error if the new state object is not valid plain object', () => {
+      const mockInvalidNewStateObject = (a: unknown) => {
+        return a;
+      };
+
+      expect(() =>
+        getValidatedParams(
+          { operation: 'update', newState: mockInvalidNewStateObject },
+          'snap_manageState',
+          STORAGE_SIZE_LIMIT,
+        ),
+      ).toThrow(
+        'Invalid snap_manageState "updateState" parameter: The new state must be a plain object.',
+      );
+    });
+
+    it('throws an error if the new state object is not valid JSON serializable object', () => {
+      const mockInvalidNewStateObject = {
+        something: {
+          something: {
+            invalidJson: () => 'a',
+          },
+        },
+      };
+
+      expect(() =>
+        getValidatedParams(
+          { operation: 'update', newState: mockInvalidNewStateObject },
+          'snap_manageState',
+          STORAGE_SIZE_LIMIT,
+        ),
+      ).toThrow(
+        'Invalid snap_manageState "updateState" parameter: The new state must be JSON serializable.',
+      );
+    });
+
+    it('throws an error if the new state object is exceeding the JSON size limit', () => {
+      const mockInvalidNewStateObject = {
+        something: {
+          something: {
+            whatever: 'whatever',
+          },
+        },
+      };
+
+      expect(() =>
+        getValidatedParams(
+          { operation: 'update', newState: mockInvalidNewStateObject },
+          'snap_manageState',
+          MOCK_SMALLER_STORAGE_SIZE_LIMIT,
+        ),
+      ).toThrow(
+        `Invalid snap_manageState "updateState" parameter: The new state must not exceed ${MOCK_SMALLER_STORAGE_SIZE_LIMIT} bytes in size.`,
+      );
+    });
+  });
+});

--- a/packages/rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/rpc-methods/src/restricted/manageState.test.ts
@@ -3,7 +3,6 @@ import {
   getValidatedParams,
   ManageStateOperation,
   specificationBuilder,
-  STORAGE_SIZE_LIMIT,
 } from './manageState';
 
 describe('snap_manageState', () => {
@@ -172,18 +171,14 @@ describe('snap_manageState', () => {
 
   describe('getValidatedParams', () => {
     it('throws an error if the params is not an object', () => {
-      expect(() =>
-        getValidatedParams([], 'snap_manageState', STORAGE_SIZE_LIMIT),
-      ).toThrow('Expected params to be a single object.');
+      expect(() => getValidatedParams([], 'snap_manageState')).toThrow(
+        'Expected params to be a single object.',
+      );
     });
 
     it('throws an error if the operation type is missing from params object', () => {
       expect(() =>
-        getValidatedParams(
-          { operation: undefined },
-          'snap_manageState',
-          STORAGE_SIZE_LIMIT,
-        ),
+        getValidatedParams({ operation: undefined }, 'snap_manageState'),
       ).toThrow('Must specify a valid manage state "operation".');
     });
 
@@ -192,18 +187,13 @@ describe('snap_manageState', () => {
         getValidatedParams(
           { operation: 'unspecifiedOperation' },
           'snap_manageState',
-          STORAGE_SIZE_LIMIT,
         ),
       ).toThrow('Must specify a valid manage state "operation".');
     });
 
     it('returns valid parameters for get operation', () => {
       expect(
-        getValidatedParams(
-          { operation: 'get' },
-          'snap_manageState',
-          STORAGE_SIZE_LIMIT,
-        ),
+        getValidatedParams({ operation: 'get' }, 'snap_manageState'),
       ).toStrictEqual({
         operation: 'get',
       });
@@ -211,11 +201,7 @@ describe('snap_manageState', () => {
 
     it('returns valid parameters for clear operation', () => {
       expect(
-        getValidatedParams(
-          { operation: 'clear' },
-          'snap_manageState',
-          STORAGE_SIZE_LIMIT,
-        ),
+        getValidatedParams({ operation: 'clear' }, 'snap_manageState'),
       ).toStrictEqual({
         operation: 'clear',
       });
@@ -229,7 +215,6 @@ describe('snap_manageState', () => {
             newState: { data: 'updated data' },
           },
           'snap_manageState',
-          STORAGE_SIZE_LIMIT,
         ),
       ).toStrictEqual({
         operation: 'update',
@@ -246,7 +231,6 @@ describe('snap_manageState', () => {
         getValidatedParams(
           { operation: 'update', newState: mockInvalidNewStateObject },
           'snap_manageState',
-          STORAGE_SIZE_LIMIT,
         ),
       ).toThrow(
         'Invalid snap_manageState "updateState" parameter: The new state must be a plain object.',
@@ -266,7 +250,6 @@ describe('snap_manageState', () => {
         getValidatedParams(
           { operation: 'update', newState: mockInvalidNewStateObject },
           'snap_manageState',
-          STORAGE_SIZE_LIMIT,
         ),
       ).toThrow(
         'Invalid snap_manageState "updateState" parameter: The new state must be JSON serializable.',

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -60,7 +60,7 @@ type ManageStateSpecification = ValidPermissionSpecification<{
  * @param options.methodHooks - The RPC method hooks needed by the method implementation.
  * @returns The specification for the `snap_manageState` permission.
  */
-const specificationBuilder: PermissionSpecificationBuilder<
+export const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
   ManageStateSpecificationBuilderOptions,
   ManageStateSpecification
@@ -92,6 +92,11 @@ export enum ManageStateOperation {
   updateState = 'update',
 }
 
+export type ManageStateArgs = {
+  operation: ManageStateOperation;
+  newState?: Record<string, Json>;
+};
+
 export const STORAGE_SIZE_LIMIT = 104857600; // In bytes (100MB)
 
 /**
@@ -104,22 +109,24 @@ export const STORAGE_SIZE_LIMIT = 104857600; // In bytes (100MB)
  * @returns The method implementation which either returns `null` for a successful state update/deletion or returns the decrypted state.
  * @throws If the params are invalid.
  */
-function getManageStateImplementation({
+export function getManageStateImplementation({
   clearSnapState,
   getSnapState,
   updateSnapState,
 }: ManageStateMethodHooks) {
   return async function manageState(
-    options: RestrictedMethodOptions<
-      [ManageStateOperation, Record<string, Json>]
-    >,
+    options: RestrictedMethodOptions<ManageStateArgs>,
   ): Promise<null | Record<string, Json>> {
     const {
-      params = [],
+      params = {},
       method,
       context: { origin },
     } = options;
-    const [operation, newState] = params;
+    const { operation, newState } = getValidatedParams(
+      params,
+      method,
+      STORAGE_SIZE_LIMIT,
+    );
 
     switch (operation) {
       case ManageStateOperation.clearState:
@@ -130,36 +137,7 @@ function getManageStateImplementation({
         return await getSnapState(origin);
 
       case ManageStateOperation.updateState: {
-        if (!isObject(newState)) {
-          throw ethErrors.rpc.invalidParams({
-            message: `Invalid ${method} "updateState" parameter: The new state must be a plain object.`,
-            data: {
-              receivedNewState:
-                typeof newState === 'undefined' ? 'undefined' : newState,
-            },
-          });
-        }
-        const [isValid, plainTextSizeInBytes] =
-          validateJsonAndGetSize(newState);
-        if (!isValid) {
-          throw ethErrors.rpc.invalidParams({
-            message: `Invalid ${method} "updateState" parameter: The new state must be JSON serializable.`,
-            data: {
-              receivedNewState:
-                typeof newState === 'undefined' ? 'undefined' : newState,
-            },
-          });
-        } else if (plainTextSizeInBytes > STORAGE_SIZE_LIMIT) {
-          throw ethErrors.rpc.invalidParams({
-            message: `Invalid ${method} "updateState" parameter: The new state must not exceed ${STORAGE_SIZE_LIMIT} bytes in size.`,
-            data: {
-              receivedNewState:
-                typeof newState === 'undefined' ? 'undefined' : newState,
-            },
-          });
-        }
-
-        await updateSnapState(origin, newState);
+        await updateSnapState(origin, newState as Record<string, Json>);
         return null;
       }
       default:
@@ -168,4 +146,69 @@ function getManageStateImplementation({
         );
     }
   };
+}
+
+/**
+ * Validates the manageState method `params` and returns them cast to the correct
+ * type. Throws if validation fails.
+ *
+ * @param params - The unvalidated params object from the method request.
+ * @param method - RPC method name used for debugging errors.
+ * @param storageSizeLimit - Maximum allowed size (in bytes) of a new state object.
+ * @returns The validated method parameter object.
+ */
+export function getValidatedParams(
+  params: unknown,
+  method: string,
+  storageSizeLimit: number,
+): ManageStateArgs {
+  if (!isObject(params)) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Expected params to be a single object.',
+    });
+  }
+
+  const { operation, newState } = params;
+
+  if (
+    !operation ||
+    typeof operation !== 'string' ||
+    !(Object.values(ManageStateOperation) as string[]).includes(operation)
+  ) {
+    throw ethErrors.rpc.invalidParams({
+      message: 'Must specify a valid manage state "operation".',
+    });
+  }
+
+  if (operation === ManageStateOperation.updateState) {
+    if (!isObject(newState)) {
+      throw ethErrors.rpc.invalidParams({
+        message: `Invalid ${method} "updateState" parameter: The new state must be a plain object.`,
+        data: {
+          receivedNewState:
+            typeof newState === 'undefined' ? 'undefined' : newState,
+        },
+      });
+    }
+    const [isValid, plainTextSizeInBytes] = validateJsonAndGetSize(newState);
+    if (!isValid) {
+      throw ethErrors.rpc.invalidParams({
+        message: `Invalid ${method} "updateState" parameter: The new state must be JSON serializable.`,
+        data: {
+          receivedNewState:
+            typeof newState === 'undefined' ? 'undefined' : newState,
+        },
+      });
+    } else if (plainTextSizeInBytes > storageSizeLimit) {
+      throw ethErrors.rpc.invalidParams({
+        message: `Invalid ${method} "updateState" parameter: The new state must not exceed ${storageSizeLimit} bytes in size.`,
+        data: {
+          receivedNewState:
+            typeof newState === 'undefined' ? 'undefined' : newState,
+        },
+      });
+    }
+  }
+
+  return params as ManageStateArgs;
 }

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -122,11 +122,7 @@ export function getManageStateImplementation({
       method,
       context: { origin },
     } = options;
-    const { operation, newState } = getValidatedParams(
-      params,
-      method,
-      STORAGE_SIZE_LIMIT,
-    );
+    const { operation, newState } = getValidatedParams(params, method);
 
     switch (operation) {
       case ManageStateOperation.clearState:
@@ -160,7 +156,7 @@ export function getManageStateImplementation({
 export function getValidatedParams(
   params: unknown,
   method: string,
-  storageSizeLimit: number,
+  storageSizeLimit = STORAGE_SIZE_LIMIT,
 ): ManageStateArgs {
   if (!isObject(params)) {
     throw ethErrors.rpc.invalidParams({

--- a/packages/rpc-methods/src/restricted/notify.test.ts
+++ b/packages/rpc-methods/src/restricted/notify.test.ts
@@ -1,0 +1,133 @@
+import {
+  getImplementation,
+  getValidatedParams,
+  NotificationType,
+} from './notify';
+
+describe('snap_notify', () => {
+  const validParams = {
+    type: 'inApp',
+    message: 'Some message',
+  };
+
+  describe('getImplementation', () => {
+    it('shows inApp notification', async () => {
+      const showNativeNotification = jest.fn().mockResolvedValueOnce(true);
+      const showInAppNotification = jest.fn().mockResolvedValueOnce(true);
+
+      const notificationImplementation = getImplementation({
+        showNativeNotification,
+        showInAppNotification,
+      });
+
+      await notificationImplementation({
+        context: {
+          origin: 'extension',
+        },
+        method: 'snap_notify',
+        params: {
+          type: NotificationType.inApp,
+          message: 'Some message',
+        },
+      });
+
+      expect(showInAppNotification).toHaveBeenCalledWith('extension', {
+        type: NotificationType.inApp,
+        message: 'Some message',
+      });
+    });
+
+    it('shows native notification', async () => {
+      const showNativeNotification = jest.fn().mockResolvedValueOnce(true);
+      const showInAppNotification = jest.fn().mockResolvedValueOnce(true);
+
+      const notificationImplementation = getImplementation({
+        showNativeNotification,
+        showInAppNotification,
+      });
+
+      await notificationImplementation({
+        context: {
+          origin: 'extension',
+        },
+        method: 'snap_notify',
+        params: {
+          type: NotificationType.native,
+          message: 'Some message',
+        },
+      });
+
+      expect(showNativeNotification).toHaveBeenCalledWith('extension', {
+        type: NotificationType.native,
+        message: 'Some message',
+      });
+    });
+
+    it('throws an error if the notification type is invalid', async () => {
+      const showNativeNotification = jest.fn().mockResolvedValueOnce(true);
+      const showInAppNotification = jest.fn().mockResolvedValueOnce(true);
+
+      const notificationImplementation = getImplementation({
+        showNativeNotification,
+        showInAppNotification,
+      });
+
+      await expect(
+        notificationImplementation({
+          context: {
+            origin: 'extension',
+          },
+          method: 'snap_notify',
+          params: {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error - invalid type for testing purposes
+            type: 'invalid-type',
+            message: 'Some message',
+          },
+        }),
+      ).rejects.toThrow('Must specify a valid notification "type".');
+    });
+  });
+
+  describe('getValidatedParams', () => {
+    it('throws an error if the params is not an object', () => {
+      expect(() => getValidatedParams([])).toThrow(
+        'Expected params to be a single object.',
+      );
+    });
+
+    it('throws an error if the type is missing from params object', () => {
+      expect(() =>
+        getValidatedParams({ type: undefined, message: 'Something happened.' }),
+      ).toThrow('Must specify a valid notification "type".');
+    });
+
+    it('throws an error if the message is empty', () => {
+      expect(() => getValidatedParams({ type: 'inApp', message: '' })).toThrow(
+        'Must specify a non-empty string "message" less than 50 characters long.',
+      );
+    });
+
+    it('throws an error if the message is not a string', () => {
+      expect(() => getValidatedParams({ type: 'inApp', message: 123 })).toThrow(
+        'Must specify a non-empty string "message" less than 50 characters long.',
+      );
+    });
+
+    it('throws an error if the message is larger than 50 characters', () => {
+      expect(() =>
+        getValidatedParams({
+          type: 'inApp',
+          message:
+            'test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg',
+        }),
+      ).toThrow(
+        'Must specify a non-empty string "message" less than 50 characters long.',
+      );
+    });
+
+    it('returns valid parameters', () => {
+      expect(getValidatedParams(validParams)).toStrictEqual(validParams);
+    });
+  });
+});

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -68,7 +68,7 @@ type Specification = ValidPermissionSpecification<{
  * @param options.methodHooks - The RPC method hooks needed by the method implementation.
  * @returns The specification for the `snap_notify` permission.
  */
-const specificationBuilder: PermissionSpecificationBuilder<
+export const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.RestrictedMethod,
   SpecificationBuilderOptions,
   Specification
@@ -99,12 +99,12 @@ export const notifyBuilder = Object.freeze({
  * @returns The method implementation which returns `null` on success.
  * @throws If the params are invalid.
  */
-function getImplementation({
+export function getImplementation({
   showNativeNotification,
   showInAppNotification,
 }: NotifyMethodHooks) {
   return async function implementation(
-    args: RestrictedMethodOptions<[NotificationArgs]>,
+    args: RestrictedMethodOptions<NotificationArgs>,
   ): Promise<null> {
     const {
       params,
@@ -133,14 +133,14 @@ function getImplementation({
  * @param params - The unvalidated params object from the method request.
  * @returns The validated method parameter object.
  */
-function getValidatedParams(params: unknown): NotificationArgs {
-  if (!Array.isArray(params) || !isObject(params[0])) {
+export function getValidatedParams(params: unknown): NotificationArgs {
+  if (!isObject(params)) {
     throw ethErrors.rpc.invalidParams({
-      message: 'Expected array params with single object.',
+      message: 'Expected params to be a single object.',
     });
   }
 
-  const { type, message } = params[0];
+  const { type, message } = params;
 
   if (
     !type ||
@@ -160,5 +160,5 @@ function getValidatedParams(params: unknown): NotificationArgs {
     });
   }
 
-  return params[0] as NotificationArgs;
+  return params as NotificationArgs;
 }


### PR DESCRIPTION
This PR will update the way of passing RPC method parameters.

All parameters will now be following the new convention where object-like named parameters are required.
All RPC methods that were accepting parameters as an array `[]` are updated and appropriate tests are added.

Updated are the following methods:
- wallet_snap_*
- snap_manageState
- snap_notify
- wallet_invokeSnap

All of these mentioned and the rest of the untouched methods in this PR require a plain object structure `{}` for passing parameters. 

Fixes: https://github.com/MetaMask/snaps-monorepo/issues/870
