### PR TITLE
Add warning if an invalid export is detected

### DIFF
--- a/packages/utils/src/eval-worker.ts
+++ b/packages/utils/src/eval-worker.ts
@@ -54,7 +54,7 @@ const invalidExports = Object.keys(snapModule.exports).filter(
     !SNAP_EXPORT_NAMES.some((exportName) => snapExport === exportName),
 );
 
-if (invalidExports.length) {
+if (invalidExports.length > 0) {
   console.warn(`Invalid exports detected:\n${invalidExports.join('\n')}`);
 }
 

--- a/packages/utils/src/eval-worker.ts
+++ b/packages/utils/src/eval-worker.ts
@@ -54,7 +54,7 @@ const invalidExports = Object.keys(snapModule.exports).filter(
 );
 
 if (invalidExports.length > 0) {
-  console.warn(`Invalid exports detected:\n${invalidExports.join('\n')}`);
+  console.warn(`Invalid snap exports detected:\n${invalidExports.join('\n')}`);
 }
 
 setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits

--- a/packages/utils/src/eval-worker.ts
+++ b/packages/utils/src/eval-worker.ts
@@ -4,6 +4,8 @@ import 'ses/lockdown';
 import { readFileSync } from 'fs';
 import { generateMockEndowments } from './mock';
 
+const allowedSnapExports = ['onRpcRequest', 'onTransaction'];
+
 declare let lockdown: any, Compartment: any;
 
 lockdown({
@@ -48,8 +50,13 @@ new Compartment({
   exports: snapModule.exports,
 }).evaluate(readFileSync(snapFilePath, 'utf8'));
 
-if (!snapModule.exports?.onRpcRequest) {
-  console.warn(`The Snap doesn't have an "onRpcRequest" export defined.`);
+const invalidExports = Object.keys(snapModule.exports).filter(
+  (snapExport) =>
+    !allowedSnapExports.some((allowedExport) => snapExport === allowedExport),
+);
+
+if (invalidExports.length) {
+  console.warn(`Invalid exports detected:\n${invalidExports.join('\n')}`);
 }
 
 setTimeout(() => process.exit(0), 1000); // Hack to ensure worker exits

--- a/packages/utils/src/eval-worker.ts
+++ b/packages/utils/src/eval-worker.ts
@@ -3,7 +3,7 @@ import 'ses/lockdown';
 
 import { readFileSync } from 'fs';
 import { generateMockEndowments } from './mock';
-import { SNAP_EXPORT_NAMES } from './types';
+import { HandlerType, SNAP_EXPORT_NAMES } from './types';
 
 declare let lockdown: any, Compartment: any;
 
@@ -50,8 +50,7 @@ new Compartment({
 }).evaluate(readFileSync(snapFilePath, 'utf8'));
 
 const invalidExports = Object.keys(snapModule.exports).filter(
-  (snapExport) =>
-    !SNAP_EXPORT_NAMES.some((exportName) => snapExport === exportName),
+  (snapExport) => !SNAP_EXPORT_NAMES.includes(snapExport as HandlerType),
 );
 
 if (invalidExports.length > 0) {

--- a/packages/utils/src/eval-worker.ts
+++ b/packages/utils/src/eval-worker.ts
@@ -3,8 +3,7 @@ import 'ses/lockdown';
 
 import { readFileSync } from 'fs';
 import { generateMockEndowments } from './mock';
-
-const allowedSnapExports = ['onRpcRequest', 'onTransaction'];
+import { SNAP_EXPORT_NAMES } from './types';
 
 declare let lockdown: any, Compartment: any;
 
@@ -52,7 +51,7 @@ new Compartment({
 
 const invalidExports = Object.keys(snapModule.exports).filter(
   (snapExport) =>
-    !allowedSnapExports.some((allowedExport) => snapExport === allowedExport),
+    !SNAP_EXPORT_NAMES.some((exportName) => snapExport === exportName),
 );
 
 if (invalidExports.length) {


### PR DESCRIPTION
This changes the warning displayed if `onRpcRequest` is not exported to a warning if an invalid export is found.

Fixes: #924 