### PR TITLE
Fix `snap_getBip32PublicKey` manifest validation

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -5,10 +5,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 88.05,
-      functions: 89.65,
-      lines: 84.11,
-      statements: 84.11,
+      branches: 87.41,
+      functions: 87.27,
+      lines: 83.36,
+      statements: 83.36,
     },
   },
   testTimeout: 2500,

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -165,6 +165,26 @@ describe('getBip32EntropyCaveatSpecifications', () => {
       ).toBe('foo');
     });
 
+    it('ignores unknown fields', async () => {
+      const fn = jest.fn().mockImplementation(() => 'foo');
+
+      expect(
+        await getBip32EntropyCaveatSpecifications[
+          SnapCaveatType.PermittedDerivationPaths
+        ].decorator(fn, {
+          type: SnapCaveatType.PermittedDerivationPaths,
+          value: [params],
+          // @ts-expect-error Missing other required properties.
+        })({
+          params: {
+            path: ['m', "44'", "60'", "0'", '0', '1'],
+            curve: 'secp256k1',
+            compressed: true,
+          },
+        }),
+      ).toBe('foo');
+    });
+
     it('throws if the path is invalid', async () => {
       const fn = jest.fn().mockImplementation(() => 'foo');
 

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.test.ts
@@ -1,7 +1,5 @@
-import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   getBip32PublicKeyBuilder,
-  getBip32PublicKeyCaveatSpecifications,
   getBip32PublicKeyImplementation,
 } from './getBip32PublicKey';
 
@@ -41,73 +39,6 @@ describe('specificationBuilder', () => {
           ],
         }),
       ).toThrow('Expected a single "permittedDerivationPaths" caveat.');
-    });
-  });
-});
-
-describe('getBip32PublicKeyCaveatSpecifications', () => {
-  describe('decorator', () => {
-    const params = { path: ['m', "44'", "60'"], curve: 'secp256k1' };
-
-    it('returns the result of the method implementation', async () => {
-      const fn = jest.fn().mockImplementation(() => 'foo');
-
-      expect(
-        await getBip32PublicKeyCaveatSpecifications[
-          SnapCaveatType.PermittedDerivationPaths
-        ].decorator(fn, {
-          type: SnapCaveatType.PermittedDerivationPaths,
-          value: [params],
-          // @ts-expect-error Missing other required properties.
-        })({ params }),
-      ).toBe('foo');
-    });
-
-    it('throws if the path is invalid', async () => {
-      const fn = jest.fn().mockImplementation(() => 'foo');
-
-      await expect(
-        getBip32PublicKeyCaveatSpecifications[
-          SnapCaveatType.PermittedDerivationPaths
-        ].decorator(fn, {
-          type: SnapCaveatType.PermittedDerivationPaths,
-          value: [params],
-          // @ts-expect-error Missing other required properties.
-        })({ params: { ...params, path: [] } }),
-      ).rejects.toThrow(
-        'Invalid BIP-32 public key path definition: At path: path -- Path must be a non-empty BIP-32 derivation path array.',
-      );
-    });
-
-    it('throws if the path is not specified in the caveats', async () => {
-      const fn = jest.fn().mockImplementation(() => 'foo');
-
-      await expect(
-        getBip32PublicKeyCaveatSpecifications[
-          SnapCaveatType.PermittedDerivationPaths
-        ].decorator(fn, {
-          type: SnapCaveatType.PermittedDerivationPaths,
-          value: [params],
-          // @ts-expect-error Missing other required properties.
-        })({ params: { ...params, path: ['m', "44'", "0'"] } }),
-      ).rejects.toThrow(
-        'The requested path is not permitted. Allowed paths must be specified in the snap manifest.',
-      );
-    });
-  });
-
-  describe('validator', () => {
-    it('throws if the caveat values are invalid', () => {
-      expect(() =>
-        getBip32PublicKeyCaveatSpecifications[
-          SnapCaveatType.PermittedDerivationPaths
-        ].validator?.({
-          type: SnapCaveatType.PermittedDerivationPaths,
-          value: [{ path: ['foo'], curve: 'secp256k1' }],
-        }),
-      ).toThrow(
-        'Invalid BIP-32 public key caveat: At path: value.0.path -- Path must start with "m".',
-      );
     });
   });
 });

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -128,7 +128,7 @@ export const bip32entropy = <T extends { path: string[]; curve: string }, S>(
 
 // Used outside @metamask/snap-utils
 export const Bip32EntropyStruct = bip32entropy(
-  object({
+  type({
     path: Bip32PathStruct,
     curve: enums(['ed25519', 'secp256k1']),
   }),

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -112,7 +112,7 @@ export const Bip32PathStruct = refine(
   },
 );
 
-const bip32entropy = <T extends { path: string[]; curve: string }, S>(
+export const bip32entropy = <T extends { path: string[]; curve: string }, S>(
   struct: Struct<T, S>,
 ) =>
   refine(struct, 'BIP-32 entropy', (value) => {
@@ -136,17 +136,13 @@ export const Bip32EntropyStruct = bip32entropy(
 
 export type Bip32Entropy = Infer<typeof Bip32EntropyStruct>;
 
-export const Bip32PublicKeyStruct = bip32entropy(
-  object({
-    path: Bip32PathStruct,
-    curve: enums(['ed225519', 'secp256k1']),
-    compressed: optional(boolean()),
-  }),
+export const SnapGetBip32EntropyPermissionsStruct = size(
+  array(Bip32EntropyStruct),
+  1,
+  Infinity,
 );
 
-export type Bip32PublicKey = Infer<typeof Bip32PublicKeyStruct>;
-
-const PermissionsStruct = type({
+export const PermissionsStruct = type({
   'endowment:long-running': optional(object({})),
   'endowment:network-access': optional(object({})),
   'endowment:transaction-insight': optional(
@@ -160,10 +156,8 @@ const PermissionsStruct = type({
   snap_confirm: optional(object({})),
   snap_manageState: optional(object({})),
   snap_notify: optional(object({})),
-  snap_getBip32Entropy: optional(size(array(Bip32EntropyStruct), 1, Infinity)),
-  snap_getBip32PublicKey: optional(
-    size(array(Bip32PublicKeyStruct), 1, Infinity),
-  ),
+  snap_getBip32Entropy: optional(SnapGetBip32EntropyPermissionsStruct),
+  snap_getBip32PublicKey: optional(SnapGetBip32EntropyPermissionsStruct),
   snap_getBip44Entropy: optional(
     size(
       array(object({ coinType: size(integer(), 0, 2 ** 32 - 1) })),


### PR DESCRIPTION
`snap_getBip32PublicKey` and `snap_getBip32Entropy` use the same caveat, meaning that the permissions in the Snap manifest should be validated the same. Before, we would validate the `snap_getBip32PublicKey` JSON-RPC params, rather than the caveat.