### PR TITLE
BREAKING: Rename `snaps` global object to `snap`

### DIFF
--- a/packages/examples/.eslintrc.js
+++ b/packages/examples/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
       },
       globals: {
         ethereum: true,
-        snaps: true,
+        snap: true,
       },
       rules: {
         'no-alert': 'off',

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "miCH7djJ/dGwPije8HLyMJsmXkmjD1E5XJ4ZWIRJt48=",
+    "shasum": "ixIA4a4Yuk4obx/C6ZwX8wKeYh9pFZTNueB60O7l+rg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/bls-signer/src/index.js
+++ b/packages/examples/examples/bls-signer/src/index.js
@@ -32,7 +32,7 @@ module.exports.onRpcRequest = async ({ request }) => {
         throw rpcErrors.eth.unauthorized();
       }
 
-      const PRIVATE_KEY = await snaps.request({
+      const PRIVATE_KEY = await snap.request({
         method: 'snap_getEntropy',
         params: {
           version: 1,
@@ -53,7 +53,7 @@ module.exports.onRpcRequest = async ({ request }) => {
  * @returns {Promise<Uint8Array>} The BLS12-381 public key.
  */
 async function getPubKey() {
-  const PRIV_KEY = await snaps.request({
+  const PRIV_KEY = await snap.request({
     method: 'snap_getAppKey',
   });
   return bls.getPublicKey(PRIV_KEY);
@@ -70,7 +70,7 @@ async function getPubKey() {
  * and `false` otherwise.
  */
 async function promptUser(header, message) {
-  const response = await snaps.request({
+  const response = await snap.request({
     method: 'snap_confirm',
     params: [{ prompt: header, textAreaContent: message }],
   });

--- a/packages/examples/examples/browserify/snap.manifest.json
+++ b/packages/examples/examples/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "8+W9D201oiHmmRETMd+n4W7Qj8Q+NicMhFutRy7Wgm4=",
+    "shasum": "NOiOxPyR8Iu9y+I/6ziTImUC223pg/bLd6z9hRVrPtc=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/browserify/src/snap.ts
+++ b/packages/examples/examples/browserify/src/snap.ts
@@ -14,7 +14,7 @@ import { OnRpcRequestHandler } from '@metamask/snaps-types';
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {
@@ -24,7 +24,7 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
         ],
       });
     case 'native':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "VOyBi0w/CPD9GUbWssCYdqrJtaPG0Lnu6GhT2ZN1eiI=",
+    "shasum": "ZKh05KNz06P5GlNCYOuSUe3QQX6OuhSbMjH7RyCQmHo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ethers-js/src/index.js
+++ b/packages/examples/examples/ethers-js/src/index.js
@@ -18,7 +18,7 @@ const provider = new ethers.providers.Web3Provider(ethereum);
  */
 module.exports.onRpcRequest = async ({ request }) => {
   console.log('received request', request);
-  const privKey = await snaps.request({
+  const privKey = await snap.request({
     method: 'snap_getAppKey',
   });
   console.log(`privKey is ${privKey}`);

--- a/packages/examples/examples/notifications/snap.manifest.json
+++ b/packages/examples/examples/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "ShjN76CTBN8ByMf+CZ9A81rHcKg3VcpU/aDsC8HjFls=",
+    "shasum": "4aAg0VXdfByp6BWb6DuQo5Ui8rq+dx03/zuVgxp+KG4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/notifications/src/index.js
+++ b/packages/examples/examples/notifications/src/index.js
@@ -13,7 +13,7 @@
 module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {
@@ -23,7 +23,7 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
         ],
       });
     case 'native':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "lXWNW+zE94++8/TeAZ1stUKzoRe1ohLqJY4dUiS54QA=",
+    "shasum": "LLph+wooA1BT1BgEem4w2xzfocSKhSOcuQOyHnSNM/4=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/rollup/src/snap.ts
+++ b/packages/examples/examples/rollup/src/snap.ts
@@ -14,7 +14,7 @@ import { OnRpcRequestHandler } from '@metamask/snaps-types';
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {
@@ -24,7 +24,7 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
         ],
       });
     case 'native':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "s67hGX4eR3eMxlZIPN3C/M19HkeubAWpVID4HQvH2Ww=",
+    "shasum": "PFi6gpY6a3nVdQwkAvujHDe0hnFmdUKjS8bKMlM/qKs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -15,7 +15,7 @@ import { getMessage } from './message';
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'hello':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "IWOYjh6N3N8KUj08/0bjGsRHJQSNuJlMvt/3/cCNPBk=",
+    "shasum": "LMGtgd574bqP5aJQSJXJwgeOzB0sBaeJ6c8t9fkIdqM=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/webpack/src/snap.ts
+++ b/packages/examples/examples/webpack/src/snap.ts
@@ -14,7 +14,7 @@ import { OnRpcRequestHandler } from '@metamask/snaps-types';
 export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case 'inApp':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {
@@ -24,7 +24,7 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
         ],
       });
     case 'native':
-      return snaps.request({
+      return snap.request({
         method: 'snap_notify',
         params: [
           {

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -533,7 +533,7 @@ describe('BaseSnapExecutor', () => {
 
   it('reports when outbound requests are made using snap API', async () => {
     const CODE = `
-      module.exports.onRpcRequest = () => snaps.request({ method: 'wallet_getPermissions', params: [] });
+      module.exports.onRpcRequest = () => snap.request({ method: 'wallet_getPermissions', params: [] });
     `;
     const executor = new TestSnapExecutor();
 
@@ -637,7 +637,7 @@ describe('BaseSnapExecutor', () => {
 
   it('only allows certain methods in snap API', async () => {
     const CODE = `
-      module.exports.onRpcRequest = () => snaps.request({ method: 'eth_blockNumber', params: [] });
+      module.exports.onRpcRequest = () => snap.request({ method: 'eth_blockNumber', params: [] });
     `;
     const executor = new TestSnapExecutor();
 

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -30,7 +30,7 @@ describe('Endowment utils', () => {
         },
         teardown: expect.any(Function),
       });
-      expect(endowments.snaps).toBe(mockSnapAPI);
+      expect(endowments.snap).toBe(mockSnapAPI);
     });
 
     it('handles unattenuated endowments', () => {
@@ -130,7 +130,7 @@ describe('Endowment utils', () => {
         WebAssembly,
       });
 
-      expect(endowments.snaps).toBe(mockSnapAPI);
+      expect(endowments.snap).toBe(mockSnapAPI);
       expect(endowments.console).toBe(console);
       expect(endowments.Uint8Array).toBe(Uint8Array);
       expect(endowments.WebAssembly).toBe(WebAssembly);

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -1,7 +1,7 @@
 import fetchMock from 'jest-fetch-mock';
 import { createEndowments, isConstructor } from '.';
 
-const mockSnapsAPI = { foo: Symbol('bar') };
+const mockSnapAPI = { foo: Symbol('bar') };
 const mockEthereum = { foo: Symbol('bar') };
 
 describe('Endowment utils', () => {
@@ -18,30 +18,30 @@ describe('Endowment utils', () => {
 
     it('handles no endowments', () => {
       const { endowments } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
       );
 
       expect(
-        createEndowments(mockSnapsAPI as any, mockEthereum as any),
+        createEndowments(mockSnapAPI as any, mockEthereum as any),
       ).toStrictEqual({
         endowments: {
-          snaps: mockSnapsAPI,
+          snap: mockSnapAPI,
         },
         teardown: expect.any(Function),
       });
-      expect(endowments.snaps).toBe(mockSnapsAPI);
+      expect(endowments.snaps).toBe(mockSnapAPI);
     });
 
     it('handles unattenuated endowments', () => {
       const { endowments } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         ['Uint8Array', 'Date'],
       );
 
       expect(endowments).toStrictEqual({
-        snaps: mockSnapsAPI,
+        snap: mockSnapAPI,
         Uint8Array,
         Date,
       });
@@ -55,7 +55,7 @@ describe('Endowment utils', () => {
       };
       Object.assign(globalThis, { mockEndowment });
       const { endowments } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         ['Date', 'mockEndowment'],
       );
@@ -65,13 +65,13 @@ describe('Endowment utils', () => {
 
     it('handles factory endowments', () => {
       const { endowments } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         ['setTimeout'],
       );
 
       expect(endowments).toStrictEqual({
-        snaps: mockSnapsAPI,
+        snap: mockSnapAPI,
         setTimeout: expect.any(Function),
       });
       expect(endowments.setTimeout).not.toBe(setTimeout);
@@ -79,13 +79,13 @@ describe('Endowment utils', () => {
 
     it('handles some endowments from the same factory', () => {
       const { endowments } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         ['setTimeout'],
       );
 
       expect(endowments).toMatchObject({
-        snaps: mockSnapsAPI,
+        snap: mockSnapAPI,
         setTimeout: expect.any(Function),
       });
       expect(endowments.setTimeout).not.toBe(setTimeout);
@@ -93,13 +93,13 @@ describe('Endowment utils', () => {
 
     it('handles all endowments from the same factory', () => {
       const { endowments } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         ['setTimeout', 'clearTimeout'],
       );
 
       expect(endowments).toMatchObject({
-        snaps: mockSnapsAPI,
+        snap: mockSnapAPI,
         setTimeout: expect.any(Function),
         clearTimeout: expect.any(Function),
       });
@@ -108,7 +108,7 @@ describe('Endowment utils', () => {
 
     it('handles multiple endowments, factory and non-factory', () => {
       const { endowments } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         [
           'console',
@@ -121,7 +121,7 @@ describe('Endowment utils', () => {
       );
 
       expect(endowments).toMatchObject({
-        snaps: mockSnapsAPI,
+        snap: mockSnapAPI,
         console,
         Uint8Array,
         Math: expect.any(Object),
@@ -130,7 +130,7 @@ describe('Endowment utils', () => {
         WebAssembly,
       });
 
-      expect(endowments.snaps).toBe(mockSnapsAPI);
+      expect(endowments.snaps).toBe(mockSnapAPI);
       expect(endowments.console).toBe(console);
       expect(endowments.Uint8Array).toBe(Uint8Array);
       expect(endowments.WebAssembly).toBe(WebAssembly);
@@ -142,13 +142,13 @@ describe('Endowment utils', () => {
 
     it('throws for unknown endowments', () => {
       expect(() =>
-        createEndowments(mockSnapsAPI as any, mockEthereum as any, ['foo']),
+        createEndowments(mockSnapAPI as any, mockEthereum as any, ['foo']),
       ).toThrow('Unknown endowment: "foo"');
     });
 
     it('teardown calls all teardown functions', () => {
       const { endowments, teardown } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
       );
@@ -175,7 +175,7 @@ describe('Endowment utils', () => {
       expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
       expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
       expect(endowments).toMatchObject({
-        snaps: mockSnapsAPI,
+        snap: mockSnapAPI,
         setTimeout: expect.any(Function),
         clearTimeout: expect.any(Function),
         setInterval: expect.any(Function),
@@ -185,7 +185,7 @@ describe('Endowment utils', () => {
 
     it('teardown can be called multiple times', async () => {
       const { endowments, teardown } = createEndowments(
-        mockSnapsAPI as any,
+        mockSnapAPI as any,
         mockEthereum as any,
         ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
       );

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -43,13 +43,13 @@ const endowmentFactories = [timeout, interval, network, crypto, math].reduce(
  * such attenuated / modified endowments. Otherwise, the value that's on the
  * root realm global will be used.
  *
- * @param snaps - The Snaps global API object.
+ * @param snap - The Snaps global API object.
  * @param ethereum - The Snap's EIP-1193 provider object.
  * @param endowments - The list of endowments to provide to the snap.
  * @returns An object containing the Snap's endowments.
  */
 export function createEndowments(
-  snaps: SnapsGlobalObject,
+  snap: SnapsGlobalObject,
   ethereum: StreamProvider,
   endowments: string[] = [],
 ): { endowments: Record<string, unknown>; teardown: () => Promise<void> } {
@@ -101,7 +101,7 @@ export function createEndowments(
       return { allEndowments, teardowns };
     },
     {
-      allEndowments: { snaps } as Record<string, unknown>,
+      allEndowments: { snap } as Record<string, unknown>,
       teardowns: [] as (() => void)[],
     },
   );

--- a/packages/snaps-types/global.d.ts
+++ b/packages/snaps-types/global.d.ts
@@ -4,5 +4,5 @@ import { SnapsGlobalObject } from './src';
 // Types that should be available globally within a Snap
 declare global {
   const ethereum: MetaMaskInpageProvider;
-  const snaps: SnapsGlobalObject;
+  const snap: SnapsGlobalObject;
 }

--- a/packages/snaps-utils/src/mock.test.ts
+++ b/packages/snaps-utils/src/mock.test.ts
@@ -5,7 +5,7 @@ import { generateMockEndowments, isConstructor } from './mock';
 describe('generateMockEndowments', () => {
   it('includes mock snap API', async () => {
     const endowments = generateMockEndowments();
-    expect(await endowments.snaps.request()).toBe(true);
+    expect(await endowments.snap.request()).toBe(true);
   });
 
   it('includes mock ethereum provider', async () => {

--- a/packages/snaps-utils/src/mock.ts
+++ b/packages/snaps-utils/src/mock.ts
@@ -19,7 +19,7 @@ type MockEthereumProvider = EventEmitter & {
  *
  * @returns A mocked snap provider.
  */
-function getMockSnapsGlobal(): MockSnapGlobal {
+function getMockSnapGlobal(): MockSnapGlobal {
   return { request: async () => true };
 }
 
@@ -117,6 +117,6 @@ const generateMockEndowment = (key: string) => {
 export const generateMockEndowments = () => {
   return ALL_APIS.reduce<Record<string, any>>(
     (acc, cur) => ({ ...acc, [cur]: generateMockEndowment(cur) }),
-    { snaps: getMockSnapsGlobal(), ethereum: getMockEthereumProvider() },
+    { snap: getMockSnapGlobal(), ethereum: getMockEthereumProvider() },
   );
 };


### PR DESCRIPTION
As per request of @rekmarks we are renaming `snaps` to `snap`.