### PR TITLE
Remove UI spacer

### DIFF
--- a/packages/snaps-ui/src/builder.test.ts
+++ b/packages/snaps-ui/src/builder.test.ts
@@ -1,12 +1,4 @@
-import {
-  copyable,
-  divider,
-  heading,
-  panel,
-  spacer,
-  spinner,
-  text,
-} from './builder';
+import { copyable, divider, heading, panel, spinner, text } from './builder';
 import { NodeType } from './nodes';
 
 describe('copyable', () => {
@@ -170,21 +162,6 @@ describe('panel', () => {
     // @ts-expect-error - Invalid args.
     expect(() => panel({})).toThrow(
       'Invalid panel component: At path: children -- Expected an array value, but received: undefined.',
-    );
-  });
-});
-
-describe('spacer', () => {
-  it('creates a spacer component', () => {
-    expect(spacer()).toStrictEqual({
-      type: NodeType.Spacer,
-    });
-  });
-
-  it('validates the args', () => {
-    // @ts-expect-error - Invalid args.
-    expect(() => spacer({ bar: 'baz' })).toThrow(
-      'Invalid spacer component: At path: bar -- Expected a value of type `never`, but received: `"baz"`.',
     );
   });
 });

--- a/packages/snaps-ui/src/builder.ts
+++ b/packages/snaps-ui/src/builder.ts
@@ -8,7 +8,6 @@ import {
   HeadingStruct,
   NodeType,
   PanelStruct,
-  SpacerStruct,
   SpinnerStruct,
   TextStruct,
 } from './nodes';
@@ -156,17 +155,6 @@ export const heading = createBuilder(NodeType.Heading, HeadingStruct, [
  * ```
  */
 export const panel = createBuilder(NodeType.Panel, PanelStruct, ['children']);
-
-/**
- * Create a {@link Spacer} node.
- *
- * @returns The spacer node as object.
- * @example
- * ```typescript
- * const node = spacer();
- * ```
- */
-export const spacer = createBuilder(NodeType.Spacer, SpacerStruct);
 
 /**
  * Create a {@link Spinner} node.

--- a/packages/snaps-ui/src/nodes.ts
+++ b/packages/snaps-ui/src/nodes.ts
@@ -59,7 +59,6 @@ export enum NodeType {
   Divider = 'divider',
   Heading = 'heading',
   Panel = 'panel',
-  Spacer = 'spacer',
   Spinner = 'spinner',
   Text = 'text',
 }
@@ -127,18 +126,6 @@ export const PanelStruct: Struct<Panel> = assign(
 // This node references itself indirectly, so it cannot be inferred.
 export type Panel = { type: NodeType.Panel; children: Component[] };
 
-export const SpacerStruct = assign(
-  NodeStruct,
-  object({
-    type: literal(NodeType.Spacer),
-  }),
-);
-
-/**
- * A spacer node, that renders a blank space between other nodes.
- */
-export type Spacer = Infer<typeof SpacerStruct>;
-
 export const SpinnerStruct = assign(
   NodeStruct,
   object({
@@ -174,7 +161,6 @@ export const ComponentStruct = union([
   DividerStruct,
   HeadingStruct,
   PanelStruct,
-  SpacerStruct,
   SpinnerStruct,
   TextStruct,
 ]);

--- a/packages/snaps-ui/src/validation.test.ts
+++ b/packages/snaps-ui/src/validation.test.ts
@@ -1,12 +1,4 @@
-import {
-  Divider,
-  Heading,
-  NodeType,
-  Panel,
-  Spacer,
-  Spinner,
-  Text,
-} from './nodes';
+import { Divider, Heading, NodeType, Panel, Spinner, Text } from './nodes';
 import { assertIsComponent, isComponent } from './validation';
 
 describe('isComponent', () => {
@@ -58,14 +50,6 @@ describe('isComponent', () => {
     };
 
     expect(isComponent(panel)).toBe(true);
-  });
-
-  it('returns true for a spacer component', () => {
-    const spacer: Spacer = {
-      type: NodeType.Spacer,
-    };
-
-    expect(isComponent(spacer)).toBe(true);
   });
 
   it('returns true for a spinner component', () => {
@@ -153,14 +137,6 @@ describe('assertIsComponent', () => {
     };
 
     expect(() => assertIsComponent(panel)).not.toThrow();
-  });
-
-  it('does not throw for a spacer component', () => {
-    const spacer: Spacer = {
-      type: NodeType.Spacer,
-    };
-
-    expect(() => assertIsComponent(spacer)).not.toThrow();
   });
 
   it('does not throw for a spinner component', () => {


### PR DESCRIPTION
We've decided that the `spacer` component is not in scope for v1 of the custom UI.