### PR TITLE
Sort imports with ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,24 @@ module.exports = {
 
   extends: ['@metamask/eslint-config'],
 
+  rules: {
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        groups: [
+          ['builtin', 'external'],
+          ['internal', 'parent', 'sibling', 'index'],
+        ],
+        pathGroupsExcludedImportTypes: [],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+      },
+    ],
+  },
+
   overrides: [
     {
       files: ['**/*.js'],

--- a/packages/examples/examples/browserify/gulpfile.ts
+++ b/packages/examples/examples/browserify/gulpfile.ts
@@ -1,7 +1,8 @@
-import { series, dest } from 'gulp';
 import browserify from 'browserify';
+import { series, dest } from 'gulp';
 import source from 'vinyl-source-stream';
 import watchify from 'watchify';
+
 import babelConfig from './babel.config.json';
 
 const ENTRY_POINT = './src/snap.ts';

--- a/packages/examples/examples/insights/src/index.ts
+++ b/packages/examples/examples/insights/src/index.ts
@@ -1,4 +1,5 @@
 import { OnTransactionHandler } from '@metamask/snaps-types';
+
 import { getInsights } from './insights';
 
 /**

--- a/packages/examples/examples/insights/src/insights.ts
+++ b/packages/examples/examples/insights/src/insights.ts
@@ -1,3 +1,4 @@
+import { decode } from '@metamask/abi-utils';
 import {
   add0x,
   bytesToHex,
@@ -5,7 +6,6 @@ import {
   isObject,
   remove0x,
 } from '@metamask/utils';
-import { decode } from '@metamask/abi-utils';
 
 // The API endpoint to get a list of functions by 4 byte signature.
 const API_ENDPOINT =

--- a/packages/examples/examples/ipfs/src/index.js
+++ b/packages/examples/examples/ipfs/src/index.js
@@ -1,4 +1,5 @@
 const { errors: rpcErrors } = require('eth-json-rpc-errors');
+
 const { IPFS } = require('./ipfs');
 
 const ipfs = new IPFS({

--- a/packages/examples/examples/rollup/rollup.config.js
+++ b/packages/examples/examples/rollup/rollup.config.js
@@ -1,5 +1,5 @@
-const { babel } = require('@rollup/plugin-babel');
 const snaps = require('@metamask/snaps-rollup-plugin').default;
+const { babel } = require('@rollup/plugin-babel');
 
 /**
  * @type {RollupOptions}

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -1,4 +1,5 @@
 import { OnRpcRequestHandler } from '@metamask/snaps-types';
+
 import { getMessage } from './message';
 
 /**

--- a/packages/examples/examples/wasm/src/index.js
+++ b/packages/examples/examples/wasm/src/index.js
@@ -1,7 +1,7 @@
 // Due to a bug of how brfs interacts with babel, we need to use require() syntax instead of import pattern
 // https://github.com/browserify/brfs/issues/39
-const fs = require('fs');
 const { ethErrors } = require('eth-rpc-errors');
+const fs = require('fs');
 
 // Ref:
 // - https://developer.mozilla.org/en-US/docs/WebAssembly/Using_the_JavaScript_API

--- a/packages/examples/examples/webpack/webpack.config.ts
+++ b/packages/examples/examples/webpack/webpack.config.ts
@@ -1,6 +1,6 @@
-import { resolve } from 'path';
 import SnapsWebpackPlugin from '@metamask/snaps-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import { resolve } from 'path';
 import { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 import WebpackBarPlugin from 'webpackbar';

--- a/packages/multichain-provider/jest.config.js
+++ b/packages/multichain-provider/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/multichain-provider/src/MultiChainProvider.test.ts
+++ b/packages/multichain-provider/src/MultiChainProvider.test.ts
@@ -4,6 +4,7 @@ import {
   getRequestNamespace,
   getSessionNamespace,
 } from '@metamask/snaps-utils/test-utils';
+
 import { MultiChainProvider } from './MultiChainProvider';
 
 Object.assign(globalThis, {

--- a/packages/multichain-provider/src/MultiChainProvider.ts
+++ b/packages/multichain-provider/src/MultiChainProvider.ts
@@ -1,5 +1,5 @@
 import SafeEventEmitter from '@metamask/safe-event-emitter';
-import { nanoid } from 'nanoid';
+import type { SnapProvider } from '@metamask/snaps-types';
 import {
   assertIsConnectArguments,
   assertIsMetaMaskNotification,
@@ -13,7 +13,8 @@ import {
   Session,
 } from '@metamask/snaps-utils';
 import { JsonRpcRequest } from '@metamask/utils';
-import type { SnapProvider } from '@metamask/snaps-types';
+import { nanoid } from 'nanoid';
+
 import { Provider } from './Provider';
 
 declare global {

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/rpc-methods/src/permitted/common/snapInstallation.ts
+++ b/packages/rpc-methods/src/permitted/common/snapInstallation.ts
@@ -1,7 +1,7 @@
-import { ethErrors } from 'eth-rpc-errors';
 import { RequestedPermissions } from '@metamask/controllers';
-import { isObject } from '@metamask/utils';
 import { InstallSnapsResult } from '@metamask/snaps-utils';
+import { isObject } from '@metamask/utils';
+import { ethErrors } from 'eth-rpc-errors';
 
 export { InstallSnapsResult } from '@metamask/snaps-utils';
 

--- a/packages/rpc-methods/src/permitted/getAppKey.ts
+++ b/packages/rpc-methods/src/permitted/getAppKey.ts
@@ -1,10 +1,10 @@
-import { ethErrors } from 'eth-rpc-errors';
 import {
   PermittedHandlerExport,
   JsonRpcRequest,
   PendingJsonRpcResponse,
   JsonRpcEngineEndCallback,
 } from '@metamask/types';
+import { ethErrors } from 'eth-rpc-errors';
 
 /**
  * `snap_getAppKey` gets the Snap's app key.

--- a/packages/rpc-methods/src/permitted/index.ts
+++ b/packages/rpc-methods/src/permitted/index.ts
@@ -1,7 +1,7 @@
 import { getAppKeyHandler, GetAppKeyHooks } from './getAppKey';
 import { getSnapsHandler, GetSnapsHooks } from './getSnaps';
-import { requestSnapsHandler, RequestSnapsHooks } from './requestSnaps';
 import { invokeSnapSugarHandler } from './invokeSnapSugar';
+import { requestSnapsHandler, RequestSnapsHooks } from './requestSnaps';
 
 export type PermittedRpcMethodHooks = GetAppKeyHooks &
   GetSnapsHooks &

--- a/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -1,4 +1,4 @@
-import { ethErrors } from 'eth-rpc-errors';
+import { SNAP_PREFIX } from '@metamask/snaps-utils';
 import {
   PermittedHandlerExport,
   JsonRpcRequest,
@@ -6,7 +6,7 @@ import {
   JsonRpcEngineEndCallback,
 } from '@metamask/types';
 import { isObject } from '@metamask/utils';
-import { SNAP_PREFIX } from '@metamask/snaps-utils';
+import { ethErrors } from 'eth-rpc-errors';
 
 /**
  * `wallet_invokeSnap` attempts to invoke an RPC method of the specified Snap.

--- a/packages/rpc-methods/src/permitted/requestSnaps.test.ts
+++ b/packages/rpc-methods/src/permitted/requestSnaps.test.ts
@@ -1,3 +1,8 @@
+import { RequestedPermissions } from '@metamask/controllers';
+import {
+  getSnapPermissionName,
+  InstallSnapsResult,
+} from '@metamask/snaps-utils';
 import {
   MOCK_SNAP_ID,
   getTruncatedSnap,
@@ -7,12 +12,8 @@ import {
   JsonRpcSuccess,
   PendingJsonRpcResponse,
 } from '@metamask/types';
-import {
-  getSnapPermissionName,
-  InstallSnapsResult,
-} from '@metamask/snaps-utils';
 import { JsonRpcEngine } from 'json-rpc-engine';
-import { RequestedPermissions } from '@metamask/controllers';
+
 import { requestSnapsHandler } from './requestSnaps';
 
 describe('requestSnapsHandler', () => {

--- a/packages/rpc-methods/src/permitted/requestSnaps.ts
+++ b/packages/rpc-methods/src/permitted/requestSnaps.ts
@@ -1,16 +1,17 @@
-import { ethErrors } from 'eth-rpc-errors';
 import {
   PermissionConstraint,
   RequestedPermissions,
 } from '@metamask/controllers';
+import { getSnapPermissionName } from '@metamask/snaps-utils';
 import {
   PermittedHandlerExport,
   JsonRpcRequest,
   PendingJsonRpcResponse,
   JsonRpcEngineEndCallback,
 } from '@metamask/types';
-import { getSnapPermissionName } from '@metamask/snaps-utils';
 import { hasProperty, isObject } from '@metamask/utils';
+import { ethErrors } from 'eth-rpc-errors';
+
 import {
   handleInstallSnaps,
   InstallSnapsHook,

--- a/packages/rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/rpc-methods/src/restricted/dialog.test.ts
@@ -1,4 +1,5 @@
 import { PermissionType } from '@metamask/controllers';
+
 import {
   dialogBuilder,
   DialogType,

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -1,4 +1,5 @@
 import { SnapCaveatType } from '@metamask/snaps-utils';
+
 import {
   getBip32EntropyBuilder,
   getBip32EntropyCaveatMapper,

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -8,15 +8,16 @@ import {
   PermissionConstraint,
   RestrictedMethodCaveatSpecificationConstraint,
 } from '@metamask/controllers';
-import { ethErrors } from 'eth-rpc-errors';
+import { BIP32Node, JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
+import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   hasProperty,
   isPlainObject,
   Json,
   NonEmptyArray,
 } from '@metamask/utils';
-import { BIP32Node, JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
-import { SnapCaveatType } from '@metamask/snaps-utils';
+import { ethErrors } from 'eth-rpc-errors';
+
 import { isEqual } from '../utils';
 
 const INDEX_REGEX = /^\d+'?$/u;

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -1,4 +1,5 @@
 import { SnapCaveatType } from '@metamask/snaps-utils';
+
 import {
   getBip32PublicKeyBuilder,
   getBip32PublicKeyCaveatSpecifications,

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -7,10 +7,11 @@ import {
   PermissionValidatorConstraint,
   RestrictedMethodCaveatSpecificationConstraint,
 } from '@metamask/controllers';
-import { ethErrors } from 'eth-rpc-errors';
-import { NonEmptyArray } from '@metamask/utils';
 import { BIP32Node, SLIP10Node } from '@metamask/key-tree';
 import { SnapCaveatType } from '@metamask/snaps-utils';
+import { NonEmptyArray } from '@metamask/utils';
+import { ethErrors } from 'eth-rpc-errors';
+
 import { isEqual } from '../utils';
 import { validateCaveatPaths, validatePath } from './getBip32Entropy';
 

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.test.ts
@@ -1,4 +1,5 @@
 import { SnapCaveatType } from '@metamask/snaps-utils';
+
 import {
   getBip44EntropyBuilder,
   getBip44EntropyCaveatMapper,

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -8,15 +8,15 @@ import {
   PermissionConstraint,
   RestrictedMethodCaveatSpecificationConstraint,
 } from '@metamask/controllers';
-import { ethErrors } from 'eth-rpc-errors';
 import { BIP44CoinTypeNode, JsonBIP44CoinTypeNode } from '@metamask/key-tree';
+import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   hasProperty,
   isPlainObject,
   Json,
   NonEmptyArray,
 } from '@metamask/utils';
-import { SnapCaveatType } from '@metamask/snaps-utils';
+import { ethErrors } from 'eth-rpc-errors';
 
 const targetKey = 'snap_getBip44Entropy';
 

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -1,16 +1,8 @@
 import { PermissionConstraint } from '@metamask/controllers';
 import { Json } from '@metamask/utils';
+
 import { confirmBuilder, ConfirmMethodHooks } from './confirm';
 import { dialogBuilder, DialogMethodHooks } from './dialog';
-import {
-  getBip44EntropyBuilder,
-  getBip44EntropyCaveatMapper,
-  getBip44EntropyCaveatSpecifications,
-  GetBip44EntropyMethodHooks,
-} from './getBip44Entropy';
-import { invokeSnapBuilder, InvokeSnapMethodHooks } from './invokeSnap';
-import { manageStateBuilder, ManageStateMethodHooks } from './manageState';
-import { notifyBuilder, NotifyMethodHooks } from './notify';
 import {
   getBip32EntropyBuilder,
   getBip32EntropyCaveatMapper,
@@ -21,6 +13,15 @@ import {
   getBip32PublicKeyBuilder,
   GetBip32PublicKeyMethodHooks,
 } from './getBip32PublicKey';
+import {
+  getBip44EntropyBuilder,
+  getBip44EntropyCaveatMapper,
+  getBip44EntropyCaveatSpecifications,
+  GetBip44EntropyMethodHooks,
+} from './getBip44Entropy';
+import { invokeSnapBuilder, InvokeSnapMethodHooks } from './invokeSnap';
+import { manageStateBuilder, ManageStateMethodHooks } from './manageState';
+import { notifyBuilder, NotifyMethodHooks } from './notify';
 
 export {
   AlertFields,

--- a/packages/rpc-methods/src/restricted/invokeSnap.test.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.test.ts
@@ -4,6 +4,7 @@ import {
   MOCK_ORIGIN,
   getTruncatedSnap,
 } from '@metamask/snaps-utils/test-utils';
+
 import { invokeSnapBuilder, getInvokeSnapImplementation } from './invokeSnap';
 
 describe('builder', () => {

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -4,8 +4,6 @@ import {
   ValidPermissionSpecification,
   PermissionType,
 } from '@metamask/controllers';
-import { isJsonRpcRequest, Json, NonEmptyArray } from '@metamask/utils';
-import { ethErrors } from 'eth-rpc-errors';
 import {
   Snap,
   SNAP_PREFIX,
@@ -13,6 +11,8 @@ import {
   HandlerType,
   SnapRpcHookArgs,
 } from '@metamask/snaps-utils';
+import { isJsonRpcRequest, Json, NonEmptyArray } from '@metamask/utils';
+import { ethErrors } from 'eth-rpc-errors';
 import { nanoid } from 'nanoid';
 
 const methodPrefix = SNAP_PREFIX;

--- a/packages/snaps-browserify-plugin/jest.config.js
+++ b/packages/snaps-browserify-plugin/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/snaps-browserify-plugin/src/plugin.test.ts
+++ b/packages/snaps-browserify-plugin/src/plugin.test.ts
@@ -1,16 +1,17 @@
 // Allow Jest snapshots because the test outputs are illegible.
 /* eslint-disable jest/no-restricted-matchers */
 
-import { Readable } from 'stream';
-import pathUtils from 'path';
-import os from 'os';
-import browserify, { Options as BrowserifyOptions } from 'browserify';
-import concat from 'concat-stream';
+import { checkManifest, evalBundle } from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
   getSnapManifest,
 } from '@metamask/snaps-utils/test-utils';
-import { checkManifest, evalBundle } from '@metamask/snaps-utils';
+import browserify, { Options as BrowserifyOptions } from 'browserify';
+import concat from 'concat-stream';
+import os from 'os';
+import pathUtils from 'path';
+import { Readable } from 'stream';
+
 import plugin, { Options, SnapsBrowserifyTransform } from './plugin';
 
 jest.mock('fs');

--- a/packages/snaps-browserify-plugin/src/plugin.ts
+++ b/packages/snaps-browserify-plugin/src/plugin.ts
@@ -1,15 +1,15 @@
-import { Transform, TransformCallback } from 'stream';
-import { promises as fs } from 'fs';
-import os from 'os';
-import pathUtils from 'path';
-import { BrowserifyObject } from 'browserify';
 import {
   checkManifest,
   evalBundle,
   postProcessBundle,
   PostProcessOptions,
 } from '@metamask/snaps-utils';
+import { BrowserifyObject } from 'browserify';
 import { fromSource } from 'convert-source-map';
+import { promises as fs } from 'fs';
+import os from 'os';
+import pathUtils from 'path';
+import { Transform, TransformCallback } from 'stream';
 
 const TEMP_BUNDLE_PATH = pathUtils.join(os.tmpdir(), 'snaps-bundle.js');
 

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/snaps-cli/scripts/computeSnapShasum.js
+++ b/packages/snaps-cli/scripts/computeSnapShasum.js
@@ -1,7 +1,7 @@
-const { readFileSync } = require('fs');
 // eslint-disable-next-line import/no-unresolved
 const { getSnapSourceShasum } = require('@metamask/snaps-utils');
 const clipboardy = require('clipboardy');
+const { readFileSync } = require('fs');
 const yargs = require('yargs');
 
 // eslint-disable-next-line no-unused-expressions

--- a/packages/snaps-cli/scripts/updateReadme.js
+++ b/packages/snaps-cli/scripts/updateReadme.js
@@ -1,6 +1,6 @@
+const execa = require('execa');
 const { promises: fs } = require('fs');
 const path = require('path');
-const execa = require('execa');
 
 // These magic strings correspond to the README.md file.
 const README_HEADING_1 = '## Usage\n\n```text\n';

--- a/packages/snaps-cli/src/cli.test.ts
+++ b/packages/snaps-cli/src/cli.test.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+
 import { cli } from './cli';
 import commands from './cmds';
 

--- a/packages/snaps-cli/src/cli.ts
+++ b/packages/snaps-cli/src/cli.ts
@@ -1,5 +1,6 @@
 import yargs, { Arguments } from 'yargs';
 import yargsType from 'yargs/yargs';
+
 import builders from './builders';
 import {
   applyConfig,

--- a/packages/snaps-cli/src/cmds/build/build.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.test.ts
@@ -1,9 +1,10 @@
-import path from 'path';
 import * as snapUtils from '@metamask/snaps-utils';
+import path from 'path';
+
+import buildModule from '.';
 import * as snapEvalModule from '../eval/evalHandler';
 import * as manifestModule from '../manifest/manifestHandler';
 import * as buildBundle from './bundle';
-import buildModule from '.';
 
 const build = buildModule.handler;
 

--- a/packages/snaps-cli/src/cmds/build/buildHandler.ts
+++ b/packages/snaps-cli/src/cmds/build/buildHandler.ts
@@ -4,10 +4,11 @@ import {
   validateFilePath,
   validateOutfileName,
 } from '@metamask/snaps-utils';
+
 import { YargsArgs } from '../../types/yargs';
 import { loadConfig } from '../../utils';
-import { manifestHandler } from '../manifest/manifestHandler';
 import { evalHandler } from '../eval/evalHandler';
+import { manifestHandler } from '../manifest/manifestHandler';
 import { bundle } from './bundle';
 
 /**

--- a/packages/snaps-cli/src/cmds/build/bundle.test.ts
+++ b/packages/snaps-cli/src/cmds/build/bundle.test.ts
@@ -1,4 +1,5 @@
 import browserify from 'browserify';
+
 import { TranspilationModes } from '../../builders';
 import { bundle } from './bundle';
 import * as bundleUtils from './utils';

--- a/packages/snaps-cli/src/cmds/build/bundle.ts
+++ b/packages/snaps-cli/src/cmds/build/bundle.ts
@@ -1,5 +1,6 @@
-import browserify, { BrowserifyObject } from 'browserify';
 import plugin, { Options } from '@metamask/snaps-browserify-plugin';
+import browserify, { BrowserifyObject } from 'browserify';
+
 import { TranspilationModes } from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { processDependencies, writeBundleFile } from './utils';

--- a/packages/snaps-cli/src/cmds/build/index.ts
+++ b/packages/snaps-cli/src/cmds/build/index.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+
 import builders from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { build } from './buildHandler';

--- a/packages/snaps-cli/src/cmds/build/utils.test.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+
 import { TranspilationModes } from '../../builders';
 import * as miscUtils from '../../utils/misc';
 import {

--- a/packages/snaps-cli/src/cmds/build/utils.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'fs';
-import { writeError } from '../../utils/misc';
-import { YargsArgs } from '../../types/yargs';
+
 import { TranspilationModes } from '../../builders';
+import { YargsArgs } from '../../types/yargs';
+import { writeError } from '../../utils/misc';
 
 type WriteBundleFileArgs = {
   bundleError: Error;

--- a/packages/snaps-cli/src/cmds/eval/evalHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/evalHandler.test.ts
@@ -1,4 +1,5 @@
 import { evalBundle } from '@metamask/snaps-utils';
+
 import { YargsArgs } from '../../types/yargs';
 import { evalHandler } from './evalHandler';
 

--- a/packages/snaps-cli/src/cmds/eval/evalHandler.ts
+++ b/packages/snaps-cli/src/cmds/eval/evalHandler.ts
@@ -1,4 +1,5 @@
 import { evalBundle } from '@metamask/snaps-utils';
+
 import { YargsArgs } from '../../types/yargs';
 import { logError } from '../../utils';
 

--- a/packages/snaps-cli/src/cmds/eval/index.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/index.test.ts
@@ -1,6 +1,6 @@
+import index from '.';
 import { YargsArgs } from '../../types/yargs';
 import { evalHandler } from './evalHandler';
-import index from '.';
 
 jest.mock('./evalHandler');
 

--- a/packages/snaps-cli/src/cmds/eval/index.ts
+++ b/packages/snaps-cli/src/cmds/eval/index.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+
 import builders from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { evalHandler } from './evalHandler';

--- a/packages/snaps-cli/src/cmds/init/index.ts
+++ b/packages/snaps-cli/src/cmds/init/index.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+
 import builders from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { build } from '../build/buildHandler';

--- a/packages/snaps-cli/src/cmds/init/init.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.test.ts
@@ -1,6 +1,6 @@
+import initModule from '.';
 import * as buildHandlerModule from '../build/buildHandler';
 import * as initHandlerModule from './initHandler';
-import initModule from '.';
 
 describe('init module', () => {
   it('console logs if successful', async () => {

--- a/packages/snaps-cli/src/cmds/init/initHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/init/initHandler.test.ts
@@ -1,12 +1,13 @@
-import { promises as fs } from 'fs';
-import pathUtils from 'path';
 import * as snapUtils from '@metamask/snaps-utils';
 import {
   getPackageJson,
   getSnapManifest,
 } from '@metamask/snaps-utils/test-utils';
-import { YargsArgs } from '../../types/yargs';
+import { promises as fs } from 'fs';
+import pathUtils from 'path';
+
 import { resetFileSystem } from '../../test-utils';
+import { YargsArgs } from '../../types/yargs';
 import { initHandler } from './initHandler';
 import * as initUtils from './initUtils';
 

--- a/packages/snaps-cli/src/cmds/init/initHandler.ts
+++ b/packages/snaps-cli/src/cmds/init/initHandler.ts
@@ -1,5 +1,3 @@
-import pathUtils from 'path';
-import { promises as fs } from 'fs';
 import {
   NpmSnapFileNames,
   SnapManifest,
@@ -7,6 +5,9 @@ import {
   satisfiesVersionRange,
   NpmSnapPackageJson,
 } from '@metamask/snaps-utils';
+import { promises as fs } from 'fs';
+import pathUtils from 'path';
+
 import { YargsArgs } from '../../types/yargs';
 import { logError } from '../../utils';
 import {

--- a/packages/snaps-cli/src/cmds/init/initUtils.test.ts
+++ b/packages/snaps-cli/src/cmds/init/initUtils.test.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
 import childProcess from 'child_process';
+import { promises as fs } from 'fs';
 import pathUtils from 'path';
 
 import { resetFileSystem } from '../../test-utils';

--- a/packages/snaps-cli/src/cmds/init/initUtils.ts
+++ b/packages/snaps-cli/src/cmds/init/initUtils.ts
@@ -1,6 +1,7 @@
-import { promises as fs } from 'fs';
 import { execSync } from 'child_process';
+import { promises as fs } from 'fs';
 import pathUtils from 'path';
+
 import { logError } from '../../utils';
 
 export const TEMPLATE_GIT_URL =

--- a/packages/snaps-cli/src/cmds/manifest/index.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/index.test.ts
@@ -1,6 +1,6 @@
+import index from '.';
 import { YargsArgs } from '../../types/yargs';
 import { manifestHandler } from './manifestHandler';
-import index from '.';
 
 jest.mock('./manifestHandler');
 

--- a/packages/snaps-cli/src/cmds/manifest/index.ts
+++ b/packages/snaps-cli/src/cmds/manifest/index.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+
 import builders from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { logError } from '../../utils';

--- a/packages/snaps-cli/src/cmds/manifest/manifestHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifestHandler.test.ts
@@ -1,4 +1,5 @@
 import { checkManifest, CheckManifestResult } from '@metamask/snaps-utils';
+
 import { YargsArgs } from '../../types/yargs';
 import { manifestHandler } from './manifestHandler';
 

--- a/packages/snaps-cli/src/cmds/manifest/manifestHandler.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifestHandler.ts
@@ -1,4 +1,5 @@
 import { checkManifest } from '@metamask/snaps-utils';
+
 import { YargsArgs } from '../../types/yargs';
 
 const ERROR_PREFIX = 'Manifest Error: ';

--- a/packages/snaps-cli/src/cmds/serve/index.ts
+++ b/packages/snaps-cli/src/cmds/serve/index.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+
 import builders from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { serve } from './serveHandler';

--- a/packages/snaps-cli/src/cmds/serve/serve.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.test.ts
@@ -1,10 +1,11 @@
+import * as snapUtils from '@metamask/snaps-utils';
 import EventEmitter from 'events';
 import http from 'http';
 import path from 'path';
 import serveHandler from 'serve-handler';
-import * as snapUtils from '@metamask/snaps-utils';
-import * as serveUtils from './serveUtils';
+
 import serve from '.';
+import * as serveUtils from './serveUtils';
 
 jest.mock('@metamask/snaps-utils', () => ({
   validateDirPath: jest.fn(),

--- a/packages/snaps-cli/src/cmds/serve/serveHandler.ts
+++ b/packages/snaps-cli/src/cmds/serve/serveHandler.ts
@@ -1,6 +1,7 @@
+import { validateDirPath } from '@metamask/snaps-utils';
 import http from 'http';
 import serveHandler from 'serve-handler';
-import { validateDirPath } from '@metamask/snaps-utils';
+
 import { YargsArgs } from '../../types/yargs';
 import { logRequest, logServerError, logServerListening } from './serveUtils';
 

--- a/packages/snaps-cli/src/cmds/watch/index.ts
+++ b/packages/snaps-cli/src/cmds/watch/index.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+
 import builders from '../../builders';
 import { YargsArgs } from '../../types/yargs';
 import { processInvalidTranspilation } from '../build/utils';

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.test.ts
@@ -1,13 +1,14 @@
-import EventEmitter from 'events';
-import path from 'path';
-import http from 'http';
-import chokidar from 'chokidar';
 import * as snapUtils from '@metamask/snaps-utils';
+import chokidar from 'chokidar';
+import EventEmitter from 'events';
+import http from 'http';
+import path from 'path';
+
+import watch from '.';
 import * as miscUtils from '../../utils/misc';
 import * as build from '../build/bundle';
 import * as evalModule from '../eval/evalHandler';
 import * as manifest from '../manifest/manifestHandler';
-import watch from '.';
 
 jest.mock('@metamask/snaps-utils', () => ({
   ...jest.requireActual('@metamask/snaps-utils'),

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.ts
@@ -1,10 +1,11 @@
-import chokidar from 'chokidar';
 import {
   getOutfilePath,
   validateDirPath,
   validateFilePath,
   validateOutfileName,
 } from '@metamask/snaps-utils';
+import chokidar from 'chokidar';
+
 import { YargsArgs } from '../../types/yargs';
 import { loadConfig, logError } from '../../utils';
 import { bundle } from '../build/bundle';

--- a/packages/snaps-cli/src/utils/misc.test.ts
+++ b/packages/snaps-cli/src/utils/misc.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import pathUtils from 'path';
+
 import {
   booleanStringToBoolean,
   trimPathString,

--- a/packages/snaps-cli/src/utils/misc.ts
+++ b/packages/snaps-cli/src/utils/misc.ts
@@ -1,6 +1,6 @@
+import { hasProperty } from '@metamask/utils';
 import { promises as filesystem } from 'fs';
 import path from 'path';
-import { hasProperty } from '@metamask/utils';
 import { Arguments } from 'yargs';
 
 export const permRequestKeys = [

--- a/packages/snaps-cli/src/utils/snap-config.test.ts
+++ b/packages/snaps-cli/src/utils/snap-config.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import builders from '../builders';
 import * as miscUtils from './misc';
 import { applyConfig, loadConfig, SnapConfig } from './snap-config';

--- a/packages/snaps-cli/src/utils/snap-config.ts
+++ b/packages/snaps-cli/src/utils/snap-config.ts
@@ -1,10 +1,11 @@
-import path from 'path';
 import { hasProperty } from '@metamask/utils';
 import type browserify from 'browserify';
+import path from 'path';
+import { object, optional, func, Infer, is } from 'superstruct';
 import { Arguments } from 'yargs';
 import yargsParse from 'yargs-parser';
 import yargs from 'yargs/yargs';
-import { object, optional, func, Infer, is } from 'superstruct';
+
 import builders from '../builders';
 import { CONFIG_FILE, logError } from './misc';
 

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.test.ts
@@ -10,6 +10,7 @@ import {
   getTruncatedSnap,
 } from '@metamask/snaps-utils/test-utils';
 import { Duration, inMilliseconds } from '@metamask/utils';
+
 import { SnapEndowments } from '../snaps';
 import {
   getRestrictedCronjobControllerMessenger,

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -12,6 +12,7 @@ import {
   parseCronExpression,
 } from '@metamask/snaps-utils';
 import { Duration, inMilliseconds } from '@metamask/utils';
+
 import {
   GetAllSnaps,
   getRunnableSnaps,

--- a/packages/snaps-controllers/src/fsm.test.ts
+++ b/packages/snaps-controllers/src/fsm.test.ts
@@ -1,6 +1,7 @@
 import { AssertionError } from '@metamask/utils';
 import { createMachine, interpret, StateMachine } from '@xstate/fsm';
 import { InitEvent } from '@xstate/fsm/lib/types';
+
 import { forceStrict, validateMachine } from './fsm';
 
 type Context = Record<string, never>;

--- a/packages/snaps-controllers/src/fsm.ts
+++ b/packages/snaps-controllers/src/fsm.ts
@@ -1,5 +1,5 @@
-import { assert } from '@metamask/utils';
 import { flatMap } from '@metamask/snaps-utils';
+import { assert } from '@metamask/utils';
 import {
   EventObject,
   InterpreterStatus,

--- a/packages/snaps-controllers/src/multichain/MultiChainController.test.ts
+++ b/packages/snaps-controllers/src/multichain/MultiChainController.test.ts
@@ -10,6 +10,7 @@ import {
   getSnapManifest,
   getPersistedSnapObject,
 } from '@metamask/snaps-utils/test-utils';
+
 import { SnapEndowments } from '../snaps';
 import {
   MOCK_CONNECT_ARGUMENTS,

--- a/packages/snaps-controllers/src/multichain/MultiChainController.ts
+++ b/packages/snaps-controllers/src/multichain/MultiChainController.ts
@@ -7,6 +7,7 @@ import {
   PermissionConstraint,
   RestrictedControllerMessenger,
 } from '@metamask/controllers';
+import { SnapKeyring } from '@metamask/snaps-types';
 import {
   parseAccountId,
   AccountId,
@@ -27,9 +28,9 @@ import {
   isAccountIdArray,
   Namespaces,
 } from '@metamask/snaps-utils';
-import { SnapKeyring } from '@metamask/snaps-types';
 import { hasProperty, assert } from '@metamask/utils';
 import { nanoid } from 'nanoid';
+
 import {
   GetAllSnaps,
   HandleSnapRequest,

--- a/packages/snaps-controllers/src/multichain/middleware.test.ts
+++ b/packages/snaps-controllers/src/multichain/middleware.test.ts
@@ -1,4 +1,5 @@
 import { JsonRpcEngine } from 'json-rpc-engine';
+
 import { createMultiChainMiddleware } from './middleware';
 
 describe('createMultiChainMiddleware', () => {

--- a/packages/snaps-controllers/src/multichain/middleware.ts
+++ b/packages/snaps-controllers/src/multichain/middleware.ts
@@ -1,16 +1,16 @@
 import {
-  createAsyncMiddleware,
-  JsonRpcMiddleware,
-  JsonRpcRequest,
-} from 'json-rpc-engine';
-import { assert } from '@metamask/utils';
-import {
   assertIsConnectArguments,
   assertIsMultiChainRequest,
   ConnectArguments,
   Session,
   MultiChainRequest,
 } from '@metamask/snaps-utils';
+import { assert } from '@metamask/utils';
+import {
+  createAsyncMiddleware,
+  JsonRpcMiddleware,
+  JsonRpcRequest,
+} from 'json-rpc-engine';
 
 /**
  * Creates a middleware that handles requests to the multichain controller.

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.test.ts
@@ -1,5 +1,6 @@
 import { ControllerMessenger } from '@metamask/controllers';
 import { HandlerType } from '@metamask/snaps-utils';
+
 import {
   ErrorMessageEvent,
   ExecutionServiceMessenger,

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -1,11 +1,10 @@
-import { Duplex } from 'stream';
 import ObjectMultiplex from '@metamask/object-multiplex';
+import { BasePostMessageStream } from '@metamask/post-message-stream';
 import {
   SnapRpcHook,
   SnapRpcHookArgs,
   SNAP_STREAM_NAMES,
 } from '@metamask/snaps-utils';
-
 import {
   Duration,
   isJsonRpcNotification,
@@ -18,10 +17,11 @@ import {
   JsonRpcRequest,
   PendingJsonRpcResponse,
 } from 'json-rpc-engine';
+import { createStreamMiddleware } from 'json-rpc-middleware-stream';
 import { nanoid } from 'nanoid';
 import pump from 'pump';
-import { createStreamMiddleware } from 'json-rpc-middleware-stream';
-import { BasePostMessageStream } from '@metamask/post-message-stream';
+import { Duplex } from 'stream';
+
 import { hasTimedOut, withTimeout } from '../utils';
 import {
   ExecutionService,

--- a/packages/snaps-controllers/src/services/ExecutionService.ts
+++ b/packages/snaps-controllers/src/services/ExecutionService.ts
@@ -1,6 +1,5 @@
 import { RestrictedControllerMessenger } from '@metamask/controllers';
 import { SnapId, SnapRpcHookArgs } from '@metamask/snaps-utils';
-
 import { Json } from '@metamask/types';
 
 type TerminateSnap = (snapId: string) => Promise<void>;

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.test.ts
@@ -1,10 +1,11 @@
 import { ControllerMessenger } from '@metamask/controllers';
+import { HandlerType } from '@metamask/snaps-utils';
 import { JsonRpcEngine } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
 import pump from 'pump';
-import { HandlerType } from '@metamask/snaps-utils';
-import { ErrorMessageEvent } from '../ExecutionService';
+
 import { setupMultiplex } from '../AbstractExecutionService';
+import { ErrorMessageEvent } from '../ExecutionService';
 import { IframeExecutionService } from './IframeExecutionService';
 import fixJSDOMPostMessageEventSource from './test/fixJSDOMPostMessageEventSource';
 import {

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
@@ -2,6 +2,7 @@ import {
   WindowPostMessageStream,
   BasePostMessageStream,
 } from '@metamask/post-message-stream';
+
 import {
   Job,
   AbstractExecutionService,

--- a/packages/snaps-controllers/src/services/node/NodeProcessExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/node/NodeProcessExecutionService.test.ts
@@ -3,8 +3,9 @@ import { HandlerType, SnapId } from '@metamask/snaps-utils';
 import { JsonRpcEngine } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
 import pump from 'pump';
-import { ErrorMessageEvent, SnapErrorJson } from '../ExecutionService';
+
 import { setupMultiplex } from '../AbstractExecutionService';
+import { ErrorMessageEvent, SnapErrorJson } from '../ExecutionService';
 import { NodeProcessExecutionService } from './NodeProcessExecutionService';
 
 const ON_RPC_REQUEST = HandlerType.OnRpcRequest;

--- a/packages/snaps-controllers/src/services/node/NodeProcessExecutionService.ts
+++ b/packages/snaps-controllers/src/services/node/NodeProcessExecutionService.ts
@@ -1,8 +1,9 @@
-import { ChildProcess, fork } from 'child_process';
 import {
   ProcessParentMessageStream,
   BasePostMessageStream,
 } from '@metamask/post-message-stream';
+import { ChildProcess, fork } from 'child_process';
+
 import { AbstractExecutionService, Job } from '..';
 
 export class NodeProcessExecutionService extends AbstractExecutionService<ChildProcess> {

--- a/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -3,8 +3,9 @@ import { HandlerType, SnapId } from '@metamask/snaps-utils';
 import { JsonRpcEngine } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
 import pump from 'pump';
-import { ErrorMessageEvent, SnapErrorJson } from '../ExecutionService';
+
 import { setupMultiplex } from '../AbstractExecutionService';
+import { ErrorMessageEvent, SnapErrorJson } from '../ExecutionService';
 import { NodeThreadExecutionService } from './NodeThreadExecutionService';
 
 const ON_RPC_REQUEST = HandlerType.OnRpcRequest;

--- a/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.ts
+++ b/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.ts
@@ -1,8 +1,9 @@
-import { Worker } from 'worker_threads';
 import {
   ThreadParentMessageStream,
   BasePostMessageStream,
 } from '@metamask/post-message-stream';
+import { Worker } from 'worker_threads';
+
 import { AbstractExecutionService, Job } from '..';
 
 export class NodeThreadExecutionService extends AbstractExecutionService<Worker> {

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -1,4 +1,3 @@
-import { Duplex } from 'stream';
 import passworder from '@metamask/browser-passworder';
 import {
   Caveat,
@@ -14,12 +13,6 @@ import {
   SnapStatus,
   SnapCaveatType,
 } from '@metamask/snaps-utils';
-import { Crypto } from '@peculiar/webcrypto';
-import { EthereumRpcError, ethErrors, serializeError } from 'eth-rpc-errors';
-import fetchMock from 'jest-fetch-mock';
-import { createAsyncMiddleware, JsonRpcEngine } from 'json-rpc-engine';
-import { createEngineStream } from 'json-rpc-middleware-stream';
-import pump from 'pump';
 import {
   getSnapManifest,
   getPersistedSnapObject,
@@ -31,8 +24,15 @@ import {
   DEFAULT_SNAP_BUNDLE,
   MOCK_LOCAL_SNAP_ID,
 } from '@metamask/snaps-utils/test-utils';
+import { Crypto } from '@peculiar/webcrypto';
+import { EthereumRpcError, ethErrors, serializeError } from 'eth-rpc-errors';
+import fetchMock from 'jest-fetch-mock';
+import { createAsyncMiddleware, JsonRpcEngine } from 'json-rpc-engine';
+import { createEngineStream } from 'json-rpc-middleware-stream';
+import pump from 'pump';
+import { Duplex } from 'stream';
+
 import { NodeThreadExecutionService, setupMultiplex } from '../services';
-import { delay } from '../utils';
 import {
   ExecutionEnvironmentStub,
   getControllerMessenger,
@@ -46,6 +46,7 @@ import {
   PERSISTED_MOCK_KEYRING_SNAP,
   MOCK_NAMESPACES,
 } from '../test-utils';
+import { delay } from '../utils';
 import { SnapEndowments } from './endowments';
 import { SNAP_APPROVAL_UPDATE, SnapControllerState } from './SnapController';
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -16,6 +16,7 @@ import {
   SubjectPermissions,
   ValidPermission,
 } from '@metamask/controllers';
+import { caveatMappers } from '@metamask/rpc-methods';
 import {
   DEFAULT_ENDOWMENTS,
   DEFAULT_REQUESTED_SNAP_VERSION,
@@ -68,7 +69,6 @@ import { ethErrors, serializeError } from 'eth-rpc-errors';
 import type { Patch } from 'immer';
 import { nanoid } from 'nanoid';
 
-import { caveatMappers } from '@metamask/rpc-methods';
 import { forceStrict, validateMachine } from '../fsm';
 import {
   ExecuteSnapAction,
@@ -81,9 +81,8 @@ import {
 import { hasTimedOut, setDiff, withTimeout } from '../utils';
 import { endowmentCaveatMappers, SnapEndowments } from './endowments';
 import { RequestQueue } from './RequestQueue';
-import { fetchNpmSnap } from './utils';
-
 import { Timer } from './Timer';
+import { fetchNpmSnap } from './utils';
 
 export const controllerName = 'SnapController';
 

--- a/packages/snaps-controllers/src/snaps/endowments/cronjob.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/cronjob.test.ts
@@ -1,12 +1,13 @@
 import { Caveat, PermissionType } from '@metamask/controllers';
 import { SnapCaveatType } from '@metamask/snaps-utils';
+
+import { SnapEndowments } from '.';
 import {
   getCronjobCaveatMapper,
   cronjobEndowmentBuilder,
   validateCronjobCaveat,
   cronjobCaveatSpecifications,
 } from './cronjob';
-import { SnapEndowments } from '.';
 
 describe('endowment:cronjob', () => {
   describe('specificationBuilder', () => {

--- a/packages/snaps-controllers/src/snaps/endowments/cronjob.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/cronjob.ts
@@ -8,18 +8,19 @@ import {
   CaveatSpecificationConstraint,
 } from '@metamask/controllers';
 import {
+  SnapCaveatType,
+  CronjobSpecification,
+  isCronjobSpecificationArray,
+} from '@metamask/snaps-utils';
+import {
   assert,
   hasProperty,
   isPlainObject,
   Json,
   NonEmptyArray,
 } from '@metamask/utils';
-import {
-  SnapCaveatType,
-  CronjobSpecification,
-  isCronjobSpecificationArray,
-} from '@metamask/snaps-utils';
 import { ethErrors } from 'eth-rpc-errors';
+
 import { SnapEndowments } from './enum';
 
 const permissionName = SnapEndowments.Cronjob;

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -1,18 +1,19 @@
 import { PermissionConstraint } from '@metamask/controllers';
 import { Json } from '@metamask/utils';
+
 import {
   cronjobCaveatSpecifications,
   cronjobEndowmentBuilder,
   getCronjobCaveatMapper,
 } from './cronjob';
-import { longRunningEndowmentBuilder } from './long-running';
-import { networkAccessEndowmentBuilder } from './network-access';
-import { transactionInsightEndowmentBuilder } from './transaction-insight';
 import {
   keyringEndowmentBuilder,
   keyringCaveatSpecifications,
   getKeyringCaveatMapper,
 } from './keyring';
+import { longRunningEndowmentBuilder } from './long-running';
+import { networkAccessEndowmentBuilder } from './network-access';
+import { transactionInsightEndowmentBuilder } from './transaction-insight';
 
 export const endowmentPermissionBuilders = {
   [networkAccessEndowmentBuilder.targetKey]: networkAccessEndowmentBuilder,

--- a/packages/snaps-controllers/src/snaps/endowments/keyring.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/keyring.test.ts
@@ -1,6 +1,7 @@
 import { PermissionConstraint, PermissionType } from '@metamask/controllers';
 import { SnapCaveatType } from '@metamask/snaps-utils';
 import { getNamespace } from '@metamask/snaps-utils/test-utils';
+
 import { SnapEndowments } from './enum';
 import {
   getKeyringCaveatNamespaces,

--- a/packages/snaps-controllers/src/snaps/endowments/keyring.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/keyring.ts
@@ -1,9 +1,4 @@
 import {
-  assertIsNamespacesObject,
-  Namespaces,
-  SnapCaveatType,
-} from '@metamask/snaps-utils';
-import {
   Caveat,
   CaveatSpecificationConstraint,
   EndowmentGetterParams,
@@ -14,6 +9,11 @@ import {
   ValidPermissionSpecification,
 } from '@metamask/controllers';
 import {
+  assertIsNamespacesObject,
+  Namespaces,
+  SnapCaveatType,
+} from '@metamask/snaps-utils';
+import {
   hasProperty,
   isPlainObject,
   Json,
@@ -21,6 +21,7 @@ import {
   assert,
 } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
+
 import { SnapEndowments } from './enum';
 
 const targetKey = SnapEndowments.Keyring;

--- a/packages/snaps-controllers/src/snaps/endowments/long-running.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/long-running.test.ts
@@ -1,6 +1,7 @@
 import { PermissionType } from '@metamask/controllers';
-import { longRunningEndowmentBuilder } from './long-running';
+
 import { SnapEndowments } from '.';
+import { longRunningEndowmentBuilder } from './long-running';
 
 describe('endowment:long-running', () => {
   it('builds the expected permission specification', () => {

--- a/packages/snaps-controllers/src/snaps/endowments/long-running.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/long-running.ts
@@ -4,6 +4,7 @@ import {
   EndowmentGetterParams,
   ValidPermissionSpecification,
 } from '@metamask/controllers';
+
 import { SnapEndowments } from './enum';
 
 const permissionName = SnapEndowments.LongRunning;

--- a/packages/snaps-controllers/src/snaps/endowments/network-access.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/network-access.test.ts
@@ -1,6 +1,7 @@
 import { PermissionType } from '@metamask/controllers';
-import { networkAccessEndowmentBuilder } from './network-access';
+
 import { SnapEndowments } from './enum';
+import { networkAccessEndowmentBuilder } from './network-access';
 
 describe('endowment:network-access', () => {
   it('builds the expected permission specification', () => {

--- a/packages/snaps-controllers/src/snaps/endowments/network-access.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/network-access.ts
@@ -4,6 +4,7 @@ import {
   PermissionType,
   ValidPermissionSpecification,
 } from '@metamask/controllers';
+
 import { SnapEndowments } from './enum';
 
 const permissionName = SnapEndowments.NetworkAccess;

--- a/packages/snaps-controllers/src/snaps/endowments/transaction-insight.test.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/transaction-insight.test.ts
@@ -1,6 +1,7 @@
 import { PermissionType } from '@metamask/controllers';
-import { transactionInsightEndowmentBuilder } from './transaction-insight';
+
 import { SnapEndowments } from '.';
+import { transactionInsightEndowmentBuilder } from './transaction-insight';
 
 describe('endowment:transaction-insight', () => {
   it('builds the expected permission specification', () => {

--- a/packages/snaps-controllers/src/snaps/endowments/transaction-insight.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/transaction-insight.ts
@@ -4,6 +4,7 @@ import {
   EndowmentGetterParams,
   ValidPermissionSpecification,
 } from '@metamask/controllers';
+
 import { SnapEndowments } from './enum';
 
 const permissionName = SnapEndowments.TransactionInsight;

--- a/packages/snaps-controllers/src/snaps/utils/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/utils/npm.test.ts
@@ -1,7 +1,8 @@
-import { readFile } from 'fs/promises';
 import { createReadStream } from 'fs';
-import path from 'path';
+import { readFile } from 'fs/promises';
 import fetchMock from 'jest-fetch-mock';
+import path from 'path';
+
 import { fetchNpmSnap } from './npm';
 
 describe('fetchNpmSnap', () => {

--- a/packages/snaps-controllers/src/snaps/utils/npm.ts
+++ b/packages/snaps-controllers/src/snaps/utils/npm.ts
@@ -1,6 +1,3 @@
-import { isObject } from '@metamask/utils';
-import pump from 'pump';
-import createGunzipStream from 'gunzip-maybe';
 import {
   SnapFiles,
   UnvalidatedSnapFiles,
@@ -8,6 +5,9 @@ import {
   getTargetVersion,
   validateNpmSnap,
 } from '@metamask/snaps-utils';
+import { isObject } from '@metamask/utils';
+import createGunzipStream from 'gunzip-maybe';
+import pump from 'pump';
 
 import { createTarballExtractionStream, getNodeStream } from './stream';
 

--- a/packages/snaps-controllers/src/snaps/utils/stream.ts
+++ b/packages/snaps-controllers/src/snaps/utils/stream.ts
@@ -1,13 +1,13 @@
-import { Readable, Writable } from 'stream';
-import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
-import { extract as tarExtract } from 'tar-stream';
-import concat from 'concat-stream';
-import { isObject } from '@metamask/utils';
 import {
   SnapManifest,
   NpmSnapFileNames,
   UnvalidatedSnapFiles,
 } from '@metamask/snaps-utils';
+import { isObject } from '@metamask/utils';
+import concat from 'concat-stream';
+import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
+import { Readable, Writable } from 'stream';
+import { extract as tarExtract } from 'tar-stream';
 
 // The paths of files within npm tarballs appear to always be prefixed with
 // "package/".

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -1,5 +1,10 @@
 import { ControllerMessenger } from '@metamask/controllers';
 import { getPersistedSnapObject } from '@metamask/snaps-utils/test-utils';
+
+import {
+  CronjobControllerActions,
+  CronjobControllerEvents,
+} from '../cronjob/CronjobController';
 import {
   AllowedActions,
   AllowedEvents,
@@ -10,10 +15,6 @@ import {
   SnapControllerEvents,
   SnapEndowments,
 } from '../snaps';
-import {
-  CronjobControllerActions,
-  CronjobControllerEvents,
-} from '../cronjob/CronjobController';
 import { getNodeEES, getNodeEESMessenger } from './execution-environment';
 
 export const getControllerMessenger = () =>

--- a/packages/snaps-controllers/src/test-utils/execution-environment.ts
+++ b/packages/snaps-controllers/src/test-utils/execution-environment.ts
@@ -1,8 +1,9 @@
 import { ControllerMessenger } from '@metamask/controllers';
+import { SnapRpcHookArgs } from '@metamask/snaps-utils';
 import { JsonRpcEngine } from 'json-rpc-engine';
 import { createEngineStream } from 'json-rpc-middleware-stream';
 import pump from 'pump';
-import { SnapRpcHookArgs } from '@metamask/snaps-utils';
+
 import {
   ExecutionService,
   ExecutionServiceActions,

--- a/packages/snaps-controllers/src/test-utils/multichain.ts
+++ b/packages/snaps-controllers/src/test-utils/multichain.ts
@@ -5,6 +5,7 @@ import {
   getSnapManifest,
   getPersistedSnapObject,
 } from '@metamask/snaps-utils/test-utils';
+
 import { SnapEndowments } from '..';
 import { MultiChainController } from '../multichain';
 import {

--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses';
-import { Duplex, DuplexOptions, EventEmitter, Readable } from 'stream';
+import { HandlerType } from '@metamask/snaps-utils';
 import {
   assertIsJsonRpcSuccess,
   Json,
@@ -8,7 +8,8 @@ import {
   JsonRpcRequest,
   JsonRpcResponse,
 } from '@metamask/utils';
-import { HandlerType } from '@metamask/snaps-utils';
+import { Duplex, DuplexOptions, EventEmitter, Readable } from 'stream';
+
 import { BaseSnapExecutor } from './BaseSnapExecutor';
 
 const FAKE_ORIGIN = 'origin:foo';

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -1,9 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference path="../../../../node_modules/ses/index.d.ts" />
-import { Duplex } from 'stream';
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { SnapProvider, SnapExports } from '@metamask/snaps-types';
-import { errorCodes, ethErrors, serializeError } from 'eth-rpc-errors';
+import {
+  HandlerType,
+  SNAP_EXPORT_NAMES,
+  SnapExportsParameters,
+} from '@metamask/snaps-utils';
 import {
   isObject,
   isValidJson,
@@ -16,22 +19,20 @@ import {
   Json,
   hasProperty,
 } from '@metamask/utils';
-import {
-  HandlerType,
-  SNAP_EXPORT_NAMES,
-  SnapExportsParameters,
-} from '@metamask/snaps-utils';
+import { errorCodes, ethErrors, serializeError } from 'eth-rpc-errors';
+import { Duplex } from 'stream';
 import { validate } from 'superstruct';
+
 import EEOpenRPCDocument from '../openrpc.json';
-import { createEndowments } from './endowments';
 import {
   getCommandMethodImplementations,
   CommandMethodsMapping,
 } from './commands';
+import { createEndowments } from './endowments';
 import { removeEventListener, addEventListener } from './globalEvents';
+import { wrapKeyring } from './keyring';
 import { sortParamKeys } from './sortParams';
 import { constructError, withTeardown } from './utils';
-import { wrapKeyring } from './keyring';
 import {
   ExecuteSnapRequestArgumentsStruct,
   PingRequestArgumentsStruct,

--- a/packages/snaps-execution-environments/src/common/commands.test.ts
+++ b/packages/snaps-execution-environments/src/common/commands.test.ts
@@ -1,5 +1,6 @@
 import { HandlerType } from '@metamask/snaps-utils';
 import { MOCK_ORIGIN } from '@metamask/snaps-utils/test-utils';
+
 import {
   CommandMethodsMapping,
   getCommandMethodImplementations,

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -1,5 +1,6 @@
-import { assertExhaustive } from '@metamask/utils';
 import { HandlerType } from '@metamask/snaps-utils';
+import { assertExhaustive } from '@metamask/utils';
+
 import { InvokeSnap, InvokeSnapArgs } from './BaseSnapExecutor';
 import {
   assertIsOnTransactionRequestArguments,

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -1,4 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
+
 import { createEndowments, isConstructor } from '.';
 
 describe('Endowment utils', () => {

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -1,10 +1,11 @@
 import { SnapProvider } from '@metamask/snaps-types';
 import { hasProperty } from '@metamask/utils';
+
 import { rootRealmGlobal } from '../globalObject';
+import crypto from './crypto';
 import interval from './interval';
 import network from './network';
 import timeout from './timeout';
-import crypto from './crypto';
 
 type EndowmentFactoryResult = {
   /**

--- a/packages/snaps-execution-environments/src/common/endowments/network.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/network.test.ts
@@ -1,5 +1,6 @@
 import fetchMock from 'jest-fetch-mock';
 import { Server as WebSocketServer } from 'mock-socket';
+
 import network from './network';
 
 describe('Network endowments', () => {

--- a/packages/snaps-execution-environments/src/common/validation.ts
+++ b/packages/snaps-execution-environments/src/common/validation.ts
@@ -1,5 +1,14 @@
-import { ChainIdStruct, HandlerType } from '@metamask/snaps-utils';
 import { SnapKeyring } from '@metamask/snaps-types';
+import { ChainIdStruct, HandlerType } from '@metamask/snaps-utils';
+import {
+  assertStruct,
+  Json,
+  JsonRpcIdStruct,
+  JsonRpcRequestStruct,
+  JsonRpcSuccess,
+  JsonRpcSuccessStruct,
+  JsonStruct,
+} from '@metamask/utils';
 import {
   array,
   assign,
@@ -16,15 +25,6 @@ import {
   union,
   unknown,
 } from 'superstruct';
-import {
-  assertStruct,
-  Json,
-  JsonRpcIdStruct,
-  JsonRpcRequestStruct,
-  JsonRpcSuccess,
-  JsonRpcSuccessStruct,
-  JsonStruct,
-} from '@metamask/utils';
 
 const VALIDATION_FUNCTIONS = {
   [HandlerType.OnRpcRequest]: validateFunctionExport,

--- a/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.test.ts
@@ -1,8 +1,9 @@
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses';
-import { EventEmitter } from 'stream';
-import { Json, JsonRpcSuccess } from '@metamask/utils';
 import { SNAP_STREAM_NAMES, HandlerType } from '@metamask/snaps-utils';
+import { Json, JsonRpcSuccess } from '@metamask/utils';
+import { EventEmitter } from 'stream';
+
 import { IFrameSnapExecutor } from './IFrameSnapExecutor';
 
 const FAKE_ORIGIN = 'origin:foo';

--- a/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.ts
@@ -1,7 +1,8 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
-import pump from 'pump';
 import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
+import pump from 'pump';
+
 import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
 
 export class IFrameSnapExecutor extends BaseSnapExecutor {

--- a/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.test.ts
@@ -1,8 +1,9 @@
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses';
-import { EventEmitter } from 'stream';
-import { Json, JsonRpcSuccess } from '@metamask/utils';
 import { SNAP_STREAM_NAMES, HandlerType } from '@metamask/snaps-utils';
+import { Json, JsonRpcSuccess } from '@metamask/utils';
+import { EventEmitter } from 'stream';
+
 import { ChildProcessSnapExecutor } from './ChildProcessSnapExecutor';
 
 const FAKE_ORIGIN = 'origin:foo';

--- a/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.ts
@@ -1,7 +1,8 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
-import pump from 'pump';
 import { ProcessMessageStream } from '@metamask/post-message-stream';
 import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
+import pump from 'pump';
+
 import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
 
 export class ChildProcessSnapExecutor extends BaseSnapExecutor {

--- a/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.test.ts
@@ -1,9 +1,10 @@
 // eslint-disable-next-line import/no-unassigned-import
 import 'ses';
+import { SNAP_STREAM_NAMES, HandlerType } from '@metamask/snaps-utils';
+import { Json, JsonRpcSuccess } from '@metamask/utils';
 import { EventEmitter } from 'stream';
 import { parentPort } from 'worker_threads';
-import { Json, JsonRpcSuccess } from '@metamask/utils';
-import { SNAP_STREAM_NAMES, HandlerType } from '@metamask/snaps-utils';
+
 import { ThreadSnapExecutor } from './ThreadSnapExecutor';
 
 const FAKE_ORIGIN = 'origin:foo';

--- a/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.ts
@@ -1,7 +1,8 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
-import pump from 'pump';
 import { ThreadMessageStream } from '@metamask/post-message-stream';
 import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
+import pump from 'pump';
+
 import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
 
 export class ThreadSnapExecutor extends BaseSnapExecutor {

--- a/packages/snaps-rollup-plugin/jest.config.js
+++ b/packages/snaps-rollup-plugin/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/snaps-rollup-plugin/src/plugin.test.ts
+++ b/packages/snaps-rollup-plugin/src/plugin.test.ts
@@ -1,11 +1,12 @@
-import { promises as fs } from 'fs';
-import virtual, { RollupVirtualOptions } from '@rollup/plugin-virtual';
-import { OutputOptions, rollup, RollupOutput } from 'rollup';
+import { checkManifest, evalBundle } from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
   getSnapManifest,
 } from '@metamask/snaps-utils/test-utils';
-import { checkManifest, evalBundle } from '@metamask/snaps-utils';
+import virtual, { RollupVirtualOptions } from '@rollup/plugin-virtual';
+import { promises as fs } from 'fs';
+import { OutputOptions, rollup, RollupOutput } from 'rollup';
+
 import snaps, { Options } from './plugin';
 
 jest.mock('fs');

--- a/packages/snaps-rollup-plugin/src/plugin.ts
+++ b/packages/snaps-rollup-plugin/src/plugin.ts
@@ -1,11 +1,11 @@
-import { promises as fs } from 'fs';
-import pathUtils from 'path';
 import {
   checkManifest,
   evalBundle,
   postProcessBundle,
   PostProcessOptions,
 } from '@metamask/snaps-utils';
+import { promises as fs } from 'fs';
+import pathUtils from 'path';
 import { Plugin, SourceMapInput } from 'rollup';
 
 type PluginOptions = {

--- a/packages/snaps-utils/jest.config.js
+++ b/packages/snaps-utils/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/snaps-utils/src/cronjob.ts
+++ b/packages/snaps-utils/src/cronjob.ts
@@ -1,4 +1,5 @@
 import { JsonRpcRequestStruct } from '@metamask/utils';
+import { parseExpression } from 'cron-parser';
 import {
   array,
   assign,
@@ -13,7 +14,6 @@ import {
   refine,
   string,
 } from 'superstruct';
-import { parseExpression } from 'cron-parser';
 
 export const CronjobRpcRequestStruct = assign(
   partial(pick(JsonRpcRequestStruct, ['id', 'jsonrpc'])),

--- a/packages/snaps-utils/src/eval-worker.ts
+++ b/packages/snaps-utils/src/eval-worker.ts
@@ -2,6 +2,7 @@
 import 'ses/lockdown';
 
 import { readFileSync } from 'fs';
+
 import { generateMockEndowments } from './mock';
 import { HandlerType, SNAP_EXPORT_NAMES } from './types';
 

--- a/packages/snaps-utils/src/eval.test.ts
+++ b/packages/snaps-utils/src/eval.test.ts
@@ -1,8 +1,9 @@
-import { join } from 'path';
-import { promises as fs } from 'fs';
 import childProcess from 'child_process';
-import { DEFAULT_SNAP_BUNDLE } from './test-utils';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
 import { evalBundle } from './eval';
+import { DEFAULT_SNAP_BUNDLE } from './test-utils';
 
 const WORKER_PATH = join(__dirname, 'eval-worker.ts');
 const TEMPORARY_FOLDER = join(__dirname, '__test__/temporary');

--- a/packages/snaps-utils/src/eval.ts
+++ b/packages/snaps-utils/src/eval.ts
@@ -1,5 +1,6 @@
-import { join } from 'path';
 import { fork } from 'child_process';
+import { join } from 'path';
+
 import { validateFilePath } from './fs';
 
 const WORKER_PATH = join(__dirname, 'eval-worker.js');

--- a/packages/snaps-utils/src/fs.test.ts
+++ b/packages/snaps-utils/src/fs.test.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import * as path from 'path';
+
 import {
   readSnapJsonFile,
   isDirectory,
@@ -11,8 +12,8 @@ import {
   validateFilePath,
   validateDirPath,
 } from './fs';
-import { NpmSnapFileNames, SnapManifest } from './types';
 import { DEFAULT_SNAP_BUNDLE, getSnapManifest } from './test-utils';
+import { NpmSnapFileNames, SnapManifest } from './types';
 
 jest.mock('fs');
 

--- a/packages/snaps-utils/src/fs.ts
+++ b/packages/snaps-utils/src/fs.ts
@@ -1,6 +1,7 @@
+import { Json } from '@metamask/utils';
 import { promises as fs } from 'fs';
 import pathUtils from 'path';
-import { Json } from '@metamask/utils';
+
 import { NpmSnapFileNames } from './types';
 
 /**

--- a/packages/snaps-utils/src/manifest.test.ts
+++ b/packages/snaps-utils/src/manifest.test.ts
@@ -1,18 +1,15 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
+
+import { readJsonFile } from './fs';
 import {
   checkManifest,
   fixManifest,
   getSnapSourceCode,
   getWritableManifest,
 } from './manifest';
-import {
-  NpmSnapFileNames,
-  SnapFiles,
-  SnapManifest,
-  SnapValidationFailureReason,
-} from './types';
-import { readJsonFile } from './fs';
+import * as npm from './npm';
+import { ProgrammaticallyFixableSnapError } from './snaps';
 import {
   DEFAULT_SNAP_BUNDLE,
   DEFAULT_SNAP_ICON,
@@ -20,8 +17,12 @@ import {
   getPackageJson,
   getSnapManifest,
 } from './test-utils';
-import { ProgrammaticallyFixableSnapError } from './snaps';
-import * as npm from './npm';
+import {
+  NpmSnapFileNames,
+  SnapFiles,
+  SnapManifest,
+  SnapValidationFailureReason,
+} from './types';
 
 jest.mock('fs');
 

--- a/packages/snaps-utils/src/manifest.ts
+++ b/packages/snaps-utils/src/manifest.ts
@@ -1,7 +1,11 @@
+import { Json } from '@metamask/utils';
 import { promises as fs } from 'fs';
 import pathUtils from 'path';
-import { Json } from '@metamask/utils';
+
+import { deepClone } from './deep-clone';
+import { readSnapJsonFile } from './fs';
 import { validateNpmSnap, validateNpmSnapManifest } from './npm';
+import { getSnapSourceShasum, ProgrammaticallyFixableSnapError } from './snaps';
 import {
   NpmSnapFileNames,
   SnapFiles,
@@ -9,9 +13,6 @@ import {
   SnapValidationFailureReason,
   UnvalidatedSnapFiles,
 } from './types';
-import { readSnapJsonFile } from './fs';
-import { getSnapSourceShasum, ProgrammaticallyFixableSnapError } from './snaps';
-import { deepClone } from './deep-clone';
 
 const MANIFEST_SORT_ORDER: Record<keyof SnapManifest, number> = {
   version: 1,

--- a/packages/snaps-utils/src/mock.test.ts
+++ b/packages/snaps-utils/src/mock.test.ts
@@ -1,5 +1,6 @@
-import { EventEmitter } from 'stream';
 import crypto from 'crypto';
+import { EventEmitter } from 'stream';
+
 import { generateMockEndowments, isConstructor } from './mock';
 
 describe('generateMockEndowments', () => {

--- a/packages/snaps-utils/src/mock.ts
+++ b/packages/snaps-utils/src/mock.ts
@@ -1,5 +1,6 @@
-import EventEmitter from 'events';
 import crypto from 'crypto';
+import EventEmitter from 'events';
+
 import { DEFAULT_ENDOWMENTS } from './default-endowments';
 
 const NETWORK_APIS = ['fetch', 'WebSocket'];

--- a/packages/snaps-utils/src/namespace.test.ts
+++ b/packages/snaps-utils/src/namespace.test.ts
@@ -1,10 +1,4 @@
 import {
-  getChain,
-  getNamespace,
-  getSessionNamespace,
-  getRequestNamespace,
-} from './test-utils';
-import {
   assertIsConnectArguments,
   assertIsMultiChainRequest,
   assertIsNamespacesObject,
@@ -20,6 +14,12 @@ import {
   parseAccountId,
   parseChainId,
 } from './namespace';
+import {
+  getChain,
+  getNamespace,
+  getSessionNamespace,
+  getRequestNamespace,
+} from './test-utils';
 
 describe('parseChainId', () => {
   it('parses valid chain ids', () => {

--- a/packages/snaps-utils/src/namespace.ts
+++ b/packages/snaps-utils/src/namespace.ts
@@ -1,4 +1,9 @@
 import {
+  JsonRpcRequestStruct,
+  AssertionErrorConstructor,
+  assertStruct,
+} from '@metamask/utils';
+import {
   array,
   Infer,
   is,
@@ -13,11 +18,6 @@ import {
   partial,
   pick,
 } from 'superstruct';
-import {
-  JsonRpcRequestStruct,
-  AssertionErrorConstructor,
-  assertStruct,
-} from '@metamask/utils';
 
 export const CHAIN_ID_REGEX =
   /^(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-a-zA-Z0-9]{1,32})$/u;

--- a/packages/snaps-utils/src/notification.ts
+++ b/packages/snaps-utils/src/notification.ts
@@ -1,5 +1,6 @@
-import { Infer, is, literal, object, string, unknown } from 'superstruct';
 import { assertStruct } from '@metamask/utils';
+import { Infer, is, literal, object, string, unknown } from 'superstruct';
+
 import { ChainIdStruct } from './namespace';
 
 export const EventStruct = object({

--- a/packages/snaps-utils/src/npm.ts
+++ b/packages/snaps-utils/src/npm.ts
@@ -1,4 +1,6 @@
 import deepEqual from 'fast-deep-equal';
+
+import { ProgrammaticallyFixableSnapError, validateSnapShasum } from './snaps';
 import {
   NpmSnapFileNames,
   SnapFiles,
@@ -9,7 +11,6 @@ import {
   NpmSnapPackageJson,
   SnapManifest,
 } from './types';
-import { ProgrammaticallyFixableSnapError, validateSnapShasum } from './snaps';
 
 export const SVG_MAX_BYTE_SIZE = 100_000;
 export const SVG_MAX_BYTE_SIZE_TEXT = `${Math.floor(

--- a/packages/snaps-utils/src/post-process.ts
+++ b/packages/snaps-utils/src/post-process.ts
@@ -1,3 +1,4 @@
+import { transformSync, Node, Visitor, template, PluginObj } from '@babel/core';
 import {
   binaryExpression,
   Expression,
@@ -7,7 +8,6 @@ import {
   templateElement,
   templateLiteral,
 } from '@babel/types';
-import { transformSync, Node, Visitor, template, PluginObj } from '@babel/core';
 
 /**
  * Source map declaration taken from `@babel/core`. Babel doesn't export the

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -2,6 +2,7 @@ import { Json } from '@metamask/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { base64 } from '@scure/base';
 import { SerializedEthereumRpcError } from 'eth-rpc-errors/dist/classes';
+
 import {
   SnapId,
   SnapIdPrefixes,

--- a/packages/snaps-utils/src/test-utils/manifest.ts
+++ b/packages/snaps-utils/src/test-utils/manifest.ts
@@ -1,10 +1,10 @@
-import { NpmSnapPackageJson, SnapManifest } from '../types';
 import {
   Chain,
   Namespace,
   RequestNamespace,
   SessionNamespace,
 } from '../namespace';
+import { NpmSnapPackageJson, SnapManifest } from '../types';
 import { DEFAULT_SNAP_SHASUM } from './snap';
 
 type GetSnapManifestOptions = Partial<Omit<SnapManifest, 'source'>> & {

--- a/packages/snaps-utils/src/types.test.ts
+++ b/packages/snaps-utils/src/types.test.ts
@@ -1,10 +1,10 @@
+import { getPackageJson, getSnapManifest } from './test-utils';
 import {
   assertIsNpmSnapPackageJson,
   assertIsSnapManifest,
   isNpmSnapPackageJson,
   isSnapManifest,
 } from './types';
-import { getPackageJson, getSnapManifest } from './test-utils';
 
 describe('isNpmSnapPackageJson', () => {
   it('returns true for a valid package.json', () => {

--- a/packages/snaps-utils/src/types.ts
+++ b/packages/snaps-utils/src/types.ts
@@ -3,6 +3,7 @@ import {
   SnapKeyring as Keyring,
 } from '@metamask/snaps-types';
 import { Json, assertStruct } from '@metamask/utils';
+import { valid as validSemver } from 'semver';
 import {
   any,
   Infer,
@@ -18,7 +19,6 @@ import {
   type,
   union,
 } from 'superstruct';
-import { valid as validSemver } from 'semver';
 
 export enum NpmSnapFileNames {
   PackageJson = 'package.json',

--- a/packages/snaps-webpack-plugin/jest.config.js
+++ b/packages/snaps-webpack-plugin/jest.config.js
@@ -1,4 +1,5 @@
 const deepmerge = require('deepmerge');
+
 const baseConfig = require('../../jest.config.base');
 
 module.exports = deepmerge(baseConfig, {

--- a/packages/snaps-webpack-plugin/src/plugin.test.ts
+++ b/packages/snaps-webpack-plugin/src/plugin.test.ts
@@ -1,14 +1,15 @@
 // Allow Jest snapshots because the test outputs are illegible.
 /* eslint-disable jest/no-restricted-matchers */
 
-import webpack, { Stats, Configuration } from 'webpack';
-import { createFsFromVolume, IFs, Volume } from 'memfs';
-import { IPromisesAPI } from 'memfs/lib/promises';
+import { checkManifest, evalBundle } from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
   getSnapManifest,
 } from '@metamask/snaps-utils/test-utils';
-import { checkManifest, evalBundle } from '@metamask/snaps-utils';
+import { createFsFromVolume, IFs, Volume } from 'memfs';
+import { IPromisesAPI } from 'memfs/lib/promises';
+import webpack, { Stats, Configuration } from 'webpack';
+
 import SnapsWebpackPlugin, { Options } from './plugin';
 
 jest.mock('@metamask/snaps-utils', () => ({

--- a/packages/snaps-webpack-plugin/src/plugin.ts
+++ b/packages/snaps-webpack-plugin/src/plugin.ts
@@ -1,5 +1,3 @@
-import pathUtils from 'path';
-import { promisify } from 'util';
 import {
   checkManifest,
   evalBundle,
@@ -8,6 +6,8 @@ import {
   SourceMap,
 } from '@metamask/snaps-utils';
 import { assert } from '@metamask/utils';
+import pathUtils from 'path';
+import { promisify } from 'util';
 import { Compiler, WebpackError } from 'webpack';
 import { RawSource, SourceMapSource } from 'webpack-sources';
 


### PR DESCRIPTION
For demonstrational purposes. We should do this in the shared ESLint config instead.