### PR TITLE
Ensure required status check always runs

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -222,8 +222,8 @@ jobs:
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash
-  all-jobs-pass:
-    name: All jobs pass
+  all-jobs-completed:
+    name: All jobs completed
     runs-on: ubuntu-latest
     needs:
       - build
@@ -232,5 +232,22 @@ jobs:
       - platform-compatibility-build
       - platform-compatibility-test
       - check-workflows
+    outputs:
+      PASSED: ${{ steps.set-output.outputs.PASSED }}
     steps:
-      - run: echo "Great success!"
+      - name: Set PASSED output
+        id: set-output
+        run: echo "PASSED=true" >> "$GITHUB_OUTPUT"
+
+  all-jobs-pass:
+    name: All jobs pass
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: all-jobs-completed
+    steps:
+      - name: Check that all jobs have passed
+        run: |
+          passed="${{ needs.all-jobs-completed.outputs.PASSED }}"
+          if [[ $passed != "true" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
Based on https://github.com/MetaMask/metamask-module-template/pull/151

Should force the "All jobs pass" status check to always run, not allowing PRs to be merged without passing all tests.