### PR TITLE
BREAKING: Improve request function types

### DIFF
--- a/packages/examples/examples/browserify/snap.manifest.json
+++ b/packages/examples/examples/browserify/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "Hx+79HmBz916t/x2uScg/n005bx+Xp1byWFqdFDWfAE=",
+    "shasum": "QHf/OS15pdI/PtbcaQtrjQKOQtxr9V62SzOF2AUrYj0=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/browserify/src/snap.ts
+++ b/packages/examples/examples/browserify/src/snap.ts
@@ -19,22 +19,18 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
     case 'inApp':
       return await snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'inApp',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'inApp',
+          message: `Hello, ${origin}!`,
+        },
       });
     case 'native':
       return await snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'native',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'native',
+          message: `Hello, ${origin}!`,
+        },
       });
     default:
       throw new Error('Method not found.');

--- a/packages/examples/examples/notifications/snap.manifest.json
+++ b/packages/examples/examples/notifications/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "k/ktrtOqQdF4qXoNuTc62BrGV+8nAFma7PtbwGxjjpg=",
+    "shasum": "PEjzfljvghGn9QX1S+0sGrMgfHxEnjT2L5xBh9Ed3Co=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/notifications/src/index.js
+++ b/packages/examples/examples/notifications/src/index.js
@@ -15,22 +15,18 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
     case 'inApp':
       return snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'inApp',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'inApp',
+          message: `Hello, ${origin}!`,
+        },
       });
     case 'native':
       return snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'native',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'native',
+          message: `Hello, ${origin}!`,
+        },
       });
     default:
       throw new Error('Method not found.');

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "0Kt0PQ1FCJdAni2Q3cLuhzcdubgAbG1VKGJB5Zu0Rbg=",
+    "shasum": "10RojruUEQUz+NIly9O6R9tpRUdpWqpOYFxdFpdI2MA=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/rollup/src/snap.ts
+++ b/packages/examples/examples/rollup/src/snap.ts
@@ -19,22 +19,18 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
     case 'inApp':
       return await snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'inApp',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'inApp',
+          message: `Hello, ${origin}!`,
+        },
       });
     case 'native':
       return await snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'native',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'native',
+          message: `Hello, ${origin}!`,
+        },
       });
     default:
       throw new Error('Method not found.');

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "qYeRR9ENHOBK6j6nYdtKLMpxoqeVTA/gAuAlP7tCno8=",
+    "shasum": "9o9f/7QeVFoyhJCjqOf9vtDIL/qbJrU1XdBiyr/Hs5g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -21,12 +21,10 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
     case 'hello':
       return await snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'inapp',
-            message: getMessage(origin),
-          },
-        ],
+        params: {
+          type: 'inapp',
+          message: getMessage(origin),
+        },
       });
     default:
       throw new Error('Method not found.');

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "9Z1sUgza3qoPYgcWVaTeqK4q5+S/cixt/Ddh2haiLlw=",
+    "shasum": "NFJs3m1wVooT9Ykknuh9iCWCVhnIOsBUg6ZrDk5zllM=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/webpack/src/snap.ts
+++ b/packages/examples/examples/webpack/src/snap.ts
@@ -19,22 +19,18 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
     case 'inApp':
       return await snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'inApp',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'inApp',
+          message: `Hello, ${origin}!`,
+        },
       });
     case 'native':
       return await snap.request({
         method: 'snap_notify',
-        params: [
-          {
-            type: 'native',
-            message: `Hello, ${origin}!`,
-          },
-        ],
+        params: {
+          type: 'native',
+          message: `Hello, ${origin}!`,
+        },
       });
     default:
       throw new Error('Method not found.');

--- a/packages/rpc-methods/.eslintrc.js
+++ b/packages/rpc-methods/.eslintrc.js
@@ -1,6 +1,20 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
 
+  overrides: [
+    {
+      files: ['**/*test.ts'],
+      rules: {
+        'jest/expect-expect': [
+          'error',
+          {
+            assertFunctionNames: ['expect', 'expectTypeOf'],
+          },
+        ],
+      },
+    },
+  ],
+
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 75.18,
-      functions: 87.5,
-      lines: 88.61,
-      statements: 88.26,
+      branches: 74.81,
+      functions: 87.32,
+      lines: 88.55,
+      statements: 88.2,
     },
   },
   testTimeout: 2500,

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -10,10 +10,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 74.81,
-      functions: 87.32,
-      lines: 88.55,
-      statements: 88.2,
+      branches: 75.36,
+      functions: 87.67,
+      lines: 88.8,
+      statements: 88.45,
     },
   },
   testTimeout: 2500,

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-jsdoc": "^39.6.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "expect-type": "^0.15.0",
     "jest": "^29.0.2",
     "jest-it-up": "^2.0.0",
     "json-rpc-engine": "^6.1.0",

--- a/packages/rpc-methods/src/index.ts
+++ b/packages/rpc-methods/src/index.ts
@@ -3,3 +3,4 @@ export { handlers as permittedMethods } from './permitted';
 export * from './restricted';
 export { SnapCaveatType } from '@metamask/snaps-utils';
 export { selectHooks } from './utils';
+export type { RequestFunction, SnapsGlobalObject } from './request';

--- a/packages/rpc-methods/src/permitted/index.ts
+++ b/packages/rpc-methods/src/permitted/index.ts
@@ -4,8 +4,12 @@ import { requestSnapsHandler, RequestSnapsHooks } from './requestSnaps';
 
 export type PermittedRpcMethodHooks = GetSnapsHooks & RequestSnapsHooks;
 
-export const handlers = [
-  getSnapsHandler,
-  requestSnapsHandler,
-  invokeSnapSugarHandler,
-];
+/* eslint-disable @typescript-eslint/naming-convention */
+export const methodHandlers = {
+  wallet_getSnaps: getSnapsHandler,
+  wallet_requestSnaps: requestSnapsHandler,
+  wallet_invokeSnap: invokeSnapSugarHandler,
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export const handlers = Object.values(methodHandlers);

--- a/packages/rpc-methods/src/request.test.ts
+++ b/packages/rpc-methods/src/request.test.ts
@@ -1,0 +1,89 @@
+import { JsonSLIP10Node } from '@metamask/key-tree';
+import { RequestedPermissions } from '@metamask/permission-controller';
+import { InstallSnapsResult } from '@metamask/snaps-utils';
+import { JsonRpcParams } from '@metamask/utils';
+import { expectTypeOf } from 'expect-type';
+
+import { MethodRequestArguments, MethodReturnType } from './request';
+
+describe('MethodRequestArguments', () => {
+  it('has the proper types for Snaps JSON-RPC methods', () => {
+    expectTypeOf<
+      MethodRequestArguments<'wallet_requestSnaps'>
+    >().toMatchTypeOf<{
+      method: 'wallet_requestSnaps';
+      params?: RequestedPermissions | undefined;
+    }>();
+
+    expectTypeOf<
+      MethodRequestArguments<'snap_getBip32Entropy'>
+    >().toMatchTypeOf<{
+      method: 'snap_getBip32Entropy';
+      params?: {
+        path: string[];
+        curve: string;
+      };
+    }>();
+
+    expectTypeOf<
+      MethodRequestArguments<'wallet_requestSnaps'>
+    >().not.toMatchTypeOf<{
+      method: 'wallet_requestSnaps';
+      params?: unknown[];
+    }>();
+
+    expectTypeOf<
+      MethodRequestArguments<'snap_getBip32Entropy'>
+    >().not.toMatchTypeOf<{
+      method: 'snap_getBip32Entropy';
+      params?: [
+        {
+          path: string[];
+          curve: string;
+        },
+      ];
+    }>();
+  });
+
+  it('supports JSON-RPC methods prefixed with "wallet_"', () => {
+    expectTypeOf<MethodRequestArguments<'wallet_foo'>>().toMatchTypeOf<{
+      method: 'wallet_foo';
+      params?: JsonRpcParams;
+    }>();
+
+    expectTypeOf<MethodRequestArguments<'wallet_bar'>>().toMatchTypeOf<{
+      method: 'wallet_bar';
+      params?: JsonRpcParams;
+    }>();
+
+    expectTypeOf<MethodRequestArguments<'wallet_baz'>>().toMatchTypeOf<{
+      method: 'wallet_baz';
+    }>();
+
+    expectTypeOf<MethodRequestArguments<'wallet_foo'>>().not.toMatchTypeOf<{
+      method: 'wallet_bar';
+    }>();
+  });
+});
+
+describe('MethodReturnType', () => {
+  it('has the proper types for Snaps JSON-RPC methods', () => {
+    expectTypeOf<MethodReturnType<'wallet_requestSnaps'>>().toEqualTypeOf<
+      Promise<InstallSnapsResult>
+    >();
+
+    expectTypeOf<MethodReturnType<'snap_getBip32Entropy'>>().toEqualTypeOf<
+      Promise<JsonSLIP10Node>
+    >();
+  });
+
+  it('supports JSON-RPC methods prefixed with "wallet_"', () => {
+    expectTypeOf<MethodReturnType<'wallet_foo'>>().toEqualTypeOf<
+      Promise<unknown>
+    >();
+
+    expectTypeOf<MethodReturnType<'wallet_bar'>>().toEqualTypeOf<
+      Promise<unknown>
+    >();
+  });
+});

--- a/packages/rpc-methods/src/request.test.ts
+++ b/packages/rpc-methods/src/request.test.ts
@@ -4,20 +4,16 @@ import { InstallSnapsResult } from '@metamask/snaps-utils';
 import { JsonRpcParams } from '@metamask/utils';
 import { expectTypeOf } from 'expect-type';
 
-import { MethodRequestArguments, MethodReturnType } from './request';
+import { ObjectFromMethodName, MethodReturnType } from './request';
 
 describe('MethodRequestArguments', () => {
   it('has the proper types for Snaps JSON-RPC methods', () => {
-    expectTypeOf<
-      MethodRequestArguments<'wallet_requestSnaps'>
-    >().toMatchTypeOf<{
+    expectTypeOf<ObjectFromMethodName<'wallet_requestSnaps'>>().toMatchTypeOf<{
       method: 'wallet_requestSnaps';
       params?: RequestedPermissions | undefined;
     }>();
 
-    expectTypeOf<
-      MethodRequestArguments<'snap_getBip32Entropy'>
-    >().toMatchTypeOf<{
+    expectTypeOf<ObjectFromMethodName<'snap_getBip32Entropy'>>().toMatchTypeOf<{
       method: 'snap_getBip32Entropy';
       params?: {
         path: string[];
@@ -26,14 +22,14 @@ describe('MethodRequestArguments', () => {
     }>();
 
     expectTypeOf<
-      MethodRequestArguments<'wallet_requestSnaps'>
+      ObjectFromMethodName<'wallet_requestSnaps'>
     >().not.toMatchTypeOf<{
       method: 'wallet_requestSnaps';
       params?: unknown[];
     }>();
 
     expectTypeOf<
-      MethodRequestArguments<'snap_getBip32Entropy'>
+      ObjectFromMethodName<'snap_getBip32Entropy'>
     >().not.toMatchTypeOf<{
       method: 'snap_getBip32Entropy';
       params?: [
@@ -46,21 +42,21 @@ describe('MethodRequestArguments', () => {
   });
 
   it('supports JSON-RPC methods prefixed with "wallet_"', () => {
-    expectTypeOf<MethodRequestArguments<'wallet_foo'>>().toMatchTypeOf<{
+    expectTypeOf<ObjectFromMethodName<'wallet_foo'>>().toMatchTypeOf<{
       method: 'wallet_foo';
       params?: JsonRpcParams;
     }>();
 
-    expectTypeOf<MethodRequestArguments<'wallet_bar'>>().toMatchTypeOf<{
+    expectTypeOf<ObjectFromMethodName<'wallet_bar'>>().toMatchTypeOf<{
       method: 'wallet_bar';
       params?: JsonRpcParams;
     }>();
 
-    expectTypeOf<MethodRequestArguments<'wallet_baz'>>().toMatchTypeOf<{
+    expectTypeOf<ObjectFromMethodName<'wallet_baz'>>().toMatchTypeOf<{
       method: 'wallet_baz';
     }>();
 
-    expectTypeOf<MethodRequestArguments<'wallet_foo'>>().not.toMatchTypeOf<{
+    expectTypeOf<ObjectFromMethodName<'wallet_foo'>>().not.toMatchTypeOf<{
       method: 'wallet_bar';
     }>();
   });

--- a/packages/rpc-methods/src/request.ts
+++ b/packages/rpc-methods/src/request.ts
@@ -119,6 +119,10 @@ export type MethodRequestArguments<
     : never;
 };
 
+export type MethodReturnType<
+  MethodName extends keyof MethodFunction | GenericMethodFunction,
+> = ReturnType<MethodFunctionFallback<MethodName>>;
+
 /**
  * A function that takes a JSON-RPC request and returns a JSON-RPC response.
  *
@@ -129,7 +133,7 @@ export type RequestFunction = <
   MethodName extends keyof MethodFunction | GenericMethodFunction,
 >(
   args: MethodRequestArguments<MethodName>,
-) => ReturnType<MethodFunctionFallback<MethodName>>;
+) => MethodReturnType<MethodName>;
 
 /**
  * The global `snap` object. This is injected into the global scope of a snap.

--- a/packages/rpc-methods/src/request.ts
+++ b/packages/rpc-methods/src/request.ts
@@ -1,0 +1,121 @@
+import {
+  PermissionSpecificationBuilder,
+  PermissionType,
+  RestrictedMethodOptions,
+} from '@metamask/permission-controller';
+import { PermittedHandlerExport } from '@metamask/types';
+
+import { methodHandlers } from './permitted';
+import { restrictedMethodPermissionBuilders } from './restricted';
+
+/**
+ * Get the method implementation from a {@link PermittedHandlerExport}.
+ *
+ * @template Handler - A permitted handler export.
+ */
+type PermittedMethodImplementation<Handler> =
+  Handler extends PermittedHandlerExport<any, infer Args, infer Result>
+    ? (args: Args) => Promise<Result>
+    : never;
+
+/**
+ * Get a JSON-RPC method type from a {@link PermittedHandlerExport} and a method
+ * name.
+ *
+ * @template MethodName - The name of the method.
+ * @template Handler - A permitted handler export.
+ */
+type PermittedMethod<
+  MethodName extends string,
+  Handler,
+> = PermittedMethodImplementation<Handler> extends (
+  args: infer Args,
+) => infer Return
+  ? (args: { method: MethodName; params?: Args }) => Return
+  : never;
+
+/**
+ * Get a restricted method implementation from a
+ * {@link PermissionSpecificationBuilder}.
+ *
+ * @template Builder - A permission specification builder.
+ */
+type RestrictedMethodImplementation<Builder> = Builder extends {
+  specificationBuilder: PermissionSpecificationBuilder<
+    PermissionType.RestrictedMethod,
+    any,
+    infer Specification
+  >;
+}
+  ? Specification['methodImplementation']
+  : never;
+
+/**
+ * Get a JSON-RPC method type from a {@link PermissionSpecificationBuilder}.
+ *
+ * @template Builder - A permission specification builder.
+ */
+type RestrictedMethod<Builder extends { targetKey: string }> =
+  RestrictedMethodImplementation<Builder> extends (
+    args: infer Args,
+  ) => infer Return
+    ? Args extends RestrictedMethodOptions<infer Params>
+      ? (args: { method: Builder['targetKey']; params?: Params }) => Return
+      : never
+    : never;
+
+/**
+ * A type containing all permitted JSON-RPC methods.
+ */
+type PermittedMethodFunction = {
+  [MethodName in keyof typeof methodHandlers]: PermittedMethod<
+    MethodName,
+    typeof methodHandlers[MethodName]
+  >;
+};
+
+/**
+ * A type containing all restricted JSON-RPC methods.
+ */
+type RestrictedMethodFunction = {
+  [Builder in keyof typeof restrictedMethodPermissionBuilders]: RestrictedMethod<
+    typeof restrictedMethodPermissionBuilders[Builder]
+  >;
+};
+
+/**
+ * A type containing all supported JSON-RPC methods.
+ */
+type MethodFunction = RestrictedMethodFunction & PermittedMethodFunction;
+
+/**
+ * The request arguments for a JSON-RPC method.
+ *
+ * @template MethodName - The name of the method. In most cases this is inferred
+ * from the args.
+ */
+export type MethodRequestArguments<MethodName extends keyof MethodFunction> = {
+  method: MethodName;
+  params?: Parameters<MethodFunction[MethodName]>[0] extends {
+    params?: infer Params;
+  }
+    ? Params
+    : never;
+};
+
+/**
+ * A function that takes a JSON-RPC request and returns a JSON-RPC response.
+ *
+ * @template MethodName - The name of the method. In most cases this is inferred
+ * from the args.
+ */
+export type RequestFunction = <MethodName extends keyof MethodFunction>(
+  args: MethodRequestArguments<MethodName>,
+) => ReturnType<MethodFunction[MethodName]>;
+
+/**
+ * The global `snap` object. This is injected into the global scope of a snap.
+ */
+export type SnapsGlobalObject = {
+  request: RequestFunction;
+};

--- a/packages/rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/rpc-methods/src/restricted/dialog.test.ts
@@ -41,6 +41,27 @@ describe('implementation', () => {
       showDialog: jest.fn(),
     } as DialogMethodHooks);
 
+  it('accepts string dialog types', async () => {
+    const hooks = getMockDialogHooks();
+    const implementation = getDialogImplementation(hooks);
+    await implementation({
+      context: { origin: 'foo' },
+      method: 'snap_dialog',
+      params: {
+        type: 'alert',
+        content: panel([heading('foo'), text('bar')]),
+      },
+    });
+
+    expect(hooks.showDialog).toHaveBeenCalledTimes(1);
+    expect(hooks.showDialog).toHaveBeenCalledWith(
+      'foo',
+      DialogType.Alert,
+      panel([heading('foo'), text('bar')]),
+      undefined,
+    );
+  });
+
   describe('alerts', () => {
     it('handles alerts', async () => {
       const hooks = getMockDialogHooks();

--- a/packages/rpc-methods/src/restricted/dialog.test.ts
+++ b/packages/rpc-methods/src/restricted/dialog.test.ts
@@ -155,7 +155,7 @@ describe('implementation', () => {
           params: value as any,
         }),
       ).rejects.toThrow(
-        'The "type" property must be one of: Alert, Confirmation, Prompt.',
+        'The "type" property must be one of: alert, confirmation, prompt.',
       );
     });
 
@@ -172,7 +172,7 @@ describe('implementation', () => {
             params: value as any,
           }),
         ).rejects.toThrow(
-          'The "type" property must be one of: Alert, Confirmation, Prompt.',
+          'The "type" property must be one of: alert, confirmation, prompt.',
         );
       },
     );

--- a/packages/rpc-methods/src/restricted/dialog.ts
+++ b/packages/rpc-methods/src/restricted/dialog.ts
@@ -11,7 +11,6 @@ import {
   create,
   enums,
   Infer,
-  literal,
   object,
   optional,
   size,
@@ -22,12 +21,14 @@ import {
   union,
 } from 'superstruct';
 
+import { EnumToUnion, enumValue } from '../utils';
+
 const methodName = 'snap_dialog';
 
 export enum DialogType {
-  Alert = 'Alert',
-  Confirmation = 'Confirmation',
-  Prompt = 'Prompt',
+  Alert = 'alert',
+  Confirmation = 'confirmation',
+  Prompt = 'prompt',
 }
 
 const PlaceholderStruct = optional(size(string(), 1, 40));
@@ -36,7 +37,7 @@ export type Placeholder = Infer<typeof PlaceholderStruct>;
 
 type ShowDialog = (
   snapId: string,
-  type: DialogType,
+  type: EnumToUnion<DialogType>,
   content: Component,
   placeholder?: Placeholder,
 ) => Promise<null | boolean | string>;
@@ -108,17 +109,17 @@ const BaseParamsStruct = type({
 });
 
 const AlertParametersStruct = object({
-  type: literal(DialogType.Alert),
+  type: enumValue(DialogType.Alert),
   content: ComponentStruct,
 });
 
 const ConfirmationParametersStruct = object({
-  type: literal(DialogType.Confirmation),
+  type: enumValue(DialogType.Confirmation),
   content: ComponentStruct,
 });
 
 const PromptParametersStruct = object({
-  type: literal(DialogType.Prompt),
+  type: enumValue(DialogType.Prompt),
   content: ComponentStruct,
   placeholder: PlaceholderStruct,
 });

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -27,8 +27,7 @@ import { notifyBuilder, NotifyMethodHooks } from './notify';
 export type { DialogParameters } from './dialog';
 export { DialogType } from './dialog';
 export { ManageStateOperation } from './manageState';
-export type { NotificationArgs } from './notify';
-export { NotificationType } from './notify';
+export type { NotificationArgs, NotificationType } from './notify';
 
 export type RestrictedMethodHooks = ConfirmMethodHooks &
   DialogMethodHooks &

--- a/packages/rpc-methods/src/restricted/notify.test.ts
+++ b/packages/rpc-methods/src/restricted/notify.test.ts
@@ -1,8 +1,4 @@
-import {
-  getImplementation,
-  getValidatedParams,
-  NotificationType,
-} from './notify';
+import { getImplementation, getValidatedParams } from './notify';
 
 describe('snap_notify', () => {
   const validParams = {
@@ -26,13 +22,13 @@ describe('snap_notify', () => {
         },
         method: 'snap_notify',
         params: {
-          type: NotificationType.InApp,
+          type: 'inApp',
           message: 'Some message',
         },
       });
 
       expect(showInAppNotification).toHaveBeenCalledWith('extension', {
-        type: NotificationType.InApp,
+        type: 'inApp',
         message: 'Some message',
       });
     });
@@ -52,13 +48,13 @@ describe('snap_notify', () => {
         },
         method: 'snap_notify',
         params: {
-          type: NotificationType.Native,
+          type: 'native',
           message: 'Some message',
         },
       });
 
       expect(showNativeNotification).toHaveBeenCalledWith('extension', {
-        type: NotificationType.Native,
+        type: 'native',
         message: 'Some message',
       });
     });

--- a/packages/rpc-methods/src/restricted/notify.test.ts
+++ b/packages/rpc-methods/src/restricted/notify.test.ts
@@ -1,8 +1,12 @@
-import { getImplementation, getValidatedParams } from './notify';
+import {
+  getImplementation,
+  getValidatedParams,
+  NotificationType,
+} from './notify';
 
 describe('snap_notify', () => {
   const validParams = {
-    type: 'inApp',
+    type: NotificationType.InApp,
     message: 'Some message',
   };
 
@@ -22,13 +26,13 @@ describe('snap_notify', () => {
         },
         method: 'snap_notify',
         params: {
-          type: 'inApp',
+          type: NotificationType.InApp,
           message: 'Some message',
         },
       });
 
       expect(showInAppNotification).toHaveBeenCalledWith('extension', {
-        type: 'inApp',
+        type: NotificationType.InApp,
         message: 'Some message',
       });
     });
@@ -48,13 +52,13 @@ describe('snap_notify', () => {
         },
         method: 'snap_notify',
         params: {
-          type: 'native',
+          type: NotificationType.Native,
           message: 'Some message',
         },
       });
 
       expect(showNativeNotification).toHaveBeenCalledWith('extension', {
-        type: 'native',
+        type: NotificationType.Native,
         message: 'Some message',
       });
     });
@@ -75,8 +79,7 @@ describe('snap_notify', () => {
           },
           method: 'snap_notify',
           params: {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error - invalid type for testing purposes
+            // @ts-expect-error - Invalid type for testing purposes.
             type: 'invalid-type',
             message: 'Some message',
           },
@@ -99,13 +102,17 @@ describe('snap_notify', () => {
     });
 
     it('throws an error if the message is empty', () => {
-      expect(() => getValidatedParams({ type: 'inApp', message: '' })).toThrow(
+      expect(() =>
+        getValidatedParams({ type: NotificationType.InApp, message: '' }),
+      ).toThrow(
         'Must specify a non-empty string "message" less than 50 characters long.',
       );
     });
 
     it('throws an error if the message is not a string', () => {
-      expect(() => getValidatedParams({ type: 'inApp', message: 123 })).toThrow(
+      expect(() =>
+        getValidatedParams({ type: NotificationType.InApp, message: 123 }),
+      ).toThrow(
         'Must specify a non-empty string "message" less than 50 characters long.',
       );
     });
@@ -113,7 +120,7 @@ describe('snap_notify', () => {
     it('throws an error if the message is larger than 50 characters', () => {
       expect(() =>
         getValidatedParams({
-          type: 'inApp',
+          type: NotificationType.InApp,
           message:
             'test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg_test_msg',
         }),

--- a/packages/rpc-methods/src/restricted/notify.test.ts
+++ b/packages/rpc-methods/src/restricted/notify.test.ts
@@ -63,6 +63,32 @@ describe('snap_notify', () => {
       });
     });
 
+    it('accepts string notification types', async () => {
+      const showNativeNotification = jest.fn().mockResolvedValueOnce(true);
+      const showInAppNotification = jest.fn().mockResolvedValueOnce(true);
+
+      const notificationImplementation = getImplementation({
+        showNativeNotification,
+        showInAppNotification,
+      });
+
+      await notificationImplementation({
+        context: {
+          origin: 'extension',
+        },
+        method: 'snap_notify',
+        params: {
+          type: 'native',
+          message: 'Some message',
+        },
+      });
+
+      expect(showNativeNotification).toHaveBeenCalledWith('extension', {
+        type: NotificationType.Native,
+        message: 'Some message',
+      });
+    });
+
     it('throws an error if the notification type is invalid', async () => {
       const showNativeNotification = jest.fn().mockResolvedValueOnce(true);
       const showInAppNotification = jest.fn().mockResolvedValueOnce(true);

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -9,11 +9,20 @@ import { ethErrors } from 'eth-rpc-errors';
 
 const methodName = 'snap_notify';
 
-// Move all the types to a shared place when implementing more notifications
-export enum NotificationType {
-  Native = 'native',
-  InApp = 'inApp',
-}
+// TODO: Move all the types to a shared place when implementing more
+// notifications.
+// Note: We can't use an enum here, because strings are not assignable to
+// their enum values. For example:
+// ```typescript
+// enum Foo {
+//   Bar = 'bar',
+// }
+//
+// // Error: Type '"bar"' is not assignable to type 'Foo'.
+// const foo: Foo = 'bar';
+// ```
+const NotificationTypeArray = ['inApp', 'native'] as const;
+export type NotificationType = typeof NotificationTypeArray[number];
 
 export type NotificationArgs = {
   /**
@@ -114,9 +123,9 @@ export function getImplementation({
     const validatedParams = getValidatedParams(params);
 
     switch (validatedParams.type) {
-      case NotificationType.Native:
+      case 'native':
         return await showNativeNotification(origin, validatedParams);
-      case NotificationType.InApp:
+      case 'inApp':
         return await showInAppNotification(origin, validatedParams);
       default:
         throw ethErrors.rpc.invalidParams({
@@ -145,7 +154,7 @@ export function getValidatedParams(params: unknown): NotificationArgs {
   if (
     !type ||
     typeof type !== 'string' ||
-    !(Object.values(NotificationType) as string[]).includes(type)
+    !NotificationTypeArray.includes(type as NotificationType)
   ) {
     throw ethErrors.rpc.invalidParams({
       message: 'Must specify a valid notification "type".',

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -7,28 +7,21 @@ import {
 import { NonEmptyArray, isObject } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
+import { EnumToUnion } from '../utils';
+
 const methodName = 'snap_notify';
 
 // TODO: Move all the types to a shared place when implementing more
-// notifications.
-// Note: We can't use an enum here, because strings are not assignable to
-// their enum values. For example:
-// ```typescript
-// enum Foo {
-//   Bar = 'bar',
-// }
-//
-// // Error: Type '"bar"' is not assignable to type 'Foo'.
-// const foo: Foo = 'bar';
-// ```
-const NotificationTypeArray = ['inApp', 'native'] as const;
-export type NotificationType = typeof NotificationTypeArray[number];
+export enum NotificationType {
+  InApp = 'inApp',
+  Native = 'native',
+}
 
 export type NotificationArgs = {
   /**
    * Enum type to determine notification type.
    */
-  type: NotificationType;
+  type: EnumToUnion<NotificationType>;
 
   /**
    * A message to show on the notification.
@@ -123,9 +116,9 @@ export function getImplementation({
     const validatedParams = getValidatedParams(params);
 
     switch (validatedParams.type) {
-      case 'native':
+      case NotificationType.Native:
         return await showNativeNotification(origin, validatedParams);
-      case 'inApp':
+      case NotificationType.InApp:
         return await showInAppNotification(origin, validatedParams);
       default:
         throw ethErrors.rpc.invalidParams({
@@ -154,7 +147,7 @@ export function getValidatedParams(params: unknown): NotificationArgs {
   if (
     !type ||
     typeof type !== 'string' ||
-    !NotificationTypeArray.includes(type as NotificationType)
+    !Object.values(NotificationType).includes(type as NotificationType)
   ) {
     throw ethErrors.rpc.invalidParams({
       message: 'Must specify a valid notification "type".',

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -12,6 +12,7 @@ import { EnumToUnion } from '../utils';
 const methodName = 'snap_notify';
 
 // TODO: Move all the types to a shared place when implementing more
+//  notifications.
 export enum NotificationType {
   InApp = 'inApp',
   Native = 'native',

--- a/packages/rpc-methods/src/utils.ts
+++ b/packages/rpc-methods/src/utils.ts
@@ -9,6 +9,7 @@ import {
   stringToBytes,
 } from '@metamask/utils';
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
+import { literal, Struct } from 'superstruct';
 
 const HARDENED_VALUE = 0x80000000;
 
@@ -150,8 +151,8 @@ export async function deriveEntropy({
 }
 
 /**
- * Get the enum values as union type. This allows using both the enum values
- * and the enum itself as values.
+ * Get the enum values as union type. This allows using both the enum string
+ * values and the enum itself as values.
  *
  * Note: This only works for string enums.
  *
@@ -170,3 +171,16 @@ export async function deriveEntropy({
  * ```
  */
 export type EnumToUnion<Type extends string> = `${Type}`;
+
+/**
+ * Superstruct struct for validating an enum value. This allows using both the
+ * enum string values and the enum itself as values.
+ *
+ * @param constant - The enum to validate against.
+ * @returns The superstruct struct.
+ */
+export function enumValue<T extends string>(
+  constant: T,
+): Struct<EnumToUnion<T>, EnumToUnion<T>> {
+  return literal(constant as EnumToUnion<T>);
+}

--- a/packages/rpc-methods/src/utils.ts
+++ b/packages/rpc-methods/src/utils.ts
@@ -148,3 +148,25 @@ export async function deriveEntropy({
 
   return add0x(privateKey);
 }
+
+/**
+ * Get the enum values as union type. This allows using both the enum values
+ * and the enum itself as values.
+ *
+ * Note: This only works for string enums.
+ *
+ * @example
+ * ```typescript
+ * enum Foo {
+ *   Bar = 'bar',
+ *   Baz = 'baz',
+ * }
+ *
+ * type FooValue = EnumToUnion<Foo>;
+ * // FooValue is 'bar' | 'baz'
+ *
+ * const foo: FooValue = Foo.Bar; // Works
+ * const foo: FooValue = 'bar'; // Also works
+ * ```
+ */
+export type EnumToUnion<Type extends string> = `${Type}`;

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -37,6 +37,7 @@
     "@metamask/object-multiplex": "^1.2.0",
     "@metamask/post-message-stream": "^6.1.0",
     "@metamask/providers": "^10.2.0",
+    "@metamask/rpc-methods": "^0.28.0",
     "@metamask/snaps-utils": "^0.28.0",
     "@metamask/utils": "^3.4.1",
     "eth-rpc-errors": "^4.0.3",

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -2,9 +2,9 @@
 /// <reference path="../../../../node_modules/ses/index.d.ts" />
 import { StreamProvider } from '@metamask/providers';
 import { RequestArguments } from '@metamask/providers/dist/BaseProvider';
+import { RequestFunction, SnapsGlobalObject } from '@metamask/rpc-methods';
 import {
   SnapExports,
-  SnapsGlobalObject,
   HandlerType,
   SnapExportsParameters,
   SNAP_EXPORT_NAMES,
@@ -393,7 +393,7 @@ export class BaseSnapExecutor {
       }
     };
 
-    return { request };
+    return { request: request as RequestFunction };
   }
 
   /**

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -1,5 +1,5 @@
 import { StreamProvider } from '@metamask/providers';
-import { SnapsGlobalObject } from '@metamask/snaps-utils';
+import { SnapsGlobalObject } from '@metamask/rpc-methods';
 import { hasProperty } from '@metamask/utils';
 
 import { rootRealmGlobal } from '../globalObject';

--- a/packages/snaps-execution-environments/tsconfig.build.json
+++ b/packages/snaps-execution-environments/tsconfig.build.json
@@ -15,6 +15,9 @@
   ],
   "references": [
     {
+      "path": "../rpc-methods/tsconfig.build.json"
+    },
+    {
       "path": "../snaps-utils/tsconfig.build.json"
     }
   ]

--- a/packages/snaps-execution-environments/tsconfig.json
+++ b/packages/snaps-execution-environments/tsconfig.json
@@ -6,5 +6,12 @@
     "lib": ["es2015.proxy"]
   },
   "include": ["./src", "./src/openrpc.json"],
-  "references": [{ "path": "../snaps-utils" }]
+  "references": [
+    {
+      "path": "../rpc-methods"
+    },
+    {
+      "path": "../snaps-utils"
+    }
+  ]
 }

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@metamask/providers": "^10.2.0",
+    "@metamask/rpc-methods": "^0.28.0",
     "@metamask/snaps-utils": "^0.28.0",
     "@metamask/utils": "^3.4.1"
   },

--- a/packages/snaps-types/src/global.ts
+++ b/packages/snaps-types/src/global.ts
@@ -1,5 +1,5 @@
 import { MetaMaskInpageProvider } from '@metamask/providers';
-import { SnapsGlobalObject } from '@metamask/snaps-utils';
+import type { SnapsGlobalObject } from '@metamask/rpc-methods';
 
 // Types that should be available globally within a snap.
 declare global {

--- a/packages/snaps-types/src/types.ts
+++ b/packages/snaps-types/src/types.ts
@@ -7,6 +7,7 @@ export type Ethereum = StreamProvider;
 
 // Exported again for convenience.
 export type { Json, JsonRpcRequest } from '@metamask/utils';
+export { DialogType, NotificationType } from '@metamask/rpc-methods';
 export type { SnapsGlobalObject } from '@metamask/rpc-methods';
 export type {
   AccountId,

--- a/packages/snaps-types/src/types.ts
+++ b/packages/snaps-types/src/types.ts
@@ -7,6 +7,7 @@ export type Ethereum = StreamProvider;
 
 // Exported again for convenience.
 export type { Json, JsonRpcRequest } from '@metamask/utils';
+export type { SnapsGlobalObject } from '@metamask/rpc-methods';
 export type {
   AccountId,
   ChainId,
@@ -18,5 +19,4 @@ export type {
   OnTransactionResponse,
   RequestArguments,
   SnapKeyring,
-  SnapsGlobalObject,
 } from '@metamask/snaps-utils';

--- a/packages/snaps-types/tsconfig.build.json
+++ b/packages/snaps-types/tsconfig.build.json
@@ -9,6 +9,9 @@
   "include": ["./src"],
   "references": [
     {
+      "path": "../rpc-methods/tsconfig.build.json"
+    },
+    {
       "path": "../snaps-utils/tsconfig.build.json"
     }
   ]

--- a/packages/snaps-types/tsconfig.json
+++ b/packages/snaps-types/tsconfig.json
@@ -6,6 +6,9 @@
   "include": ["./src"],
   "references": [
     {
+      "path": "../rpc-methods"
+    },
+    {
       "path": "../snaps-utils"
     }
   ]

--- a/packages/snaps-utils/src/handlers.ts
+++ b/packages/snaps-utils/src/handlers.ts
@@ -1,13 +1,7 @@
-import type { StreamProvider } from '@metamask/providers';
 import { Component } from '@metamask/snaps-ui';
 import { Json, JsonRpcRequest } from '@metamask/utils';
 
 import { AccountId, ChainId, RequestArguments } from './namespace';
-
-/**
- * The global `snap` object. This is injected into the global scope of a snap.
- */
-export type SnapsGlobalObject = { request: StreamProvider['request'] };
 
 /**
  * The `onRpcRequest` handler. This is called whenever a JSON-RPC request is

--- a/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
@@ -7,13 +7,6 @@ exports[`SnapsWebpackPlugin applies a transform 1`] = `
 })();"
 `;
 
-exports[`SnapsWebpackPlugin applies a transform 2`] = `
-"(() => {
-  var __webpack_exports__ = {};
-  const foo = 'bar';
-})();"
-`;
-
 exports[`SnapsWebpackPlugin forwards the options 1`] = `
 "/******/(() => {
   // webpackBootstrap

--- a/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
+++ b/packages/snaps-webpack-plugin/src/__snapshots__/plugin.test.ts.snap
@@ -7,6 +7,13 @@ exports[`SnapsWebpackPlugin applies a transform 1`] = `
 })();"
 `;
 
+exports[`SnapsWebpackPlugin applies a transform 2`] = `
+"(() => {
+  var __webpack_exports__ = {};
+  const foo = 'bar';
+})();"
+`;
+
 exports[`SnapsWebpackPlugin forwards the options 1`] = `
 "/******/(() => {
   // webpackBootstrap

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,6 +2712,7 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
     eth-rpc-errors: ^4.0.2
+    expect-type: ^0.15.0
     jest: ^29.0.2
     jest-it-up: ^2.0.0
     json-rpc-engine: ^6.1.0
@@ -8248,6 +8249,13 @@ __metadata:
   dependencies:
     homedir-polyfill: ^1.0.1
   checksum: 2efe6ed407d229981b1b6ceb552438fbc9e5c7d6a6751ad6ced3e0aa5cf12f0b299da695e90d6c2ac79191b5c53c613e508f7149e4573abfbb540698ddb7301a
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "expect-type@npm:0.15.0"
+  checksum: f5d3733bb593d9f7cf302b393e34b19389fb7022d72963815e9a847a9517b65201faef733dd9006bed9e200486d77204fd958c8d29ef58b466bed2da076fc0ba
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,6 +2926,7 @@ __metadata:
     "@metamask/object-multiplex": ^1.2.0
     "@metamask/post-message-stream": ^6.1.0
     "@metamask/providers": ^10.2.0
+    "@metamask/rpc-methods": ^0.28.0
     "@metamask/snaps-utils": ^0.28.0
     "@metamask/utils": ^3.4.1
     "@types/jest": ^27.5.1
@@ -3026,6 +3027,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/providers": ^10.2.0
+    "@metamask/rpc-methods": ^0.28.0
     "@metamask/snaps-utils": ^0.28.0
     "@metamask/utils": ^3.4.1
     "@typescript-eslint/eslint-plugin": ^5.42.1


### PR DESCRIPTION
This changes the global `snap.request` function to be strongly typed. Only the supported JSON-RPC methods (inferred from `rpc-methods`) can be used, and the parameters are validated by TypeScript.

I've also fixed some issues with enums, i.e., not being able to use a string value instead of an enum. Now both the enum value and string value are accepted.

## Breaking changes

- `SnapsGlobalObject` is now exported from `rpc-methods`, rather than `snaps-utils`.
- `snap_dialog` now uses `alert`, `confirmation`, and `prompt` as dialog types, rather than `Alert`, `Confirmation`, and `Prompt`. This breaks existing implementations using string values.
   - Implementations using the `DialogType` enum are unaffected.