### PR TITLE
Hotfix for SnapLocation paths being wrongly normalized

### DIFF
--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,7 +5,7 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 91.08,
+      branches: 91.04,
       functions: 97.45,
       lines: 97.45,
       statements: 97.45,

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,7 +5,7 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 90.81,
+      branches: 91.08,
       functions: 97.45,
       lines: 97.45,
       statements: 97.45,

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -15,6 +15,8 @@ import {
   SnapPermissions,
   SnapStatus,
   VirtualFile,
+  SnapManifest,
+  NpmSnapFileNames,
 } from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
@@ -2578,6 +2580,36 @@ describe('SnapController', () => {
       controller.destroy();
       await service.terminateAllSnaps();
     });
+
+    it('handles unnormalized paths correctly', async () => {
+      const manifest = getSnapManifest({
+        filePath: './bundle.js',
+        iconPath: 'icon.svg',
+      });
+      const controller = getSnapController(
+        getSnapControllerOptions({
+          detectSnapLocation: loopbackDetect({
+            manifest: new VirtualFile<SnapManifest>({
+              result: manifest,
+              value: JSON.stringify(manifest),
+              path: NpmSnapFileNames.Manifest,
+            }),
+            files: [
+              new VirtualFile({
+                value: DEFAULT_SNAP_BUNDLE,
+                path: 'bundle.js',
+              }),
+              new VirtualFile({ value: DEFAULT_SNAP_ICON, path: 'icon.svg' }),
+            ],
+          }),
+        }),
+      );
+
+      const result = await controller.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
+      });
+      expect((result[MOCK_SNAP_ID] as any).error).toBeUndefined();
+    });
   });
 
   describe('updateSnap', () => {
@@ -3189,6 +3221,8 @@ describe('SnapController', () => {
       await snapController.installSnaps(MOCK_ORIGIN, { [MOCK_SNAP_ID]: {} });
       await snapController.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
     });
+
+    it.todo('handles unnormalized paths correctly');
   });
 
   describe('enableSnap', () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3222,7 +3222,29 @@ describe('SnapController', () => {
       await snapController.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
     });
 
-    it.todo('handles unnormalized paths correctly');
+    it('handles unnormalized paths correctly', async () => {
+      const messenger = getSnapControllerMessenger();
+      const controller = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+          detectSnapLocation: loopbackDetect({
+            manifest: getSnapManifest({
+              version: '1.2.0' as SemVerVersion,
+              filePath: './dist/bundle.js',
+              iconPath: './images/icon.svg',
+            }),
+          }),
+        }),
+      );
+
+      await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+
+      const newSnap = controller.get(MOCK_SNAP_ID);
+      expect(newSnap?.version).toBe('1.2.0');
+    });
   });
 
   describe('enableSnap', () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2028,7 +2028,9 @@ export class SnapController extends BaseController<
       )
       ?.toString();
     const svgIcon = files.find(
-      (file) => file.path === manifest.result.source.location.npm.iconPath,
+      (file) =>
+        manifest.result.source.location.npm.iconPath !== undefined &&
+        file.path === manifest.result.source.location.npm.iconPath,
     );
     assert(sourceCode !== undefined);
     if (typeof sourceCode !== 'string' || sourceCode.length === 0) {

--- a/packages/snaps-controllers/src/snaps/location/http.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.test.ts
@@ -62,8 +62,8 @@ describe('HttpLocation', () => {
     const manifest = await location.manifest();
     const bundle = await location.fetch('./foo.js');
 
-    expect(manifest.path).toBe('./snap.manifest.json');
-    expect(bundle.path).toBe('./foo.js');
+    expect(manifest.path).toBe('snap.manifest.json');
+    expect(bundle.path).toBe('foo.js');
     expect(manifest.data.canonicalPath).toBe(canonical.manifest);
     expect(bundle.data.canonicalPath).toBe(canonical.bundle);
   });

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -1,9 +1,9 @@
 import {
   SnapManifest,
-  assertIsSnapManifest,
   VirtualFile,
   HttpSnapIdStruct,
   NpmSnapFileNames,
+  createSnapManifest,
 } from '@metamask/snaps-utils';
 import { assert, assertStruct } from '@metamask/utils';
 
@@ -60,11 +60,10 @@ export class HttpLocation implements SnapLocation {
       await this.fetchFn(canonicalPath, this.fetchOptions)
     ).text();
     const manifest = JSON.parse(contents);
-    assertIsSnapManifest(manifest);
     const vfile = new VirtualFile<SnapManifest>({
       value: contents,
-      result: manifest,
-      path: `./${NpmSnapFileNames.Manifest}`,
+      result: createSnapManifest(manifest),
+      path: NpmSnapFileNames.Manifest,
       data: { canonicalPath },
     });
     this.validatedManifest = vfile;

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -7,7 +7,7 @@ import {
 } from '@metamask/snaps-utils';
 import { assert, assertStruct } from '@metamask/utils';
 
-import { ensureRelative } from '../../utils';
+import { normalizeRelative } from '../../utils';
 import { SnapLocation } from './location';
 
 export interface HttpOptions {
@@ -73,7 +73,7 @@ export class HttpLocation implements SnapLocation {
   }
 
   async fetch(path: string): Promise<VirtualFile> {
-    const relativePath = ensureRelative(path);
+    const relativePath = normalizeRelative(path);
     const cached = this.cache.get(relativePath);
     if (cached !== undefined) {
       const { file, contents } = cached;

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -4,10 +4,10 @@ import {
   HttpSnapIdStruct,
   NpmSnapFileNames,
   createSnapManifest,
+  normalizeRelative,
 } from '@metamask/snaps-utils';
 import { assert, assertStruct } from '@metamask/utils';
 
-import { normalizeRelative } from '../../utils';
 import { SnapLocation } from './location';
 
 export interface HttpOptions {

--- a/packages/snaps-controllers/src/snaps/location/local.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/local.test.ts
@@ -65,8 +65,8 @@ describe('LocalLocation', () => {
     const manifest = await location.manifest();
     const bundle = await location.fetch('./foo.js');
 
-    expect(manifest.path).toBe('./snap.manifest.json');
-    expect(bundle.path).toBe('./foo.js');
+    expect(manifest.path).toBe('snap.manifest.json');
+    expect(bundle.path).toBe('foo.js');
     expect(manifest.data.canonicalPath).toBe(canonical.manifest);
     expect(bundle.data.canonicalPath).toBe(canonical.bundle);
   });

--- a/packages/snaps-controllers/src/snaps/location/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.test.ts
@@ -132,18 +132,6 @@ describe('NpmLocation', () => {
   // TODO(ritave): Doing this tests requires writing tarball packing utility function
   //               With the the current changeset going way out of scope, I'm leaving this for future.
   it.todo('sets canonical path properly');
-  // eslint-disable-next-line jest/no-commented-out-tests
-  /*
-  it.each([
-    ['npm:foo', 'npm://registry.npmjs.org/foo/foo.js'],
-    [
-      'npm:@foo/bar',
-      ['npm://registry.npmjs.org/@foo/bar/foo.js'],
-      [
-        'npm://user:pass@asd.com:8080/@foo/bar',
-        'npm://user:pass@asd.com:8080/@foo/bar/foo.js',
-      ],
-    ],
-  ]);
-  */
+  // TODO(ritave): Requires writing tarball packing utility out of scope for a hot-fix blocking release.
+  it.todo('paths are normalized to remove "./" prefix');
 });

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -9,6 +9,7 @@ import {
   SemVerVersion,
   SnapManifest,
   VirtualFile,
+  normalizeRelative,
 } from '@metamask/snaps-utils';
 import { assert, assertStruct, isObject } from '@metamask/utils';
 import concat from 'concat-stream';
@@ -18,7 +19,6 @@ import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
 import { Readable, Writable } from 'stream';
 import { extract as tarExtract } from 'tar-stream';
 
-import { normalizeRelative } from '../../utils';
 import { DetectSnapLocationOptions, SnapLocation } from './location';
 
 const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org';

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -1,6 +1,6 @@
 import {
   assertIsSemVerVersion,
-  assertIsSnapManifest,
+  createSnapManifest,
   DEFAULT_REQUESTED_SNAP_VERSION,
   getTargetVersion,
   isValidUrl,
@@ -112,10 +112,9 @@ export class NpmLocation implements SnapLocation {
       return this.validatedManifest.clone();
     }
 
-    const vfile = await this.fetch('./snap.manifest.json');
+    const vfile = await this.fetch('snap.manifest.json');
     const result = JSON.parse(vfile.toString());
-    assertIsSnapManifest(result);
-    vfile.result = result;
+    vfile.result = createSnapManifest(result);
     this.validatedManifest = vfile as VirtualFile<SnapManifest>;
 
     return this.manifest();

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -18,7 +18,7 @@ import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
 import { Readable, Writable } from 'stream';
 import { extract as tarExtract } from 'tar-stream';
 
-import { ensureRelative } from '../../utils';
+import { normalizeRelative } from '../../utils';
 import { DetectSnapLocationOptions, SnapLocation } from './location';
 
 const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org';
@@ -122,7 +122,7 @@ export class NpmLocation implements SnapLocation {
   }
 
   async fetch(path: string): Promise<VirtualFile> {
-    const relativePath = ensureRelative(path);
+    const relativePath = normalizeRelative(path);
     if (!this.files) {
       await this.#lazyInit();
       assert(this.files !== undefined);
@@ -320,7 +320,7 @@ function createTarballStream(
     const { name: headerName, type: headerType } = header;
     if (headerType === 'file') {
       // The name is a path if the header type is "file".
-      const path = headerName.replace(NPM_TARBALL_PATH_PREFIX, './');
+      const path = headerName.replace(NPM_TARBALL_PATH_PREFIX, '');
       return entryStream.pipe(
         concat((data) => {
           const vfile = new VirtualFile({

--- a/packages/snaps-controllers/src/test-utils/location.ts
+++ b/packages/snaps-controllers/src/test-utils/location.ts
@@ -1,4 +1,8 @@
-import { VirtualFile, SnapManifest } from '@metamask/snaps-utils';
+import {
+  VirtualFile,
+  SnapManifest,
+  createSnapManifest,
+} from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
   DEFAULT_SNAP_ICON,
@@ -7,7 +11,7 @@ import {
 import { assert } from '@metamask/utils';
 import { SnapLocation } from 'src/snaps/location';
 
-const MANIFEST_PATH = './snap.manifest.json';
+const MANIFEST_PATH = 'snap.manifest.json';
 
 type LoopbackOptions = {
   /**
@@ -24,6 +28,12 @@ type LoopbackOptions = {
   shouldAlwaysReload?: boolean;
 };
 
+// Mirror NPM and HTTP implementation
+const coerceManifest = (manifest: VirtualFile<SnapManifest>) => {
+  manifest.result = createSnapManifest(manifest.result);
+  return manifest;
+};
+
 export class LoopbackLocation implements SnapLocation {
   #manifest: VirtualFile<SnapManifest>;
 
@@ -33,14 +43,15 @@ export class LoopbackLocation implements SnapLocation {
 
   constructor(opts: LoopbackOptions = {}) {
     const shouldAlwaysReload = opts.shouldAlwaysReload ?? false;
-    const manifest =
+    const manifest = coerceManifest(
       opts.manifest instanceof VirtualFile
         ? opts.manifest
         : new VirtualFile({
             value: '',
             result: opts.manifest ?? getSnapManifest(),
-            path: './snap.manifest.json',
-          });
+            path: 'snap.manifest.json',
+          }),
+    );
     let files;
     if (opts.files === undefined) {
       files = [

--- a/packages/snaps-controllers/src/utils.test.ts
+++ b/packages/snaps-controllers/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { AssertionError } from '@metamask/utils';
 
-import { ensureRelative, setDiff } from './utils';
+import { normalizeRelative, setDiff } from './utils';
 
 describe('setDiff', () => {
   it('does nothing on empty type {}-B', () => {
@@ -32,22 +32,22 @@ describe('setDiff', () => {
   });
 });
 
-describe('ensureRelative', () => {
+describe('normalizeRelative', () => {
   it('throws on absolute paths', () => {
-    expect(() => ensureRelative('/foo/bar.js')).toThrow(AssertionError);
+    expect(() => normalizeRelative('/foo/bar.js')).toThrow(AssertionError);
   });
 
   it('throws on URIs', () => {
-    expect(() => ensureRelative('http://foo.bar')).toThrow(
+    expect(() => normalizeRelative('http://foo.bar')).toThrow(
       'Path "http://foo.bar" potentially an URI instead of local relative',
     );
   });
 
-  it('does nothing on "./" paths', () => {
-    expect(ensureRelative('./foo/bar.js')).toBe('./foo/bar.js');
+  it('removes "./" prefix', () => {
+    expect(normalizeRelative('./foo/bar.js')).toBe('foo/bar.js');
   });
 
-  it('adds "./" if it\'s missing', () => {
-    expect(ensureRelative('foo/bar.js')).toBe('./foo/bar.js');
+  it("does nothing if there's no prefix", () => {
+    expect(normalizeRelative('foo/bar.js')).toBe('foo/bar.js');
   });
 });

--- a/packages/snaps-controllers/src/utils.test.ts
+++ b/packages/snaps-controllers/src/utils.test.ts
@@ -1,6 +1,4 @@
-import { AssertionError } from '@metamask/utils';
-
-import { normalizeRelative, setDiff } from './utils';
+import { setDiff } from './utils';
 
 describe('setDiff', () => {
   it('does nothing on empty type {}-B', () => {
@@ -29,25 +27,5 @@ describe('setDiff', () => {
   it('works for the same object A-A', () => {
     const object = { a: 'foo', b: 'bar' };
     expect(setDiff(object, object)).toStrictEqual({});
-  });
-});
-
-describe('normalizeRelative', () => {
-  it('throws on absolute paths', () => {
-    expect(() => normalizeRelative('/foo/bar.js')).toThrow(AssertionError);
-  });
-
-  it('throws on URIs', () => {
-    expect(() => normalizeRelative('http://foo.bar')).toThrow(
-      'Path "http://foo.bar" potentially an URI instead of local relative',
-    );
-  });
-
-  it('removes "./" prefix', () => {
-    expect(normalizeRelative('./foo/bar.js')).toBe('foo/bar.js');
-  });
-
-  it("does nothing if there's no prefix", () => {
-    expect(normalizeRelative('foo/bar.js')).toBe('foo/bar.js');
   });
 });

--- a/packages/snaps-controllers/src/utils.ts
+++ b/packages/snaps-controllers/src/utils.ts
@@ -202,12 +202,12 @@ export type Mutable<
 };
 
 /**
- * Ensures that a relative path starts with `./` prefix.
+ * Normalizes relative paths by optionally removing `./` prefix.
  *
- * @param path - Path to make relative.
- * @returns The same path, with optional `./` prefix.
+ * @param path - Path to make normalize.
+ * @returns The same path, with `./` prefix remove.
  */
-export function ensureRelative(path: string): string {
+export function normalizeRelative(path: string): string {
   assert(!path.startsWith('/'));
   assert(
     path.search(/:|\/\//u) === -1,
@@ -215,7 +215,7 @@ export function ensureRelative(path: string): string {
   );
 
   if (path.startsWith('./')) {
-    return path;
+    return path.slice(2);
   }
-  return `./${path}`;
+  return path;
 }

--- a/packages/snaps-controllers/src/utils.ts
+++ b/packages/snaps-controllers/src/utils.ts
@@ -1,5 +1,3 @@
-import { assert } from '@metamask/utils';
-
 import { Timer } from './snaps/Timer';
 
 /**
@@ -200,22 +198,3 @@ export type Mutable<
 } & {
   [Key in keyof Omit<T, TargetKey>]: T[Key];
 };
-
-/**
- * Normalizes relative paths by optionally removing `./` prefix.
- *
- * @param path - Path to make normalize.
- * @returns The same path, with `./` prefix remove.
- */
-export function normalizeRelative(path: string): string {
-  assert(!path.startsWith('/'));
-  assert(
-    path.search(/:|\/\//u) === -1,
-    `Path "${path}" potentially an URI instead of local relative`,
-  );
-
-  if (path.startsWith('./')) {
-    return path.slice(2);
-  }
-  return path;
-}

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -7,6 +7,7 @@ export * from './manifest/index.browser';
 export * from './namespace';
 export * from './notification';
 export * from './object';
+export * from './path';
 export * from './snaps';
 export * from './types';
 export * from './versions';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -12,6 +12,7 @@ export * from './namespace';
 export * from './notification';
 export * from './npm';
 export * from './object';
+export * from './path';
 export * from './post-process';
 export * from './snaps';
 export * from './types';

--- a/packages/snaps-utils/src/manifest/validation.test.ts
+++ b/packages/snaps-utils/src/manifest/validation.test.ts
@@ -7,6 +7,7 @@ import {
   Base64Opts,
   Bip32EntropyStruct,
   Bip32PathStruct,
+  createSnapManifest,
   isSnapManifest,
 } from './validation';
 
@@ -226,5 +227,40 @@ describe('assertIsSnapManifest', () => {
     expect(() => assertIsSnapManifest(value)).toThrow(
       '"snap.manifest.json" is invalid:',
     );
+  });
+});
+
+describe('createSnapManifest', () => {
+  it('does not throw for a valid snap manifest', () => {
+    expect(() => createSnapManifest(getSnapManifest())).not.toThrow();
+  });
+
+  it('coerces source paths', () => {
+    expect(
+      createSnapManifest(
+        getSnapManifest({ filePath: './bundle.js', iconPath: './icon.svg' }),
+      ),
+    ).toStrictEqual(
+      getSnapManifest({ filePath: 'bundle.js', iconPath: 'icon.svg' }),
+    );
+  });
+
+  it.each([
+    true,
+    false,
+    null,
+    undefined,
+    0,
+    1,
+    '',
+    'foo',
+    [],
+    {},
+    { name: 'foo' },
+    { version: '1.0.0' },
+    getSnapManifest({ version: 'foo bar' }),
+  ])('throws for an invalid snap manifest', (value) => {
+    // eslint-disable-next-line jest/require-to-throw-message
+    expect(() => createSnapManifest(value)).toThrow();
   });
 });

--- a/packages/snaps-utils/src/manifest/validation.test.ts
+++ b/packages/snaps-utils/src/manifest/validation.test.ts
@@ -1,4 +1,4 @@
-import { assert, is, size, string } from 'superstruct';
+import { assert, is, size, string, StructError } from 'superstruct';
 
 import { getSnapManifest } from '../test-utils';
 import {
@@ -260,7 +260,6 @@ describe('createSnapManifest', () => {
     { version: '1.0.0' },
     getSnapManifest({ version: 'foo bar' }),
   ])('throws for an invalid snap manifest', (value) => {
-    // eslint-disable-next-line jest/require-to-throw-message
-    expect(() => createSnapManifest(value)).toThrow();
+    expect(() => createSnapManifest(value)).toThrow(StructError);
   });
 });

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -3,6 +3,7 @@ import {
   array,
   boolean,
   coerce,
+  create,
   enums,
   Infer,
   integer,
@@ -247,4 +248,17 @@ export function assertIsSnapManifest(
     SnapManifestStruct,
     `"${NpmSnapFileNames.Manifest}" is invalid`,
   );
+}
+
+/**
+ * Creates a {@link SnapManifest} object from JSON.
+ *
+ *
+ * @param value - The value to check.
+ * @throws If the value cannot be coerced to a {@link SnapManifest} object.
+ * @returns The created {@link SnapManifest} object.
+ */
+export function createSnapManifest(value: unknown): SnapManifest {
+  // TODO: Add a utility to prefix these errors similar to assertStruct
+  return create(value, SnapManifestStruct);
 }

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -2,6 +2,7 @@ import { assert, assertStruct } from '@metamask/utils';
 import {
   array,
   boolean,
+  coerce,
   enums,
   Infer,
   integer,
@@ -21,6 +22,7 @@ import {
 import { CronjobSpecificationArrayStruct } from '../cronjob';
 import { RpcOriginsStruct } from '../json-rpc';
 import { NamespacesStruct } from '../namespace';
+import { normalizeRelative } from '../path';
 import { NameStruct, NpmSnapFileNames } from '../types';
 import { VersionStruct } from '../versions';
 
@@ -179,6 +181,9 @@ export const PermissionsStruct = type({
 });
 /* eslint-enable @typescript-eslint/naming-convention */
 
+const relativePath = <Type extends string>(struct: Struct<Type>) =>
+  coerce(struct, struct, (value) => normalizeRelative(value));
+
 export type SnapPermissions = Infer<typeof PermissionsStruct>;
 
 export const SnapManifestStruct = object({
@@ -202,8 +207,8 @@ export const SnapManifestStruct = object({
     shasum: size(base64(string(), { paddingRequired: true }), 44, 44),
     location: object({
       npm: object({
-        filePath: size(string(), 1, Infinity),
-        iconPath: optional(size(string(), 1, Infinity)),
+        filePath: relativePath(size(string(), 1, Infinity)),
+        iconPath: optional(relativePath(size(string(), 1, Infinity))),
         packageName: NameStruct,
         registry: union([
           literal('https://registry.npmjs.org'),

--- a/packages/snaps-utils/src/path.test.ts
+++ b/packages/snaps-utils/src/path.test.ts
@@ -1,0 +1,23 @@
+import { AssertionError } from '@metamask/utils';
+
+import { normalizeRelative } from './path';
+
+describe('normalizeRelative', () => {
+  it('throws on absolute paths', () => {
+    expect(() => normalizeRelative('/foo/bar.js')).toThrow(AssertionError);
+  });
+
+  it('throws on URIs', () => {
+    expect(() => normalizeRelative('http://foo.bar')).toThrow(
+      'Path "http://foo.bar" potentially an URI instead of local relative',
+    );
+  });
+
+  it('removes "./" prefix', () => {
+    expect(normalizeRelative('./foo/bar.js')).toBe('foo/bar.js');
+  });
+
+  it("does nothing if there's no prefix", () => {
+    expect(normalizeRelative('foo/bar.js')).toBe('foo/bar.js');
+  });
+});

--- a/packages/snaps-utils/src/path.ts
+++ b/packages/snaps-utils/src/path.ts
@@ -1,0 +1,21 @@
+import { assert } from '@metamask/utils';
+
+/**
+ * Normalizes relative paths by optionally removing `./` prefix.
+ *
+ * @param path - Path to make normalize.
+ * @returns The same path, with `./` prefix remove.
+ */
+// TODO(ritave): Include NodeJS path polyfill and use path.normalize as well
+export function normalizeRelative(path: string): string {
+  assert(!path.startsWith('/'));
+  assert(
+    path.search(/:|\/\//u) === -1,
+    `Path "${path}" potentially an URI instead of local relative`,
+  );
+
+  if (path.startsWith('./')) {
+    return path.slice(2);
+  }
+  return path;
+}


### PR DESCRIPTION
This PR stops prefixing paths internally with `./`. It also adds SnapManifest coercing that normalizes the bundle and icon paths to be non-prefixed.