### PR TITLE
Prefer Babel for Jest coverage

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -53,6 +53,8 @@ jobs:
       - run: yarn --immutable
       - run: yarn build
       - run: yarn workspace @metamask/snaps-controllers run test:ci
+      - name: CodeCov
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       - name: Require clean working directory
         shell: bash
         run: |

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -31,7 +31,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['./src/index.ts'],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: 'v8',
+  coverageProvider: 'babel',
 
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: ['html', 'json-summary', 'text', 'json'],

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -22,7 +22,11 @@ module.exports = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['./src/**/*.ts', '!./src/**/*.test.ts'],
+  collectCoverageFrom: [
+    './src/**/*.ts',
+    '!./src/**/*.test.ts',
+    '!./src/test-utils/**/*.ts',
+  ],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -6,10 +6,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 87.09,
-      functions: 87.27,
-      lines: 83.27,
-      statements: 83.27,
+      branches: 74.63,
+      functions: 83.33,
+      lines: 83.46,
+      statements: 82.44,
     },
   },
   testTimeout: 2500,

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -6,10 +6,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/types'],
   coverageThreshold: {
     global: {
-      branches: 97.89,
-      functions: 98.07,
-      lines: 99.47,
-      statements: 99.47,
+      branches: 98.09,
+      functions: 94.73,
+      lines: 98.51,
+      statements: 98.52,
     },
   },
   setupFiles: ['./test/setup.js'],

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -7,9 +7,9 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 98.09,
-      functions: 94.73,
-      lines: 98.51,
-      statements: 98.52,
+      functions: 94.66,
+      lines: 98.49,
+      statements: 98.5,
     },
   },
   setupFiles: ['./test/setup.js'],

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,10 +5,10 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 87.94,
-      functions: 94.69,
-      lines: 95.4,
-      statements: 95.4,
+      branches: 87.92,
+      functions: 94.44,
+      lines: 95.6,
+      statements: 95.52,
     },
   },
   projects: [

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,10 +5,10 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 0.04,
-      functions: 0.45,
-      lines: 0.45,
-      statements: 0.45,
+      branches: 87.94,
+      functions: 94.69,
+      lines: 95.4,
+      statements: 95.4,
     },
   },
   projects: [

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,10 +5,10 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 91.04,
-      functions: 97.45,
-      lines: 97.45,
-      statements: 97.45,
+      branches: 0.04,
+      functions: 0.45,
+      lines: 0.45,
+      statements: 0.45,
     },
   },
   projects: [

--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts', '.ava.test.ts'],
   coverageThreshold: {
     global: {
-      branches: 89.78,
-      functions: 90.51,
-      lines: 88.46,
-      statements: 88.46,
+      branches: 83.68,
+      functions: 92.19,
+      lines: 87.11,
+      statements: 87.22,
     },
   },
   testEnvironment: '<rootDir>/jest.environment.js',

--- a/packages/snaps-utils/jest.config.js
+++ b/packages/snaps-utils/jest.config.js
@@ -18,10 +18,10 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 94.42,
-      functions: 97.95,
-      lines: 95.11,
-      statements: 95.11,
+      branches: 91.31,
+      functions: 99.28,
+      lines: 98.89,
+      statements: 98.91,
     },
   },
   testTimeout: 2500,


### PR DESCRIPTION
Change coverage provider to hopefully improve reliability of code coverage numbers.

The previously selected coverage provider seemed to be counting type information as lines covered.

Also add CodeCov reporting for controllers and ignore test-utils in coverage.