### PR TITLE
Allow insights object to be null in `onTransactionResponse`

### DIFF
--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -9,7 +9,7 @@ export type SnapRpcHandler = (args: {
 export type OnRpcRequestHandler = SnapRpcHandler;
 
 export type OnTransactionResponse = {
-  insights: { [key: string]: unknown };
+  insights: { [key: string]: unknown } | null;
 };
 
 // TODO: improve type


### PR DESCRIPTION
This changes the `onTransactionResponse` type to allow the `insights` object to be null.

Fixes: #901
See: https://github.com/MetaMask/metamask-extension/pull/16416