### PR TITLE
Simplify reduce types in some files

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -580,7 +580,6 @@ function truncateSnap(snap: Snap): TruncatedSnap {
       }
 
       return serialized;
-      // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
     },
     {},
   );

--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -8,8 +8,8 @@ module.exports = deepmerge(baseConfig, {
     global: {
       branches: 89.78,
       functions: 90.51,
-      lines: 88.47,
-      statements: 88.47,
+      lines: 88.46,
+      statements: 88.46,
     },
   },
   testEnvironment: '<rootDir>/jest.environment.js',

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "jest && yarn posttest",
-    "posttest": "jest-it-up",
+    "posttest": "jest-it-up --margin 0.25",
     "test:ci": "yarn test",
     "test:watch": "jest --watch",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/packages/snaps-execution-environments/src/common/endowments/math.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.ts
@@ -14,15 +14,13 @@ function createMath() {
     rootRealmGlobal.Math,
   ) as (keyof typeof Math)[];
 
-  const math = keys.reduce<Math>((target, key) => {
+  const math = keys.reduce<Partial<Math>>((target, key) => {
     if (key === 'random') {
       return target;
     }
 
     return { ...target, [key]: rootRealmGlobal.Math[key] };
-    // It seems like there is an issue with the reduce type
-    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-  }, {} as Math);
+  }, {});
 
   return {
     Math: {

--- a/packages/snaps-utils/jest.config.js
+++ b/packages/snaps-utils/jest.config.js
@@ -14,10 +14,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 93.45,
-      functions: 95.45,
-      lines: 98.34,
-      statements: 98.34,
+      branches: 94.08,
+      functions: 96.55,
+      lines: 98.64,
+      statements: 98.64,
     },
   },
   testTimeout: 2500,

--- a/packages/snaps-utils/src/manifest/manifest.test.ts
+++ b/packages/snaps-utils/src/manifest/manifest.test.ts
@@ -1,3 +1,4 @@
+import { fromEntries } from '@metamask/snaps-utils';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
@@ -272,20 +273,9 @@ describe('getSnapSourceCode', () => {
 describe('getWritableManifest', () => {
   it('sorts the manifest keys', () => {
     // This reverses the order of the keys in the manifest.
-    // TODO: Replace `reduce` with `Object.fromEntries` when we support ES2019
-    // or higher.
-    const manifest = Object.entries(getSnapManifest())
-      .reverse()
-      .reduce<SnapManifest>(
-        (target, [key, value]) => ({
-          ...target,
-          [key]: value,
-        }),
-        // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-        {} as SnapManifest,
-      );
+    const manifest = fromEntries(Object.entries(getSnapManifest()).reverse());
 
-    const writableManifest = getWritableManifest(manifest);
+    const writableManifest = getWritableManifest(manifest as SnapManifest);
     expect(Object.keys(writableManifest)).toStrictEqual(
       Object.keys(getSnapManifest()),
     );

--- a/packages/snaps-utils/src/manifest/manifest.ts
+++ b/packages/snaps-utils/src/manifest/manifest.ts
@@ -272,16 +272,17 @@ export function getWritableManifest(manifest: SnapManifest): SnapManifest {
     repository ? { ...remaining, repository } : remaining,
   ) as (keyof SnapManifest)[];
 
-  return keys
+  const writableManifest = keys
     .sort((a, b) => MANIFEST_SORT_ORDER[a] - MANIFEST_SORT_ORDER[b])
-    .reduce<SnapManifest>(
+    .reduce<Partial<SnapManifest>>(
       (result, key) => ({
         ...result,
         [key]: manifest[key],
       }),
-      // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-      {} as SnapManifest,
+      {},
     );
+
+  return writableManifest as SnapManifest;
 }
 
 /**

--- a/packages/snaps-utils/src/object.ts
+++ b/packages/snaps-utils/src/object.ts
@@ -8,9 +8,8 @@
 export const fromEntries = <Key extends string, Value>(
   entries: readonly (readonly [Key, Value])[],
 ): Record<Key, Value> => {
-  return entries.reduce<Record<Key, Value>>(
+  return entries.reduce<Record<string, Value>>(
     (acc, [key, value]) => ({ ...acc, [key]: value }),
-    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
-    {} as Record<Key, Value>,
+    {},
   );
 };


### PR DESCRIPTION
This is based on some suggestions from @Gudahtt. It simplifies the reducer types in some files, and removes the need for disabling an ESLint rule.