### PR TITLE
Fix post processing issue with `object.eval`

### DIFF
--- a/packages/snaps-utils/src/post-process.test.ts
+++ b/packages/snaps-utils/src/post-process.test.ts
@@ -63,6 +63,21 @@ describe('postProcessBundle', () => {
     `);
   });
 
+  it('allows eval assignments', () => {
+    const code = `
+      foo.eval = null;
+    `;
+
+    const processedCode = postProcessBundle(code);
+    expect(processedCode).toMatchInlineSnapshot(`
+      {
+        "code": "foo.eval = null;",
+        "sourceMap": null,
+        "warnings": [],
+      }
+    `);
+  });
+
   it('removes the Buffer argument', () => {
     const code = `
       (function (Buffer, foo) {

--- a/packages/snaps-utils/src/post-process.ts
+++ b/packages/snaps-utils/src/post-process.ts
@@ -284,8 +284,9 @@ export function postProcessBundle(
       if (
         node.property.type === 'Identifier' &&
         node.property.name === 'eval' &&
-        // If the expression is already wrapped we can ignore it
-        path.parent.type !== 'SequenceExpression'
+        // We only apply this to MemberExpressions that are the callee of CallExpression
+        path.parent.type === 'CallExpression' &&
+        path.parent.callee === node
       ) {
         path.replaceWith(
           objectEvalWrapper({


### PR DESCRIPTION
Fixes a post processing issue that would happen with assignments to properties called `eval`. This has been fixed by only applying our transform to callees of `CallExpression`s. Before we would apply it to all `MemberExpression`s

This illustrates the issue: https://astexplorer.net/#/gist/b1c6c7101a6a58666ad0929ef89a414a/355961e03669ad775df0a771d2e5d35f9c960bb0

Fixes #1034