### PR TITLE
Add transaction origin caveat export

### DIFF
--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -6,7 +6,7 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 88.74,
-      functions: 97.6,
+      functions: 97.23,
       lines: 97.1,
       statements: 97.1,
     },

--- a/packages/snaps-controllers/src/snaps/endowments/index.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/index.ts
@@ -64,3 +64,4 @@ export const handlerEndowments: Record<HandlerType, string> = {
 };
 
 export * from './enum';
+export { getTransactionOriginCaveat } from './transaction-insight';


### PR DESCRIPTION
Adds a missing export for `getTransactionOriginCaveat` which will be used in the extension.