### PR TITLE
Fix utils browser export

### DIFF
--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -20,7 +20,7 @@
   },
   "main": "dist/index.js",
   "browser": {
-    "./dist/index": "./dist/index.browser.js"
+    "./dist/index.js": "./dist/index.browser.js"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
Fixes the browser export on `snaps-utils`. Without this change Browserify would pull in our normal bundle in the extension.