### PR TITLE
Validate local snap URL protocols

### DIFF
--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,7 +5,7 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 88.85,
+      branches: 89.25,
       functions: 96.58,
       lines: 96.74,
       statements: 96.74,

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -7,7 +7,19 @@ import { SnapManifest, SnapPermissions } from './manifest/validation';
 import { SnapId, SnapIdPrefixes, SnapValidationFailureReason } from './types';
 import { SemVerVersion } from './versions';
 
+/**
+ * Supported URL protocols for locally hosted snaps.
+ */
+export const LOCALHOST_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * Supported URL hostnames for locally hosted snaps.
+ */
 export const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+/**
+ * The prefix of the Snap restricted RPC method / permission.
+ */
 export const SNAP_PREFIX = 'wallet_snap_';
 
 export const SNAP_PREFIX_REGEX = new RegExp(`^${SNAP_PREFIX}`, 'u');


### PR DESCRIPTION
This PR ensures that we only accept `http:` or `https:` as the URL protocols for locally hosted snaps. New test cases are added for snap installs and updates.