### PR TITLE
Fix usage of wrong `ethereum` object for `ethereum` endowment

### DIFF
--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -64,6 +64,16 @@ describe('Endowment utils', () => {
       expect(endowments.mockEndowment).toBeDefined();
     });
 
+    it('handles special case for ethereum endowment', () => {
+      Object.assign(globalThis, { ethereum: {} });
+      const { endowments } = createEndowments(
+        mockSnapAPI as any,
+        mockEthereum as any,
+        ['ethereum'],
+      );
+      expect(endowments.ethereum).toBe(mockEthereum);
+    });
+
     it('handles factory endowments', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -84,6 +84,9 @@ export function createEndowments(
         }
 
         allEndowments[endowmentName] = attenuatedEndowments[endowmentName];
+      } else if (endowmentName === 'ethereum') {
+        // Special case for adding the EIP-1193 provider.
+        allEndowments[endowmentName] = ethereum;
       } else if (endowmentName in rootRealmGlobal) {
         // If the endowment doesn't have a factory, just use whatever is on the
         // global object.
@@ -94,9 +97,6 @@ export function createEndowments(
           typeof globalValue === 'function' && !isConstructor(globalValue)
             ? globalValue.bind(rootRealmGlobal)
             : globalValue;
-      } else if (endowmentName === 'ethereum') {
-        // Special case for adding the EIP-1193 provider.
-        allEndowments[endowmentName] = ethereum;
       } else {
         // If we get to this point, we've been passed an endowment that doesn't
         // exist in our current environment.


### PR DESCRIPTION
In production we were accidentally using `globalThis.ethereum` instead of our limited EIP-1193 provider. This PR fixes that by moving an if-statement.