### PR TITLE
Fix non-snap permission processing

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -619,6 +619,36 @@ describe('SnapController', () => {
     await eventSubscriptionPromise;
   });
 
+  it('supports non-snap permissions', async () => {
+    const messenger = getSnapControllerMessenger();
+    const initialPermissions = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      eth_accounts: {
+        requiredMethods: [],
+      },
+    } as any;
+    const snapController = getSnapController(
+      getSnapControllerOptions({
+        messenger,
+        detectSnapLocation: loopbackDetect({
+          manifest: getSnapManifest({
+            initialPermissions,
+          }),
+        }),
+      }),
+    );
+
+    const expectedSnapObject = getTruncatedSnap({ initialPermissions });
+
+    expect(
+      await snapController.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
+      }),
+    ).toStrictEqual({
+      [MOCK_SNAP_ID]: expectedSnapObject,
+    });
+  });
+
   it('throws an error on invalid semver range during installSnaps', async () => {
     const controller = getSnapController();
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -12,6 +12,7 @@ import {
   SemVerRange,
   SemVerVersion,
   SnapCaveatType,
+  SnapPermissions,
   SnapStatus,
   VirtualFile,
 } from '@metamask/snaps-utils';
@@ -621,12 +622,13 @@ describe('SnapController', () => {
 
   it('supports non-snap permissions', async () => {
     const messenger = getSnapControllerMessenger();
-    const initialPermissions = {
+    const initialPermissions: SnapPermissions = {
+      // @ts-expect-error Current type only expects snap permissions
       // eslint-disable-next-line @typescript-eslint/naming-convention
       eth_accounts: {
         requiredMethods: [],
       },
-    } as any;
+    };
     const snapController = getSnapController(
       getSnapControllerOptions({
         messenger,

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2088,10 +2088,7 @@ export class SnapController extends BaseController<
    */
   #processSnapPermissions(
     initialPermissions: SnapPermissions,
-  ): Record<
-    string,
-    Pick<PermissionConstraint, 'caveats'> | Record<string, never>
-  > {
+  ): Record<string, Pick<PermissionConstraint, 'caveats'>> {
     return fromEntries(
       Object.entries(initialPermissions).map(([initialPermission, value]) => {
         if (hasProperty(caveatMappers, initialPermission)) {
@@ -2103,8 +2100,11 @@ export class SnapController extends BaseController<
           ];
         }
 
-        assert(Object.keys(value).length === 0);
-        return [initialPermission, {}];
+        // If we have no mapping, this may be a non-snap permission, return as-is
+        return [
+          initialPermission,
+          value as Pick<PermissionConstraint, 'caveats'>,
+        ];
       }),
     );
   }


### PR DESCRIPTION
Reverts snap permission processing change that broke non-snap permissions. Also adds a test to catch a potential regression in the future.

Fixes #1043