### PR TITLE
Remove `wallet_enable` from examples

### DIFF
--- a/packages/examples/examples/bls-signer/index.html
+++ b/packages/examples/examples/bls-signer/index.html
@@ -48,12 +48,10 @@
 
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
 

--- a/packages/examples/examples/browserify/index.html
+++ b/packages/examples/examples/browserify/index.html
@@ -46,12 +46,10 @@
     // here we get permissions to interact with and install the snap
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
 

--- a/packages/examples/examples/ethers-js/index.html
+++ b/packages/examples/examples/ethers-js/index.html
@@ -44,12 +44,10 @@
 
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
 

--- a/packages/examples/examples/insights/index.html
+++ b/packages/examples/examples/insights/index.html
@@ -99,12 +99,10 @@
     // here we get permissions to interact with and install the snap
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
   </script>

--- a/packages/examples/examples/ipfs/index.html
+++ b/packages/examples/examples/ipfs/index.html
@@ -60,12 +60,10 @@
 
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
 

--- a/packages/examples/examples/notifications/index.html
+++ b/packages/examples/examples/notifications/index.html
@@ -46,12 +46,10 @@
     // here we get permissions to interact with and install the snap
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
 

--- a/packages/examples/examples/rollup/src/index.ts
+++ b/packages/examples/examples/rollup/src/index.ts
@@ -21,12 +21,10 @@ sendNativeButton.addEventListener('click', () => send('native'));
  */
 async function connect() {
   await ethereum.request({
-    method: 'wallet_enable',
-    params: [
-      {
-        wallet_snap: { [snapId]: {} },
-      },
-    ],
+    method: 'wallet_requestSnaps',
+    params: {
+      [snapId]: {},
+    },
   });
 }
 

--- a/packages/examples/examples/typescript/index.html
+++ b/packages/examples/examples/typescript/index.html
@@ -43,12 +43,10 @@
     // here we get permissions to interact with and install the snap
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
 

--- a/packages/examples/examples/wasm/index.html
+++ b/packages/examples/examples/wasm/index.html
@@ -46,12 +46,10 @@
 
     async function connect() {
       await ethereum.request({
-        method: 'wallet_enable',
-        params: [
-          {
-            wallet_snap: { [snapId]: {} },
-          },
-        ],
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: {},
+        },
       });
     }
 

--- a/packages/examples/examples/webpack/src/index.ts
+++ b/packages/examples/examples/webpack/src/index.ts
@@ -21,12 +21,10 @@ sendNativeButton.addEventListener('click', () => send('native'));
  */
 async function connect() {
   await ethereum.request({
-    method: 'wallet_enable',
-    params: [
-      {
-        wallet_snap: { [snapId]: {} },
-      },
-    ],
+    method: 'wallet_requestSnaps',
+    params: {
+      [snapId]: {},
+    },
   });
 }
 

--- a/packages/rpc-methods/src/permitted/requestSnaps.test.ts
+++ b/packages/rpc-methods/src/permitted/requestSnaps.test.ts
@@ -70,7 +70,7 @@ describe('implementation', () => {
     const response = (await engine.handle({
       jsonrpc: '2.0',
       id: 1,
-      method: 'wallet_installSnaps',
+      method: 'wallet_requestSnaps',
       params: {
         [MOCK_SNAP_ID]: {},
       },
@@ -122,7 +122,7 @@ describe('implementation', () => {
     const response = (await engine.handle({
       jsonrpc: '2.0',
       id: 1,
-      method: 'wallet_installSnaps',
+      method: 'wallet_requestSnaps',
       params: {
         [MOCK_SNAP_ID]: {},
       },


### PR DESCRIPTION
Removes usage of `wallet_enable` from the examples.