### PR TITLE
Add experimental offscreen execution environment

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -26,6 +26,7 @@ module.exports = {
     './src/**/*.ts',
     '!./src/**/*.test.ts',
     '!./src/test-utils/**/*.ts',
+    '!./src/**/*.d.ts',
   ],
 
   // The directory where Jest should output its coverage files

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -169,9 +169,7 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: ['.ava.test.ts'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
       "prettier --write"
     ]
   },
-  "resolutions": {
-    "@metamask/post-message-stream": "portal:/Users/morten/Development/MetaMask/post-message-stream"
-  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
       "prettier --write"
     ]
   },
+  "resolutions": {
+    "@metamask/post-message-stream": "portal:/Users/morten/Development/MetaMask/post-message-stream"
+  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -6,7 +6,7 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 88.64,
-      functions: 94.42,
+      functions: 94.67,
       lines: 96,
       statements: 95.92,
     },

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,10 +5,10 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 88.48,
-      functions: 93.25,
-      lines: 95.22,
-      statements: 95.14,
+      branches: 88.64,
+      functions: 94.42,
+      lines: 96,
+      statements: 95.92,
     },
   },
   projects: [

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,10 +5,10 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 88.32,
-      functions: 92.37,
-      lines: 94.61,
-      statements: 94.54,
+      branches: 88.48,
+      functions: 93.25,
+      lines: 95.22,
+      statements: 95.14,
     },
   },
   projects: [

--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -6,9 +6,9 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 88.32,
-      functions: 94.37,
-      lines: 95.8,
-      statements: 95.73,
+      functions: 92.37,
+      lines: 94.61,
+      statements: 94.54,
     },
   },
   projects: [

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -35,7 +35,7 @@
     "@metamask/base-controller": "^1.1.1",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/permission-controller": "^1.0.1",
-    "@metamask/post-message-stream": "^6.0.0",
+    "@metamask/post-message-stream": "^6.1.0",
     "@metamask/rpc-methods": "^0.27.1",
     "@metamask/snaps-execution-environments": "^0.27.1",
     "@metamask/snaps-registry": "^1.0.0",

--- a/packages/snaps-controllers/src/services/AbstractExecutionService.ts
+++ b/packages/snaps-controllers/src/services/AbstractExecutionService.ts
@@ -151,7 +151,7 @@ export abstract class AbstractExecutionService<WorkerType>
     );
 
     if (result === hasTimedOut || result !== 'OK') {
-      // We tried to shutdown gracefully but failed. This probably means the Snap is in infite loop and
+      // We tried to shutdown gracefully but failed. This probably means the Snap is in infinite loop and
       // hogging down the whole JS process.
       // TODO(ritave): It might be doing weird things such as posting a lot of setTimeouts. Add a test to ensure that this behaviour
       //               doesn't leak into other workers. Especially important in IframeExecutionEnvironment since they all share the same
@@ -264,6 +264,7 @@ export abstract class AbstractExecutionService<WorkerType>
         );
       }
     };
+
     commandStream.on('data', notificationHandler);
     const rpcStream = mux.createStream(SNAP_STREAM_NAMES.JSON_RPC);
 

--- a/packages/snaps-controllers/src/services/browser.test.ts
+++ b/packages/snaps-controllers/src/services/browser.test.ts
@@ -5,6 +5,8 @@ describe('browser entrypoint', () => {
     'AbstractExecutionService',
     'setupMultiplex',
     'IframeExecutionService',
+    'OffscreenExecutionService',
+    'OffscreenPostMessageStream',
   ];
 
   it('entrypoint has expected exports', () => {

--- a/packages/snaps-controllers/src/services/browser.ts
+++ b/packages/snaps-controllers/src/services/browser.ts
@@ -2,3 +2,4 @@
 export * from './AbstractExecutionService';
 export * from './ExecutionService';
 export * from './iframe';
+export * from './offscreen';

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.test.ts
@@ -52,6 +52,8 @@ describe('IframeExecutionService', () => {
 
   // eslint-disable-next-line jest/no-done-callback, consistent-return
   afterAll((done) => {
+    // `server` is undefined if the server failed to start. This is unlikely to
+    // happen, but we check it anyway to keep TypeScript happy.
     if (!server) {
       return done();
     }

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
@@ -2,6 +2,7 @@ import {
   WindowPostMessageStream,
   BasePostMessageStream,
 } from '@metamask/post-message-stream';
+import { createWindow } from '@metamask/snaps-utils';
 
 import {
   Job,
@@ -36,10 +37,7 @@ export class IframeExecutionService extends AbstractExecutionService<Window> {
     worker: Window;
     stream: BasePostMessageStream;
   }> {
-    const iframeWindow = await this.createWindow(
-      this.iframeUrl.toString(),
-      jobId,
-    );
+    const iframeWindow = await createWindow(this.iframeUrl.toString(), jobId);
 
     const stream = new WindowPostMessageStream({
       name: 'parent',
@@ -49,64 +47,5 @@ export class IframeExecutionService extends AbstractExecutionService<Window> {
     });
 
     return { worker: iframeWindow, stream };
-  }
-
-  /**
-   * Creates the iframe to be used as the execution environment. This may run
-   * forever if the iframe never loads, but the promise should be wrapped in
-   * an initialization timeout in the SnapController.
-   *
-   * @param uri - The iframe URI.
-   * @param jobId - The job id.
-   * @returns A promise that resolves to the contentWindow of the iframe.
-   */
-  private async createWindow(uri: string, jobId: string): Promise<Window> {
-    return new Promise((resolve, reject) => {
-      const iframe = document.createElement('iframe');
-      // The order of operations appears to matter for everything except this
-      // attribute. We may as well set it here.
-      iframe.setAttribute('id', jobId);
-
-      // In the past, we've had problems that appear to be symptomatic of the
-      // iframe firing the `load` event before its scripts are actually loaded,
-      // which has prevented snaps from executing properly. Therefore, we set
-      // the `src` attribute and append the iframe to the DOM before attaching
-      // the `load` listener.
-      //
-      // `load` should only fire when "all dependent resources" have been
-      // loaded, which includes scripts.
-      //
-      // MDN article for `load` event: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
-      // Re: `load` firing twice: https://stackoverflow.com/questions/10781880/dynamically-created-iframe-triggers-onload-event-twice/15880489#15880489
-      iframe.setAttribute('src', uri);
-      document.body.appendChild(iframe);
-
-      iframe.addEventListener('load', () => {
-        if (iframe.contentWindow) {
-          resolve(iframe.contentWindow);
-        } else {
-          // We don't know of a case when this would happen, but better to fail
-          // fast if it does.
-          reject(
-            new Error(
-              `iframe.contentWindow not present on load for job "${jobId}".`,
-            ),
-          );
-        }
-      });
-
-      // We need to set the sandbox attribute after appending the iframe to the
-      // DOM, otherwise errors in the iframe will not be propagated via `error`
-      // and `unhandledrejection` events, and we cannot catch and handle them.
-      // We wish we knew why this was the case.
-      //
-      // We set this property after adding the `load` listener because it
-      // appears to work dependably. ¯\_(ツ)_/¯
-      //
-      // We apply this property as a principle of least authority (POLA)
-      // measure.
-      // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
-      iframe.setAttribute('sandbox', 'allow-scripts');
-    });
   }
 }

--- a/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
+++ b/packages/snaps-controllers/src/services/iframe/IframeExecutionService.ts
@@ -40,6 +40,7 @@ export class IframeExecutionService extends AbstractExecutionService<Window> {
       this.iframeUrl.toString(),
       jobId,
     );
+
     const stream = new WindowPostMessageStream({
       name: 'parent',
       target: 'child',

--- a/packages/snaps-controllers/src/services/iframe/test/fixJSDOMPostMessageEventSource.ts
+++ b/packages/snaps-controllers/src/services/iframe/test/fixJSDOMPostMessageEventSource.ts
@@ -4,55 +4,6 @@ import { IframeExecutionService } from '../IframeExecutionService';
 const fixJSDOMPostMessageEventSource = (
   iframeExecutionService: IframeExecutionService,
 ) => {
-  const oldCreateWindow = (iframeExecutionService as any).createWindow;
-  (iframeExecutionService as any).createWindow = async (
-    uri: string,
-    envId: string,
-    timeout: number,
-  ) => {
-    const result = await oldCreateWindow(uri, envId, timeout);
-
-    const scriptElement = result.document.createElement('script');
-
-    if (!scriptElement) {
-      return result;
-    }
-
-    // fix the inside window
-    scriptElement.textContent = `
-    window.addEventListener('message', (postMessageEvent) => {
-      if (postMessageEvent.source === null && !postMessageEvent.origin) {
-        let source;
-        let postMessageEventOrigin;
-        if (postMessageEvent.data.target === 'child') {
-          source = window.parent;
-          postMessageEventOrigin = '*';
-        } else if (postMessageEvent.data.target === 'parent') {
-          source = window;
-          postMessageEventOrigin = window.location.origin;
-        }
-        if (postMessageEvent.data.target) {
-          postMessageEvent.stopImmediatePropagation();
-          const args = Object.assign({
-            ...postMessageEvent,
-            data: postMessageEvent.data,
-            source,
-            origin: postMessageEventOrigin,
-          });
-          const postMessageEventWithOrigin = new MessageEvent(
-            'message',
-            args,
-          );
-          window.dispatchEvent(postMessageEventWithOrigin);
-        }
-      }
-    });
-  `;
-    result.document.body.appendChild(scriptElement);
-
-    return result;
-  };
-
   const listener = (event: MessageEvent) => {
     if (event.source === null && !event.origin) {
       let source;

--- a/packages/snaps-controllers/src/services/index.ts
+++ b/packages/snaps-controllers/src/services/index.ts
@@ -2,3 +2,4 @@ export * from './AbstractExecutionService';
 export * from './ExecutionService';
 export * from './iframe';
 export * from './node';
+export * from './offscreen';

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
@@ -1,0 +1,192 @@
+import { OffscreenExecutionService } from '@metamask/snaps-controllers';
+import { createService } from '@metamask/snaps-controllers/test-utils';
+import {
+  DEFAULT_SNAP_BUNDLE,
+  MOCK_LOCAL_SNAP_ID,
+  MOCK_SNAP_ID,
+} from '@metamask/snaps-utils/test-utils';
+import {
+  isJsonRpcRequest,
+  isPlainObject,
+  Json,
+  JsonRpcParams,
+  JsonRpcRequest,
+} from '@metamask/utils';
+
+import { getMockedFunction } from '../../test-utils/mock';
+
+const DOCUMENT_URL = new URL('https://foo');
+const FRAME_URL = new URL('https://bar');
+
+/**
+ * Create a response message for the given request. This function assumes that
+ * the response is for the parent, and uses the command stream.
+ *
+ * @param message - The request message.
+ * @param request - The request to respond to.
+ * @param response - The response to send.
+ * @returns The response message.
+ */
+function getResponse(
+  message: Record<string, unknown>,
+  request: JsonRpcRequest<JsonRpcParams>,
+  response: Json,
+) {
+  return {
+    target: 'parent',
+    data: {
+      jobId: message.jobId,
+      frameUrl: message.frameUrl,
+      data: {
+        name: 'command',
+        data: {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: response,
+        },
+      },
+    },
+  };
+}
+
+describe('OffscreenExecutionService', () => {
+  beforeEach(() => {
+    const addListener = jest.fn();
+    const sendMessage = jest.fn().mockImplementation((message) => {
+      // Propagate message to all listeners.
+      addListener.mock.calls.forEach(([listener]) => {
+        setTimeout(() => listener(message));
+      });
+    });
+
+    // Since we can't easily run the offscreen execution service in a real
+    // environment, we mock the responses that are expected from the service.
+    addListener((message: Record<string, unknown>) => {
+      const { target, data } = message;
+
+      if (target !== 'child') {
+        return;
+      }
+
+      // Respond with a handshake acknowledgement.
+      if (data === 'SYN') {
+        sendMessage({ target: 'parent', data: 'ACK' });
+      }
+
+      // Handle incoming requests.
+      if (
+        isPlainObject(data) &&
+        isPlainObject(data.data) &&
+        data.data.name === 'command' &&
+        isJsonRpcRequest(data.data.data)
+      ) {
+        const request = data.data.data;
+
+        // Respond "OK" to the `ping`, `executeSnap`, and `terminate` request.
+        if (
+          request.method === 'ping' ||
+          request.method === 'executeSnap' ||
+          request.method === 'terminate'
+        ) {
+          sendMessage(getResponse(data, request, 'OK'));
+        }
+      }
+    });
+
+    Object.assign(global, {
+      chrome: {
+        runtime: {
+          sendMessage,
+          onMessage: {
+            addListener,
+            removeListener: jest.fn(),
+          },
+        },
+
+        offscreen: {
+          hasDocument: jest.fn(),
+          createDocument: jest.fn(),
+        },
+      },
+    });
+  });
+
+  it('can boot', async () => {
+    const { service } = createService(OffscreenExecutionService, {
+      documentUrl: DOCUMENT_URL,
+      frameUrl: FRAME_URL,
+    });
+
+    expect(service).toBeDefined();
+    await service.terminateAllSnaps();
+  });
+
+  it('creates a document if it does not exist', async () => {
+    const { service } = createService(OffscreenExecutionService, {
+      documentUrl: DOCUMENT_URL,
+      frameUrl: FRAME_URL,
+    });
+
+    const hasDocument = getMockedFunction(chrome.offscreen.hasDocument);
+    const createDocument = getMockedFunction(chrome.offscreen.createDocument);
+
+    hasDocument.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    expect(hasDocument).not.toHaveBeenCalled();
+    expect(createDocument).not.toHaveBeenCalled();
+
+    // Run two snaps to ensure that the document is created only once.
+    expect(
+      await service.executeSnap({
+        snapId: MOCK_SNAP_ID,
+        sourceCode: DEFAULT_SNAP_BUNDLE,
+      }),
+    ).toBe('OK');
+
+    expect(
+      await service.executeSnap({
+        snapId: MOCK_LOCAL_SNAP_ID,
+        sourceCode: DEFAULT_SNAP_BUNDLE,
+      }),
+    ).toBe('OK');
+
+    expect(hasDocument).toHaveBeenCalledTimes(2);
+    expect(createDocument).toHaveBeenCalledTimes(1);
+    expect(createDocument).toHaveBeenCalledWith({
+      justification: 'MetaMask Snaps Execution Environment',
+      reasons: ['IFRAME_SCRIPTING'],
+      url: DOCUMENT_URL.toString(),
+    });
+
+    await service.terminateAllSnaps();
+  });
+
+  it('writes a termination command to the stream', async () => {
+    const { service } = createService(OffscreenExecutionService, {
+      documentUrl: DOCUMENT_URL,
+      frameUrl: FRAME_URL,
+    });
+
+    expect(
+      await service.executeSnap({
+        snapId: MOCK_SNAP_ID,
+        sourceCode: DEFAULT_SNAP_BUNDLE,
+      }),
+    ).toBe('OK');
+
+    await service.terminateSnap(MOCK_SNAP_ID);
+
+    const sendMessage = getMockedFunction(chrome.runtime.sendMessage);
+    expect(sendMessage).toHaveBeenLastCalledWith({
+      target: 'child',
+      data: {
+        jobId: expect.any(String),
+        data: {
+          jsonrpc: '2.0',
+          id: expect.any(String),
+          method: 'terminateJob',
+        },
+      },
+    });
+  });
+});

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.test.ts
@@ -9,7 +9,6 @@ import {
   isJsonRpcRequest,
   isPlainObject,
   Json,
-  JsonRpcParams,
   JsonRpcRequest,
 } from '@metamask/utils';
 
@@ -29,7 +28,7 @@ const FRAME_URL = new URL('https://bar');
  */
 function getResponse(
   message: Record<string, unknown>,
-  request: JsonRpcRequest<JsonRpcParams>,
+  request: JsonRpcRequest,
   response: Json,
 ) {
   return {

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -82,8 +82,7 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
     await this.createDocument();
 
     const stream = new OffscreenPostMessageStream({
-      name: 'parent',
-      target: 'child',
+      stream: this.#runtimeStream,
       frameUrl: this.frameUrl.toString(),
       jobId,
     });

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -1,0 +1,58 @@
+import {
+  BasePostMessageStream,
+  RuntimePostMessageStream,
+} from '@metamask/post-message-stream';
+
+import {
+  AbstractExecutionService,
+  ExecutionServiceArgs,
+} from '../AbstractExecutionService';
+
+type OffscreenExecutionEnvironmentServiceArgs = {
+  documentUrl: URL;
+} & ExecutionServiceArgs;
+
+export class OffscreenExecutionService extends AbstractExecutionService<undefined> {
+  public documentUrl: URL;
+
+  constructor({
+    documentUrl,
+    messenger,
+    setupSnapProvider,
+  }: OffscreenExecutionEnvironmentServiceArgs) {
+    super({
+      messenger,
+      setupSnapProvider,
+    });
+    this.documentUrl = documentUrl;
+  }
+
+  protected async terminateJob(): Promise<void> {
+    // await chrome.offscreen.closeDocument();
+  }
+
+  protected async initEnvStream(): Promise<{
+    worker: undefined;
+    stream: BasePostMessageStream;
+  }> {
+    await this.createDocument();
+
+    const stream = new RuntimePostMessageStream({
+      name: 'parent',
+      target: 'child',
+    });
+
+    return { worker: undefined, stream };
+  }
+
+  /**
+   * Creates the offscreen document to be used as the execution environment.
+   */
+  private async createDocument() {
+    await chrome.offscreen.createDocument({
+      justification: 'MetaMask Snaps Execution Environment',
+      reasons: ['IFRAME_SCRIPTING'],
+      url: this.documentUrl.toString(),
+    });
+  }
+}

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -10,10 +10,13 @@ import { OffscreenPostMessageStream } from './OffscreenPostMessageStream';
 
 type OffscreenExecutionEnvironmentServiceArgs = {
   documentUrl: URL;
+  frameUrl: URL;
 } & ExecutionServiceArgs;
 
 export class OffscreenExecutionService extends AbstractExecutionService<string> {
   public readonly documentUrl: URL;
+
+  public readonly frameUrl: URL;
 
   readonly #runtimeStream: BrowserRuntimePostMessageStream;
 
@@ -24,6 +27,8 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
    * @param args.documentUrl - The URL of the offscreen document to use as the
    * execution environment. This must be a URL relative to the location where
    * this is called. This cannot be a public (http(s)) URL.
+   * @param args.frameUrl - The URL of the iframe to load inside the offscreen
+   * document.
    * @param args.messenger - The messenger to use for communication with the
    * `SnapController`.
    * @param args.setupSnapProvider - The function to use to set up the snap
@@ -31,6 +36,7 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
    */
   constructor({
     documentUrl,
+    frameUrl,
     messenger,
     setupSnapProvider,
   }: OffscreenExecutionEnvironmentServiceArgs) {
@@ -40,6 +46,7 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
     });
 
     this.documentUrl = documentUrl;
+    this.frameUrl = frameUrl;
     this.#runtimeStream = new BrowserRuntimePostMessageStream({
       name: 'parent',
       target: 'child',
@@ -76,6 +83,7 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
 
     const stream = new OffscreenPostMessageStream({
       stream: this.#runtimeStream,
+      frameUrl: this.frameUrl.toString(),
       jobId,
     });
 

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -1,20 +1,33 @@
-import {
-  BasePostMessageStream,
-  RuntimePostMessageStream,
-} from '@metamask/post-message-stream';
+import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
 
 import {
   AbstractExecutionService,
   ExecutionServiceArgs,
+  Job,
 } from '../AbstractExecutionService';
+import { OffscreenPostMessageStream } from './OffscreenPostMessageStream';
 
 type OffscreenExecutionEnvironmentServiceArgs = {
   documentUrl: URL;
 } & ExecutionServiceArgs;
 
-export class OffscreenExecutionService extends AbstractExecutionService<undefined> {
-  public documentUrl: URL;
+export class OffscreenExecutionService extends AbstractExecutionService<string> {
+  public readonly documentUrl: URL;
 
+  readonly #runtimeStream: BrowserRuntimePostMessageStream;
+
+  /**
+   * Create a new offscreen execution service.
+   *
+   * @param args - The constructor arguments.
+   * @param args.documentUrl - The URL of the offscreen document to use as the
+   * execution environment. This must be a URL relative to the location where
+   * this is called. This cannot be a public (http(s)) URL.
+   * @param args.messenger - The messenger to use for communication with the
+   * `SnapController`.
+   * @param args.setupSnapProvider - The function to use to set up the snap
+   * provider.
+   */
   constructor({
     documentUrl,
     messenger,
@@ -24,31 +37,47 @@ export class OffscreenExecutionService extends AbstractExecutionService<undefine
       messenger,
       setupSnapProvider,
     });
+
     this.documentUrl = documentUrl;
-  }
-
-  protected async terminateJob(): Promise<void> {
-    // await chrome.offscreen.closeDocument();
-  }
-
-  protected async initEnvStream(): Promise<{
-    worker: undefined;
-    stream: BasePostMessageStream;
-  }> {
-    await this.createDocument();
-
-    const stream = new RuntimePostMessageStream({
+    this.#runtimeStream = new BrowserRuntimePostMessageStream({
       name: 'parent',
       target: 'child',
     });
+  }
 
-    return { worker: undefined, stream };
+  protected async terminateJob(_job: Job<string>): Promise<void> {
+    // TODO.
+  }
+
+  /**
+   * Create a new stream for the specified job. This wraps the runtime stream
+   * in a stream specific to the job.
+   *
+   * @param jobId - The job ID.
+   */
+  protected async initEnvStream(jobId: string) {
+    // Lazily create the offscreen document.
+    await this.createDocument();
+
+    const stream = new OffscreenPostMessageStream({
+      stream: this.#runtimeStream,
+      jobId,
+    });
+
+    return { worker: jobId, stream };
   }
 
   /**
    * Creates the offscreen document to be used as the execution environment.
+   *
+   * If the document already exists, this does nothing.
    */
   private async createDocument() {
+    // Extensions can only have a single offscreen document.
+    if (await chrome.offscreen.hasDocument()) {
+      return;
+    }
+
     await chrome.offscreen.createDocument({
       justification: 'MetaMask Snaps Execution Environment',
       reasons: ['IFRAME_SCRIPTING'],

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -1,4 +1,5 @@
 import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
+import { nanoid } from 'nanoid';
 
 import {
   AbstractExecutionService,
@@ -45,8 +46,22 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
     });
   }
 
-  protected async terminateJob(_job: Job<string>): Promise<void> {
-    // TODO.
+  /**
+   * Send a termination command to the offscreen document.
+   *
+   * @param job - The job to terminate.
+   */
+  protected async terminateJob(job: Job<string>) {
+    // The `AbstractExecutionService` will have already closed the job stream,
+    // so we write to the runtime stream directly.
+    this.#runtimeStream.write({
+      jobId: job.id,
+      data: {
+        jsonrpc: '2.0',
+        method: 'terminateJob',
+        id: nanoid(),
+      },
+    });
   }
 
   /**

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenExecutionService.ts
@@ -82,7 +82,8 @@ export class OffscreenExecutionService extends AbstractExecutionService<string> 
     await this.createDocument();
 
     const stream = new OffscreenPostMessageStream({
-      stream: this.#runtimeStream,
+      name: 'parent',
+      target: 'child',
       frameUrl: this.frameUrl.toString(),
       jobId,
     });

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
@@ -31,7 +31,7 @@ describe('OffScreenPostMessageStream', () => {
   });
 
   it('handles incoming messages with the right job id', async () => {
-    const mockStream = new MockPostMessageStream(jest.fn());
+    const mockStream = new MockPostMessageStream();
     const stream = new OffscreenPostMessageStream({
       stream: mockStream,
       jobId: MOCK_JOB_ID,

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
@@ -1,22 +1,7 @@
-import { BasePostMessageStream } from '@metamask/post-message-stream';
 import { OffscreenPostMessageStream } from '@metamask/snaps-controllers';
+import { MockPostMessageStream } from '@metamask/snaps-utils/test-utils';
 
 import { sleep } from '../../test-utils';
-
-class MockPostMessageStream extends BasePostMessageStream {
-  readonly #write: (...args: unknown[]) => unknown;
-
-  constructor(write: () => void) {
-    super();
-
-    this.#write = write;
-  }
-
-  protected _postMessage(data: unknown): void {
-    this.#write(data);
-    this.emit('data', data);
-  }
-}
 
 const MOCK_JOB_ID = 'job-id';
 const MOCK_FRAME_URL = 'frame-url';

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
@@ -4,7 +4,7 @@ import { OffscreenPostMessageStream } from '@metamask/snaps-controllers';
 import { sleep } from '../../test-utils';
 
 class MockPostMessageStream extends BasePostMessageStream {
-  #write: (...args: unknown[]) => unknown;
+  readonly #write: (...args: unknown[]) => unknown;
 
   constructor(write: () => void) {
     super();

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.test.ts
@@ -24,8 +24,10 @@ const MOCK_FRAME_URL = 'frame-url';
 describe('OffScreenPostMessageStream', () => {
   it('wraps messages with an iframe url and job id', async () => {
     const write = jest.fn();
+
+    const mockStream = new MockPostMessageStream(write);
     const stream = new OffscreenPostMessageStream({
-      stream: new MockPostMessageStream(write),
+      stream: mockStream,
       jobId: MOCK_JOB_ID,
       frameUrl: MOCK_FRAME_URL,
     });
@@ -39,6 +41,7 @@ describe('OffScreenPostMessageStream', () => {
       data: message,
     });
 
+    mockStream.destroy();
     stream.destroy();
   });
 
@@ -73,5 +76,8 @@ describe('OffScreenPostMessageStream', () => {
     expect(onData).toHaveBeenCalledTimes(1);
     expect(onData).toHaveBeenCalledWith({ foo: 'bar' });
     expect(onData).not.toHaveBeenCalledWith({ bar: 'baz' });
+
+    mockStream.destroy();
+    stream.destroy();
   });
 });

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
@@ -1,0 +1,65 @@
+import { BasePostMessageStream } from '@metamask/post-message-stream';
+import { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+
+export type OffscreenDuplexStreamArgs = {
+  stream: BasePostMessageStream;
+  jobId: string;
+};
+
+export type OffscreenDuplexStreamMessage = {
+  jobId: string;
+  data: JsonRpcRequest<JsonRpcParams>;
+};
+
+/**
+ * A post message stream that wraps messages in a job ID, before sending them
+ * over the underlying stream.
+ */
+export class OffscreenPostMessageStream extends BasePostMessageStream {
+  readonly #stream: BasePostMessageStream;
+
+  readonly #jobId: string;
+
+  /**
+   * Initializes a new `OffscreenDuplexStream` instance.
+   *
+   * @param args - The constructor arguments.
+   * @param args.stream - The underlying stream to use for communication.
+   * @param args.jobId - The ID of the job this stream is associated with.
+   */
+  constructor({ stream, jobId }: OffscreenDuplexStreamArgs) {
+    super();
+
+    this.#stream = stream;
+    this.#jobId = jobId;
+
+    this.#stream.on('data', this.#onData.bind(this));
+  }
+
+  /**
+   * Handle incoming data from the underlying stream. This checks that the job
+   * ID matches the expected job ID, and pushes the data to the stream if so.
+   *
+   * @param data - The data to handle.
+   */
+  #onData(data: OffscreenDuplexStreamMessage) {
+    if (data.jobId !== this.#jobId) {
+      return;
+    }
+
+    this.push(data.data);
+  }
+
+  /**
+   * Write data to the underlying stream. This wraps the data in an object with
+   * the job ID.
+   *
+   * @param data - The data to write.
+   */
+  _postMessage(data: OffscreenDuplexStreamMessage) {
+    this.#stream.write({
+      jobId: this.#jobId,
+      data,
+    });
+  }
+}

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
@@ -1,5 +1,5 @@
 import { BasePostMessageStream } from '@metamask/post-message-stream';
-import { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+import { JsonRpcRequest } from '@metamask/utils';
 
 export type OffscreenPostMessageStreamArgs = {
   stream: BasePostMessageStream;
@@ -9,7 +9,7 @@ export type OffscreenPostMessageStreamArgs = {
 
 export type OffscreenPostMessage = {
   jobId: string;
-  data: JsonRpcRequest<JsonRpcParams>;
+  data: JsonRpcRequest;
 };
 
 /**

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
@@ -23,7 +23,7 @@ export class OffscreenPostMessageStream extends BrowserRuntimePostMessageStream 
   readonly #frameUrl: string;
 
   /**
-   * Initializes a new `OffscreenDuplexStream` instance.
+   * Initializes a new `OffscreenPostMessageStream` instance.
    *
    * @param args - The constructor arguments.
    * @param args.name - The name of the stream.

--- a/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
+++ b/packages/snaps-controllers/src/services/offscreen/OffscreenPostMessageStream.ts
@@ -4,6 +4,7 @@ import { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 export type OffscreenDuplexStreamArgs = {
   stream: BasePostMessageStream;
   jobId: string;
+  frameUrl: string;
 };
 
 export type OffscreenDuplexStreamMessage = {
@@ -20,18 +21,23 @@ export class OffscreenPostMessageStream extends BasePostMessageStream {
 
   readonly #jobId: string;
 
+  readonly #frameUrl: string;
+
   /**
    * Initializes a new `OffscreenDuplexStream` instance.
    *
    * @param args - The constructor arguments.
    * @param args.stream - The underlying stream to use for communication.
    * @param args.jobId - The ID of the job this stream is associated with.
+   * @param args.frameUrl - The URL of the frame to load inside the offscreen
+   * document.
    */
-  constructor({ stream, jobId }: OffscreenDuplexStreamArgs) {
+  constructor({ stream, jobId, frameUrl }: OffscreenDuplexStreamArgs) {
     super();
 
     this.#stream = stream;
     this.#jobId = jobId;
+    this.#frameUrl = frameUrl;
 
     this.#stream.on('data', this.#onData.bind(this));
   }
@@ -59,6 +65,10 @@ export class OffscreenPostMessageStream extends BasePostMessageStream {
   _postMessage(data: OffscreenDuplexStreamMessage) {
     this.#stream.write({
       jobId: this.#jobId,
+      // TODO: Rather than injecting the frame URL here, we should come up with
+      // a better way to do this. The frame URL is needed to avoid hard coding
+      // it in the offscreen execution environment.
+      frameUrl: this.#frameUrl,
       data,
     });
   }

--- a/packages/snaps-controllers/src/services/offscreen/index.ts
+++ b/packages/snaps-controllers/src/services/offscreen/index.ts
@@ -1,0 +1,1 @@
+export * from './OffscreenExecutionService';

--- a/packages/snaps-controllers/src/services/offscreen/index.ts
+++ b/packages/snaps-controllers/src/services/offscreen/index.ts
@@ -1,1 +1,2 @@
 export * from './OffscreenExecutionService';
+export * from './OffscreenPostMessageStream';

--- a/packages/snaps-controllers/src/services/offscreen/vendor/offscreen.d.ts
+++ b/packages/snaps-controllers/src/services/offscreen/vendor/offscreen.d.ts
@@ -1,0 +1,27 @@
+// eslint-disable-next-line import/unambiguous
+declare namespace chrome.offscreen {
+  export type Reason =
+    | 'TESTING'
+    | 'AUDIO_PLAYBACK'
+    | 'IFRAME_SCRIPTING'
+    | 'DOM_SCRAPING'
+    | 'BLOBS'
+    | 'DOM_PARSER'
+    | 'USER_MEDIA'
+    | 'DISPLAY_MEDIA'
+    | 'WEB_RTC'
+    | 'CLIPBOARD';
+
+  export type CreateParameters = {
+    justification: string;
+    reasons: Reason[];
+    url: string;
+  };
+
+  export function createDocument(
+    parameters: CreateParameters,
+    callback?: () => void,
+  ): Promise<void>;
+
+  export function closeDocument(callback?: () => void): Promise<void>;
+}

--- a/packages/snaps-controllers/src/services/offscreen/vendor/offscreen.d.ts
+++ b/packages/snaps-controllers/src/services/offscreen/vendor/offscreen.d.ts
@@ -18,6 +18,8 @@ declare namespace chrome.offscreen {
     url: string;
   };
 
+  export function hasDocument(): Promise<boolean>;
+
   export function createDocument(
     parameters: CreateParameters,
     callback?: () => void,

--- a/packages/snaps-controllers/src/test-utils/mock.ts
+++ b/packages/snaps-controllers/src/test-utils/mock.ts
@@ -1,0 +1,29 @@
+import { assert } from '@metamask/utils';
+
+/**
+ * Get an existing function as mocked Jest function. This assumes that the
+ * function is already mocked.
+ *
+ * This asserts that the function is mocked, and throws an error if it is not.
+ *
+ * @param fn - The function to get as a mocked function.
+ * @returns The mocked function.
+ * @example
+ * The following code:
+ * ```ts
+ * const mock = jest.fn();
+ * const fn = getMockedFunction(mock);
+ * ```
+ * Is equivalent to:
+ * ```ts
+ * const mock = jest.fn();
+ * const fn = mock as jest.MockedFunction<typeof mock>;
+ * ```
+ */
+export function getMockedFunction<Fn extends (...args: any[]) => unknown>(
+  fn: Fn,
+): jest.MockedFunction<Fn> {
+  const mock = fn as jest.MockedFunction<Fn>;
+  assert(mock.mock, 'Function is not mocked.');
+  return mock;
+}

--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -6,16 +6,32 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts', '.ava.test.ts'],
   coverageThreshold: {
     global: {
-      branches: 83.93,
-      functions: 92.25,
-      lines: 87.07,
-      statements: 87.18,
+      branches: 82.02,
+      functions: 91.6,
+      lines: 90.4,
+      statements: 90.47,
     },
   },
-  testEnvironment: '<rootDir>/jest.environment.js',
-  testEnvironmentOptions: {
-    customExportConditions: ['node', 'node-addons'],
-  },
-  testTimeout: 2500,
-  testPathIgnorePatterns: ['.ava.test.ts'],
+  projects: [
+    deepmerge(baseConfig, {
+      coveragePathIgnorePatterns: ['index.ts', '.ava.test.ts'],
+      testMatch: ['<rootDir>/src/offscreen/*.test.ts'],
+      testEnvironment: '<rootDir>/jest.environment.js',
+
+      // These options are required to run iframes in JSDOM.
+      testEnvironmentOptions: {
+        resources: 'usable',
+        runScripts: 'dangerously',
+        customExportConditions: ['node', 'node-addons'],
+      },
+    }),
+    deepmerge(baseConfig, {
+      coveragePathIgnorePatterns: ['index.ts', '.ava.test.ts'],
+      testPathIgnorePatterns: ['<rootDir>/src/offscreen/*'],
+      testEnvironment: '<rootDir>/jest.environment.js',
+      testEnvironmentOptions: {
+        customExportConditions: ['node', 'node-addons'],
+      },
+    }),
+  ],
 });

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@metamask/object-multiplex": "^1.2.0",
-    "@metamask/post-message-stream": "^6.0.0",
+    "@metamask/post-message-stream": "^6.1.0",
     "@metamask/providers": "^10.2.0",
     "@metamask/snaps-utils": "^0.27.1",
     "@metamask/utils": "^3.4.1",
@@ -73,6 +73,7 @@
     "eslint-plugin-jsdoc": "^39.6.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "http-server": "^14.1.1",
     "jest": "^29.0.2",
     "jest-environment-jsdom": "^29.0.2",
     "jest-fetch-mock": "^3.0.3",

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -73,7 +73,6 @@
     "eslint-plugin-jsdoc": "^39.6.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "http-server": "^14.1.1",
     "jest": "^29.0.2",
     "jest-environment-jsdom": "^29.0.2",
     "jest-fetch-mock": "^3.0.3",

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.test.ts
@@ -1,4 +1,5 @@
 import {
+  fixCreateWindow,
   MockPostMessageStream,
   startServer,
   stopServer,
@@ -18,48 +19,8 @@ jest.mock('@metamask/snaps-utils', () => {
   const actual = jest.requireActual('@metamask/snaps-utils');
   return {
     ...actual,
-    createWindow: async (uri: string, jobId: string) => {
-      const result = await actual.createWindow(uri, jobId);
-      const scriptElement = result.document.createElement('script');
-
-      if (!scriptElement) {
-        return result;
-      }
-
-      // Fix the inside window.
-      scriptElement.textContent = `
-        window.addEventListener('message', (postMessageEvent) => {
-          if (postMessageEvent.source === null && !postMessageEvent.origin) {
-            let source;
-            let postMessageEventOrigin;
-            if (postMessageEvent.data.target === 'child') {
-              source = window.parent;
-              postMessageEventOrigin = '*';
-            } else if (postMessageEvent.data.target === 'parent') {
-              source = window;
-              postMessageEventOrigin = window.location.origin;
-            }
-            if (postMessageEvent.data.target) {
-              postMessageEvent.stopImmediatePropagation();
-              const args = Object.assign({
-                ...postMessageEvent,
-                data: postMessageEvent.data,
-                source,
-                origin: postMessageEventOrigin,
-              });
-              const postMessageEventWithOrigin = new MessageEvent(
-                'message',
-                args,
-              );
-              window.dispatchEvent(postMessageEventWithOrigin);
-            }
-          }
-        });
-      `;
-      result.document.body.appendChild(scriptElement);
-
-      return result;
-    },
+    createWindow: (...args: Parameters<typeof fixCreateWindow>) =>
+      fixCreateWindow(...args),
   };
 });
 

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.test.ts
@@ -131,6 +131,8 @@ describe('OffscreenSnapExecutor', () => {
 
   // eslint-disable-next-line jest/no-done-callback, consistent-return
   afterAll((done) => {
+    // `server` is undefined if the server failed to start. This is unlikely to
+    // happen, but we check it anyway to keep TypeScript happy.
     if (!server) {
       return done();
     }

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.test.ts
@@ -1,0 +1,233 @@
+import {
+  MockPostMessageStream,
+  startServer,
+  stopServer,
+} from '@metamask/snaps-utils/test-utils';
+import http from 'http';
+
+import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
+
+const SERVER_PORT = 6365;
+const IFRAME_URL = `http://localhost:${SERVER_PORT}/`;
+
+const MOCK_JOB_ID = 'job-id';
+
+jest.setTimeout(5000);
+
+jest.mock('@metamask/snaps-utils', () => {
+  const actual = jest.requireActual('@metamask/snaps-utils');
+  return {
+    ...actual,
+    createWindow: async (uri: string, jobId: string) => {
+      const result = await actual.createWindow(uri, jobId);
+      const scriptElement = result.document.createElement('script');
+
+      if (!scriptElement) {
+        return result;
+      }
+
+      // Fix the inside window.
+      scriptElement.textContent = `
+        window.addEventListener('message', (postMessageEvent) => {
+          if (postMessageEvent.source === null && !postMessageEvent.origin) {
+            let source;
+            let postMessageEventOrigin;
+            if (postMessageEvent.data.target === 'child') {
+              source = window.parent;
+              postMessageEventOrigin = '*';
+            } else if (postMessageEvent.data.target === 'parent') {
+              source = window;
+              postMessageEventOrigin = window.location.origin;
+            }
+            if (postMessageEvent.data.target) {
+              postMessageEvent.stopImmediatePropagation();
+              const args = Object.assign({
+                ...postMessageEvent,
+                data: postMessageEvent.data,
+                source,
+                origin: postMessageEventOrigin,
+              });
+              const postMessageEventWithOrigin = new MessageEvent(
+                'message',
+                args,
+              );
+              window.dispatchEvent(postMessageEventWithOrigin);
+            }
+          }
+        });
+      `;
+      result.document.body.appendChild(scriptElement);
+
+      return result;
+    },
+  };
+});
+
+/**
+ * Set a event source and origin for post message events.
+ *
+ * @param service - The execution service.
+ * @returns A teardown function.
+ */
+function fixPostMessageEventSource(service: OffscreenSnapExecutor) {
+  const listener = (event: MessageEvent) => {
+    if (event.source === null && !event.origin) {
+      let source;
+      let origin;
+      if (event.data.target === 'child') {
+        source = window;
+        origin = window.location.origin;
+      } else if (event.data.target === 'parent') {
+        source = service.jobs[MOCK_JOB_ID].window;
+        origin = IFRAME_URL;
+      }
+
+      if (event.data.target) {
+        event.stopImmediatePropagation();
+        const args = Object.assign({
+          ...event,
+          data: event.data,
+          source,
+          origin,
+        });
+
+        const eventWithOrigin: MessageEvent = new MessageEvent('message', args);
+        window.dispatchEvent(eventWithOrigin);
+      }
+    }
+  };
+
+  window.addEventListener('message', listener);
+
+  return () => {
+    window.removeEventListener('message', listener);
+  };
+}
+
+/**
+ * Write a message to the stream, wrapped with the job ID and frame URL.
+ *
+ * @param stream - The stream to write to.
+ * @param message - The message to write.
+ */
+function writeMessage(
+  stream: MockPostMessageStream,
+  message: Record<string, unknown>,
+) {
+  stream.write({
+    jobId: MOCK_JOB_ID,
+    frameUrl: IFRAME_URL,
+    data: message,
+  });
+}
+
+/**
+ * Write a termination message to the stream.
+ *
+ * @param stream - The stream to write to.
+ * @returns A promise that resolves after 1 millisecond.
+ */
+async function terminateJob(stream: MockPostMessageStream) {
+  writeMessage(stream, {
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'terminateJob',
+  });
+
+  return await new Promise((resolve) => setTimeout(resolve, 1));
+}
+
+/**
+ * Wait for a response from the stream.
+ *
+ * @param stream - The stream to wait for a response on.
+ * @returns The raw JSON-RPC response object.
+ */
+async function getResponse(
+  stream: MockPostMessageStream,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    stream.once('response', (data) => {
+      resolve(data);
+    });
+  });
+}
+
+describe('OffscreenSnapExecutor', () => {
+  let server: http.Server | undefined;
+
+  // The tests start running before the server is ready if we don't use the done
+  // callback.
+  // eslint-disable-next-line jest/no-done-callback
+  beforeAll((done) => {
+    startServer(SERVER_PORT)
+      .then((newServer) => {
+        server = newServer;
+        done();
+      })
+      .catch(done.fail);
+  });
+
+  // eslint-disable-next-line jest/no-done-callback, consistent-return
+  afterAll((done) => {
+    if (!server) {
+      return done();
+    }
+
+    stopServer(server).then(done).catch(done.fail);
+  });
+
+  it('forwards messages to the iframe', async () => {
+    const mockStream = new MockPostMessageStream();
+
+    const executor = OffscreenSnapExecutor.initialize(mockStream);
+    const teardown = fixPostMessageEventSource(executor);
+
+    writeMessage(mockStream, {
+      name: 'command',
+      data: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'ping',
+      },
+    });
+
+    // eslint-disable-next-line jest/prefer-strict-equal
+    expect(await getResponse(mockStream)).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 'OK',
+    });
+
+    expect(document.getElementById(MOCK_JOB_ID)).toBeDefined();
+
+    await terminateJob(mockStream);
+    teardown();
+  });
+
+  it('terminates the iframe', async () => {
+    const mockStream = new MockPostMessageStream();
+
+    const executor = OffscreenSnapExecutor.initialize(mockStream);
+    const teardown = fixPostMessageEventSource(executor);
+
+    // Send ping to ensure that the iframe is created.
+    writeMessage(mockStream, {
+      name: 'command',
+      data: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'ping',
+      },
+    });
+
+    // Wait for the response, so that we know the iframe is created.
+    await getResponse(mockStream);
+    await terminateJob(mockStream);
+
+    expect(executor.jobs[MOCK_JOB_ID]).toBeUndefined();
+    expect(document.getElementById(MOCK_JOB_ID)).toBeNull();
+
+    teardown();
+  });
+});

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -16,6 +16,17 @@ export class OffscreenSnapExecutor {
 
   readonly #jobs: Record<string, ExecutorJob> = {};
 
+  /**
+   * Initialize the executor with the given stream. This is a wrapper around the
+   * constructor.
+   *
+   * @param stream - The stream to use for communication.
+   * @returns The initialized executor.
+   */
+  static initialize(stream: BasePostMessageStream) {
+    return new OffscreenSnapExecutor(stream);
+  }
+
   constructor(stream: BasePostMessageStream) {
     this.#stream = stream;
     this.#stream.on('data', this.#onData.bind(this));

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -3,7 +3,7 @@ import {
   WindowPostMessageStream,
 } from '@metamask/post-message-stream';
 import { createWindow } from '@metamask/snaps-utils';
-import { JsonRpcParams, JsonRpcRequest, assert } from '@metamask/utils';
+import { JsonRpcRequest, assert } from '@metamask/utils';
 
 type ExecutorJob = {
   id: string;
@@ -42,11 +42,7 @@ export class OffscreenSnapExecutor {
    * @param data.jobId - The job ID.
    * @param data.frameUrl - The URL to load in the iframe.
    */
-  #onData(data: {
-    data: JsonRpcRequest<JsonRpcParams>;
-    jobId: string;
-    frameUrl: string;
-  }) {
+  #onData(data: { data: JsonRpcRequest; jobId: string; frameUrl: string }) {
     const { jobId, frameUrl, data: request } = data;
 
     if (!this.jobs[jobId]) {

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -2,6 +2,7 @@ import {
   BasePostMessageStream,
   WindowPostMessageStream,
 } from '@metamask/post-message-stream';
+import { createWindow } from '@metamask/snaps-utils';
 import { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 
 type ExecutorJob = {
@@ -69,7 +70,7 @@ export class OffscreenSnapExecutor {
    * @param frameUrl - The URL to load in the iframe.
    */
   async #initializeJob(jobId: string, frameUrl: string): Promise<ExecutorJob> {
-    const window = await this.#createWindow(frameUrl, jobId);
+    const window = await createWindow(frameUrl, jobId);
     const jobStream = new WindowPostMessageStream({
       name: 'parent',
       target: 'child',
@@ -101,66 +102,5 @@ export class OffscreenSnapExecutor {
     iframe.parentNode.removeChild(iframe);
     this.#jobs[jobId].stream.destroy();
     delete this.#jobs[jobId];
-  }
-
-  /**
-   * Creates the iframe to be used as the execution environment. This may run
-   * forever if the iframe never loads, but the promise should be wrapped in
-   * an initialization timeout in the SnapController.
-   *
-   * @param uri - The iframe URI.
-   * @param jobId - The job id.
-   * @returns A promise that resolves to the contentWindow of the iframe.
-   */
-  // TODO: Move this to a reusable utility, as it is also used in the iframe
-  // execution service.
-  async #createWindow(uri: string, jobId: string): Promise<Window> {
-    return new Promise((resolve, reject) => {
-      const iframe = document.createElement('iframe');
-      // The order of operations appears to matter for everything except this
-      // attribute. We may as well set it here.
-      iframe.setAttribute('id', jobId);
-
-      // In the past, we've had problems that appear to be symptomatic of the
-      // iframe firing the `load` event before its scripts are actually loaded,
-      // which has prevented snaps from executing properly. Therefore, we set
-      // the `src` attribute and append the iframe to the DOM before attaching
-      // the `load` listener.
-      //
-      // `load` should only fire when "all dependent resources" have been
-      // loaded, which includes scripts.
-      //
-      // MDN article for `load` event: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
-      // Re: `load` firing twice: https://stackoverflow.com/questions/10781880/dynamically-created-iframe-triggers-onload-event-twice/15880489#15880489
-      iframe.setAttribute('src', uri);
-      document.body.appendChild(iframe);
-
-      iframe.addEventListener('load', () => {
-        if (iframe.contentWindow) {
-          resolve(iframe.contentWindow);
-        } else {
-          // We don't know of a case when this would happen, but better to fail
-          // fast if it does.
-          reject(
-            new Error(
-              `iframe.contentWindow not present on load for job "${jobId}".`,
-            ),
-          );
-        }
-      });
-
-      // We need to set the sandbox attribute after appending the iframe to the
-      // DOM, otherwise errors in the iframe will not be propagated via `error`
-      // and `unhandledrejection` events, and we cannot catch and handle them.
-      // We wish we knew why this was the case.
-      //
-      // We set this property after adding the `load` listener because it
-      // appears to work dependably. ¯\_(ツ)_/¯
-      //
-      // We apply this property as a principle of least authority (POLA)
-      // measure.
-      // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
-      iframe.setAttribute('sandbox', 'allow-scripts');
-    });
   }
 }

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -1,37 +1,161 @@
-import ObjectMultiplex from '@metamask/object-multiplex';
-import { RuntimePostMessageStream } from '@metamask/post-message-stream';
-import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
-import pump from 'pump';
+import {
+  BasePostMessageStream,
+  WindowPostMessageStream,
+} from '@metamask/post-message-stream';
+import { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 
-import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
+// TODO: This should be configurable somehow.
+const IFRAME_URL =
+  'https://metamask.github.io/iframe-execution-environment/0.11.1/';
 
-export class OffscreenSnapExecutor extends BaseSnapExecutor {
+type ExecutorJob = {
+  id: string;
+  window: Window;
+  stream: WindowPostMessageStream;
+};
+
+export class OffscreenSnapExecutor {
+  readonly #stream: BasePostMessageStream;
+
+  readonly #jobs: Record<string, ExecutorJob> = {};
+
+  constructor(stream: BasePostMessageStream) {
+    this.#stream = stream;
+    this.#stream.on('data', this.#onData.bind(this));
+  }
+
   /**
-   * Initialize the OffscreenSnapExecutor. This creates a post message stream
-   * from and to the parent window, for two-way communication with the iframe.
+   * Handle an incoming message from the `OffscreenExecutionService`. This
+   * assumes that the message contains a `jobId` property, and a JSON-RPC
+   * request in the `data` property.
    *
-   * @returns An instance of `OffscreenSnapExecutor`, with the initialized post
-   * message streams.
+   * @param data - The message data.
+   * @param data.data - The JSON-RPC request.
+   * @param data.jobId - The job ID.
    */
-  static initialize() {
-    console.log('Worker: Connecting to parent.');
+  #onData(data: { data: JsonRpcRequest<JsonRpcParams>; jobId: string }) {
+    const { jobId, data: request } = data;
 
-    const parentStream = new RuntimePostMessageStream({
-      name: 'child',
-      target: 'parent',
+    if (!this.#jobs[jobId]) {
+      // This ensures that a job is initialized before it is used. To avoid
+      // code duplication, we call the `#onData` method again, which will
+      // run the rest of the logic after initialization.
+      this.#initializeJob(jobId)
+        .then(() => {
+          this.#onData(data);
+        })
+        .catch((error) => {
+          console.error('[Worker] Error initializing job:', error);
+        });
+
+      return;
+    }
+
+    // TODO: Verify that this is correct.
+    if (request.method === 'terminate') {
+      this.#jobs[jobId].stream.write(request);
+      this.#terminateJob(jobId);
+      return;
+    }
+
+    this.#jobs[jobId].stream.write(request);
+  }
+
+  /**
+   * Create a new iframe and set up a stream to communicate with it.
+   *
+   * @param jobId - The job ID.
+   */
+  async #initializeJob(jobId: string): Promise<ExecutorJob> {
+    const window = await this.#createWindow(IFRAME_URL, jobId);
+    const jobStream = new WindowPostMessageStream({
+      name: 'parent',
+      target: 'child',
+      targetWindow: window,
+      targetOrigin: '*',
     });
 
-    const mux = new ObjectMultiplex();
-    pump(parentStream, mux, parentStream, (error) => {
-      if (error) {
-        console.error(`Parent stream failure, closing worker.`, error);
-      }
-      self.close();
+    // Write messages from the iframe to the parent, wrapped with the job ID.
+    jobStream.on('data', (data) => {
+      this.#stream.write({ data, jobId });
     });
 
-    const commandStream = mux.createStream(SNAP_STREAM_NAMES.COMMAND);
-    const rpcStream = mux.createStream(SNAP_STREAM_NAMES.JSON_RPC);
+    this.#jobs[jobId] = { id: jobId, window, stream: jobStream };
+    return this.#jobs[jobId];
+  }
 
-    return new OffscreenSnapExecutor(commandStream, rpcStream);
+  /**
+   * Terminate the job with the given ID. This will close the iframe and delete
+   * the job from the internal job map.
+   *
+   * @param jobId - The job ID.
+   */
+  #terminateJob(jobId: string) {
+    assert(this.#jobs[jobId], `Job "${jobId}" not found.`);
+
+    this.#jobs[jobId].stream.destroy();
+    this.#jobs[jobId].window.close();
+    delete this.#jobs[jobId];
+  }
+
+  /**
+   * Creates the iframe to be used as the execution environment. This may run
+   * forever if the iframe never loads, but the promise should be wrapped in
+   * an initialization timeout in the SnapController.
+   *
+   * @param uri - The iframe URI.
+   * @param jobId - The job id.
+   * @returns A promise that resolves to the contentWindow of the iframe.
+   */
+  // TODO: Move this to a reusable utility, as it is also used in the iframe
+  // execution service.
+  async #createWindow(uri: string, jobId: string): Promise<Window> {
+    return new Promise((resolve, reject) => {
+      const iframe = document.createElement('iframe');
+      // The order of operations appears to matter for everything except this
+      // attribute. We may as well set it here.
+      iframe.setAttribute('id', jobId);
+
+      // In the past, we've had problems that appear to be symptomatic of the
+      // iframe firing the `load` event before its scripts are actually loaded,
+      // which has prevented snaps from executing properly. Therefore, we set
+      // the `src` attribute and append the iframe to the DOM before attaching
+      // the `load` listener.
+      //
+      // `load` should only fire when "all dependent resources" have been
+      // loaded, which includes scripts.
+      //
+      // MDN article for `load` event: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
+      // Re: `load` firing twice: https://stackoverflow.com/questions/10781880/dynamically-created-iframe-triggers-onload-event-twice/15880489#15880489
+      iframe.setAttribute('src', uri);
+      document.body.appendChild(iframe);
+
+      iframe.addEventListener('load', () => {
+        if (iframe.contentWindow) {
+          resolve(iframe.contentWindow);
+        } else {
+          // We don't know of a case when this would happen, but better to fail
+          // fast if it does.
+          reject(
+            new Error(
+              `iframe.contentWindow not present on load for job "${jobId}".`,
+            ),
+          );
+        }
+      });
+
+      // We need to set the sandbox attribute after appending the iframe to the
+      // DOM, otherwise errors in the iframe will not be propagated via `error`
+      // and `unhandledrejection` events, and we cannot catch and handle them.
+      // We wish we knew why this was the case.
+      //
+      // We set this property after adding the `load` listener because it
+      // appears to work dependably. ¯\_(ツ)_/¯
+      //
+      // We apply this property as a principle of least authority (POLA)
+      // measure.
+      // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
+      iframe.setAttribute('sandbox', 'allow-scripts');
+    });
   }
 }

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -1,0 +1,37 @@
+import ObjectMultiplex from '@metamask/object-multiplex';
+import { RuntimePostMessageStream } from '@metamask/post-message-stream';
+import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
+import pump from 'pump';
+
+import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
+
+export class OffscreenSnapExecutor extends BaseSnapExecutor {
+  /**
+   * Initialize the OffscreenSnapExecutor. This creates a post message stream
+   * from and to the parent window, for two-way communication with the iframe.
+   *
+   * @returns An instance of `OffscreenSnapExecutor`, with the initialized post
+   * message streams.
+   */
+  static initialize() {
+    console.log('Worker: Connecting to parent.');
+
+    const parentStream = new RuntimePostMessageStream({
+      name: 'child',
+      target: 'parent',
+    });
+
+    const mux = new ObjectMultiplex();
+    pump(parentStream, mux, parentStream, (error) => {
+      if (error) {
+        console.error(`Parent stream failure, closing worker.`, error);
+      }
+      self.close();
+    });
+
+    const commandStream = mux.createStream(SNAP_STREAM_NAMES.COMMAND);
+    const rpcStream = mux.createStream(SNAP_STREAM_NAMES.JSON_RPC);
+
+    return new OffscreenSnapExecutor(commandStream, rpcStream);
+  }
+}

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -51,9 +51,7 @@ export class OffscreenSnapExecutor {
       return;
     }
 
-    // TODO: Verify that this is correct.
-    if (request.method === 'terminate') {
-      this.#jobs[jobId].stream.write(request);
+    if (request.method === 'terminateJob') {
       this.#terminateJob(jobId);
       return;
     }
@@ -93,8 +91,11 @@ export class OffscreenSnapExecutor {
   #terminateJob(jobId: string) {
     assert(this.#jobs[jobId], `Job "${jobId}" not found.`);
 
+    const iframe = document.getElementById(jobId);
+    assert(iframe?.parentNode, `Iframe with ID "${jobId}" not found.`);
+
+    iframe.parentNode.removeChild(iframe);
     this.#jobs[jobId].stream.destroy();
-    this.#jobs[jobId].window.close();
     delete this.#jobs[jobId];
   }
 

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -106,7 +106,7 @@ export class OffscreenSnapExecutor {
     const iframe = document.getElementById(jobId);
     assert(iframe?.parentNode, `Iframe with ID "${jobId}" not found.`);
 
-    iframe.parentNode.removeChild(iframe);
+    iframe.remove();
     this.jobs[jobId].stream.destroy();
     delete this.jobs[jobId];
   }

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -11,6 +11,20 @@ type ExecutorJob = {
   stream: WindowPostMessageStream;
 };
 
+/**
+ * A snap executor using the Offscreen Documents API.
+ *
+ * This is not a traditional snap executor, as it does not execute snaps itself.
+ * Instead, it creates an iframe window for each snap execution, and sends the
+ * snap execution request to the iframe window. The iframe window is responsible
+ * for executing the snap.
+ *
+ * Extensions can only have a single offscreen document, so this executor is
+ * persisted between snap executions. The offscreen snap executor essentially
+ * acts as a proxy between the extension and the iframe execution environment.
+ *
+ * @see https://developer.chrome.com/docs/extensions/reference/offscreen/
+ */
 export class OffscreenSnapExecutor {
   readonly #stream: BasePostMessageStream;
 
@@ -104,7 +118,7 @@ export class OffscreenSnapExecutor {
     assert(this.jobs[jobId], `Job "${jobId}" not found.`);
 
     const iframe = document.getElementById(jobId);
-    assert(iframe?.parentNode, `Iframe with ID "${jobId}" not found.`);
+    assert(iframe, `Iframe with ID "${jobId}" not found.`);
 
     iframe.remove();
     this.jobs[jobId].stream.destroy();

--- a/packages/snaps-execution-environments/src/offscreen/index.html
+++ b/packages/snaps-execution-environments/src/offscreen/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>MetaMask Snaps Offscreen Execution Environment</title>
+  </head>
+  <body>
+    <script src="lockdown.umd.min.js"></script>
+    <script src="bundle.js"></script>
+  </body>
+</html>

--- a/packages/snaps-execution-environments/src/offscreen/index.ts
+++ b/packages/snaps-execution-environments/src/offscreen/index.ts
@@ -13,5 +13,4 @@ const parentStream = new BrowserRuntimePostMessageStream({
   target: 'parent',
 });
 
-// eslint-disable-next-line no-new
-new OffscreenSnapExecutor(parentStream);
+OffscreenSnapExecutor.initialize(parentStream);

--- a/packages/snaps-execution-environments/src/offscreen/index.ts
+++ b/packages/snaps-execution-environments/src/offscreen/index.ts
@@ -1,3 +1,5 @@
+import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
+
 import { executeLockdown } from '../common/lockdown/lockdown';
 import { executeLockdownMore } from '../common/lockdown/lockdown-more';
 import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
@@ -5,4 +7,11 @@ import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
 executeLockdown();
 executeLockdownMore();
 
-OffscreenSnapExecutor.initialize();
+// The stream from the offscreen document to the execution service.
+const parentStream = new BrowserRuntimePostMessageStream({
+  name: 'child',
+  target: 'parent',
+});
+
+// eslint-disable-next-line no-new
+new OffscreenSnapExecutor(parentStream);

--- a/packages/snaps-execution-environments/src/offscreen/index.ts
+++ b/packages/snaps-execution-environments/src/offscreen/index.ts
@@ -1,11 +1,12 @@
 import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
 
-import { executeLockdown } from '../common/lockdown/lockdown';
-import { executeLockdownMore } from '../common/lockdown/lockdown-more';
+// import { executeLockdown } from '../common/lockdown/lockdown';
+// import { executeLockdownMore } from '../common/lockdown/lockdown-more';
 import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
 
-executeLockdown();
-executeLockdownMore();
+// TODO: Uncomment this.
+// executeLockdown();
+// executeLockdownMore();
 
 // The stream from the offscreen document to the execution service.
 const parentStream = new BrowserRuntimePostMessageStream({

--- a/packages/snaps-execution-environments/src/offscreen/index.ts
+++ b/packages/snaps-execution-environments/src/offscreen/index.ts
@@ -1,0 +1,8 @@
+import { executeLockdown } from '../common/lockdown/lockdown';
+import { executeLockdownMore } from '../common/lockdown/lockdown-more';
+import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
+
+executeLockdown();
+executeLockdownMore();
+
+OffscreenSnapExecutor.initialize();

--- a/packages/snaps-execution-environments/src/offscreen/index.ts
+++ b/packages/snaps-execution-environments/src/offscreen/index.ts
@@ -1,12 +1,11 @@
 import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
 
-// import { executeLockdown } from '../common/lockdown/lockdown';
-// import { executeLockdownMore } from '../common/lockdown/lockdown-more';
+import { executeLockdown } from '../common/lockdown/lockdown';
+import { executeLockdownMore } from '../common/lockdown/lockdown-more';
 import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
 
-// TODO: Uncomment this.
-// executeLockdown();
-// executeLockdownMore();
+executeLockdown();
+executeLockdownMore();
 
 // The stream from the offscreen document to the execution service.
 const parentStream = new BrowserRuntimePostMessageStream({

--- a/packages/snaps-execution-environments/webpack.config.js
+++ b/packages/snaps-execution-environments/webpack.config.js
@@ -90,6 +90,7 @@ module.exports = (_, argv) => {
     mode: argv.mode,
     entry: {
       iframe: './src/iframe/index.ts',
+      offscreen: './src/offscreen/index.ts',
     },
     output: {
       filename: '[name]/bundle.js',

--- a/packages/snaps-execution-environments/webpack.config.js
+++ b/packages/snaps-execution-environments/webpack.config.js
@@ -102,28 +102,19 @@ module.exports = (_, argv) => {
         patterns: [
           // TODO: Merge this with above if possible
           {
-            // For use in <script> tag along with the iframe bundle. Copied to ensure same version as bundled
+            // For use in <script> tag along with the iframe and offscreen
+            // bundle. Copied to ensure same version as bundled.
             from: path.resolve(
               `${path.dirname(require.resolve('ses/package.json'))}`,
               'dist',
               'lockdown.umd.min.js',
             ),
-            to: path.resolve(ENVIRONMENTS, 'iframe/lockdown.umd.min.js'),
+            to: path.resolve(ENVIRONMENTS, 'lockdown.umd.min.js'),
             toType: 'file',
           },
           {
             from: path.resolve('src', 'iframe', 'index.html'),
             to: path.resolve(ENVIRONMENTS, 'iframe/index.html'),
-            toType: 'file',
-          },
-          {
-            // For use in <script> tag along with the offscreen bundle. Copied to ensure same version as bundled
-            from: path.resolve(
-              `${path.dirname(require.resolve('ses/package.json'))}`,
-              'dist',
-              'lockdown.umd.min.js',
-            ),
-            to: path.resolve(ENVIRONMENTS, 'offscreen/lockdown.umd.min.js'),
             toType: 'file',
           },
           {

--- a/packages/snaps-execution-environments/webpack.config.js
+++ b/packages/snaps-execution-environments/webpack.config.js
@@ -102,14 +102,25 @@ module.exports = (_, argv) => {
         patterns: [
           // TODO: Merge this with above if possible
           {
-            // For use in <script> tag along with the iframe and offscreen
-            // bundle. Copied to ensure same version as bundled.
+            // For use in <script> tag along with the iframe bundle. Copied to
+            // ensure same version as bundled.
             from: path.resolve(
               `${path.dirname(require.resolve('ses/package.json'))}`,
               'dist',
               'lockdown.umd.min.js',
             ),
-            to: path.resolve(ENVIRONMENTS, 'lockdown.umd.min.js'),
+            to: path.resolve(ENVIRONMENTS, 'iframe/lockdown.umd.min.js'),
+            toType: 'file',
+          },
+          {
+            // For use in <script> tag along with the iframe bundle. Copied to
+            // ensure same version as bundled.
+            from: path.resolve(
+              `${path.dirname(require.resolve('ses/package.json'))}`,
+              'dist',
+              'lockdown.umd.min.js',
+            ),
+            to: path.resolve(ENVIRONMENTS, 'offscreen/lockdown.umd.min.js'),
             toType: 'file',
           },
           {

--- a/packages/snaps-execution-environments/webpack.config.js
+++ b/packages/snaps-execution-environments/webpack.config.js
@@ -116,6 +116,21 @@ module.exports = (_, argv) => {
             to: path.resolve(ENVIRONMENTS, 'iframe/index.html'),
             toType: 'file',
           },
+          {
+            // For use in <script> tag along with the offscreen bundle. Copied to ensure same version as bundled
+            from: path.resolve(
+              `${path.dirname(require.resolve('ses/package.json'))}`,
+              'dist',
+              'lockdown.umd.min.js',
+            ),
+            to: path.resolve(ENVIRONMENTS, 'offscreen/lockdown.umd.min.js'),
+            toType: 'file',
+          },
+          {
+            from: path.resolve('src', 'offscreen', 'index.html'),
+            to: path.resolve(ENVIRONMENTS, 'offscreen/index.html'),
+            toType: 'file',
+          },
         ],
       }),
     ],

--- a/packages/snaps-utils/jest.config.js
+++ b/packages/snaps-utils/jest.config.js
@@ -2,27 +2,49 @@ const deepmerge = require('deepmerge');
 
 const baseConfig = require('../../jest.config.base');
 
+const coveragePathIgnorePatterns = [
+  './src/index.ts',
+  './src/index.browser.ts',
+  './src/virtual-file/index.ts',
+  './src/virtual-file/index.browser.ts',
+  './src/manifest/index.ts',
+  './src/manifest/index.browser.ts',
+  './src/test-utils',
+  './src/json-schemas',
+  // Jest currently doesn't collect coverage for child processes.
+  // https://github.com/facebook/jest/issues/5274
+  './src/eval-worker.ts',
+];
+
 module.exports = deepmerge(baseConfig, {
-  coveragePathIgnorePatterns: [
-    './src/index.ts',
-    './src/index.browser.ts',
-    './src/virtual-file/index.ts',
-    './src/virtual-file/index.browser.ts',
-    './src/manifest/index.ts',
-    './src/manifest/index.browser.ts',
-    './src/test-utils',
-    './src/json-schemas',
-    // Jest currently doesn't collect coverage for child processes.
-    // https://github.com/facebook/jest/issues/5274
-    './src/eval-worker.ts',
-  ],
   coverageThreshold: {
     global: {
-      branches: 90.87,
-      functions: 99.22,
-      lines: 98.83,
-      statements: 98.85,
+      branches: 90.6,
+      functions: 99.24,
+      lines: 98.68,
+      statements: 98.72,
     },
   },
+  projects: [
+    deepmerge(baseConfig, {
+      coveragePathIgnorePatterns,
+      testMatch: ['<rootDir>/src/iframe.test.ts'],
+
+      // These options are required to run iframes in JSDOM.
+      testEnvironment: '<rootDir>/jest.environment.js',
+      testEnvironmentOptions: {
+        resources: 'usable',
+        runScripts: 'dangerously',
+        customExportConditions: ['node', 'node-addons'],
+      },
+    }),
+    deepmerge(baseConfig, {
+      coveragePathIgnorePatterns,
+      testPathIgnorePatterns: ['<rootDir>/src/iframe.test.ts'],
+      testEnvironmentOptions: {
+        customExportConditions: ['node', 'node-addons'],
+      },
+    }),
+  ],
   testTimeout: 2500,
 });

--- a/packages/snaps-utils/jest.environment.js
+++ b/packages/snaps-utils/jest.environment.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+const { TestEnvironment } = require('jest-environment-jsdom');
+
+// Custom test environment copied from https://github.com/jsdom/jsdom/issues/2524
+// in order to add TextEncoder to jsdom. TextEncoder is expected by jose.
+
+module.exports = class CustomTestEnvironment extends TestEnvironment {
+  async setup() {
+    await super.setup();
+    if (typeof this.global.TextEncoder === 'undefined') {
+      const { TextEncoder, TextDecoder } = require('util');
+      this.global.TextEncoder = TextEncoder;
+      this.global.TextDecoder = TextDecoder;
+      this.global.ArrayBuffer = ArrayBuffer;
+      this.global.Uint8Array = Uint8Array;
+    }
+  }
+};

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -74,6 +74,7 @@
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.1",
     "@metamask/eslint-config-typescript": "^11.0.0",
+    "@metamask/post-message-stream": "^6.1.0",
     "@types/jest": "^27.5.1",
     "@types/semver": "^7.3.10",
     "@types/validate-npm-package-name": "^4.0.0",
@@ -93,6 +94,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",
+    "serve-handler": "^6.1.5",
     "ts-jest": "^29.0.0",
     "typescript": "~4.8.4"
   },

--- a/packages/snaps-utils/src/iframe.test.ts
+++ b/packages/snaps-utils/src/iframe.test.ts
@@ -1,0 +1,52 @@
+import { startServer, stopServer } from '@metamask/snaps-utils/test-utils';
+import http from 'http';
+
+import { createWindow } from './iframe';
+
+const SERVER_PORT = 6366;
+const IFRAME_URL = `http://localhost:${SERVER_PORT}/`;
+
+const MOCK_JOB_ID = 'job-id';
+
+jest.setTimeout(5000);
+
+describe('createWindow', () => {
+  let server: http.Server;
+
+  // The tests start running before the server is ready if we don't use the done
+  // callback.
+  // eslint-disable-next-line jest/no-done-callback
+  beforeAll((done) => {
+    // We use the current directory as the bundle path, as the test doesn't
+    // actually use the bundle. We just need to serve something so the iframe
+    // can load.
+    startServer(SERVER_PORT, '.')
+      .then((newServer) => {
+        server = newServer;
+        done();
+      })
+      .catch(done.fail);
+  });
+
+  // eslint-disable-next-line jest/no-done-callback, consistent-return
+  afterAll((done) => {
+    if (!server) {
+      return done();
+    }
+
+    stopServer(server).then(done).catch(done.fail);
+  });
+
+  it('creates an iframe window with the provided job ID as the iframe ID', async () => {
+    const window = await createWindow(IFRAME_URL, MOCK_JOB_ID);
+    const iframe = document.getElementById(MOCK_JOB_ID) as HTMLIFrameElement;
+
+    expect(iframe).toBeDefined();
+    expect(iframe.contentWindow).toBe(window);
+    expect(iframe.id).toBe(MOCK_JOB_ID);
+
+    // Jest shares the same JSDOM instance between tests, so we need to clean up
+    // after ourselves.
+    iframe.remove();
+  });
+});

--- a/packages/snaps-utils/src/iframe.test.ts
+++ b/packages/snaps-utils/src/iframe.test.ts
@@ -30,6 +30,8 @@ describe('createWindow', () => {
 
   // eslint-disable-next-line jest/no-done-callback, consistent-return
   afterAll((done) => {
+    // `server` is undefined if the server failed to start. This is unlikely to
+    // happen, but we check it anyway to keep TypeScript happy.
     if (!server) {
       return done();
     }

--- a/packages/snaps-utils/src/iframe.ts
+++ b/packages/snaps-utils/src/iframe.ts
@@ -1,0 +1,61 @@
+/**
+ * Creates the iframe to be used as the execution environment. This may run
+ * forever if the iframe never loads, but the promise should be wrapped in
+ * an initialization timeout in the SnapController.
+ *
+ * @param uri - The iframe URI.
+ * @param jobId - The job id.
+ * @returns A promise that resolves to the contentWindow of the iframe.
+ */
+export async function createWindow(
+  uri: string,
+  jobId: string,
+): Promise<Window> {
+  return new Promise((resolve, reject) => {
+    const iframe = document.createElement('iframe');
+    // The order of operations appears to matter for everything except this
+    // attribute. We may as well set it here.
+    iframe.setAttribute('id', jobId);
+
+    // In the past, we've had problems that appear to be symptomatic of the
+    // iframe firing the `load` event before its scripts are actually loaded,
+    // which has prevented snaps from executing properly. Therefore, we set
+    // the `src` attribute and append the iframe to the DOM before attaching
+    // the `load` listener.
+    //
+    // `load` should only fire when "all dependent resources" have been
+    // loaded, which includes scripts.
+    //
+    // MDN article for `load` event: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
+    // Re: `load` firing twice: https://stackoverflow.com/questions/10781880/dynamically-created-iframe-triggers-onload-event-twice/15880489#15880489
+    iframe.setAttribute('src', uri);
+    document.body.appendChild(iframe);
+
+    iframe.addEventListener('load', () => {
+      if (iframe.contentWindow) {
+        resolve(iframe.contentWindow);
+      } else {
+        // We don't know of a case when this would happen, but better to fail
+        // fast if it does.
+        reject(
+          new Error(
+            `iframe.contentWindow not present on load for job "${jobId}".`,
+          ),
+        );
+      }
+    });
+
+    // We need to set the sandbox attribute after appending the iframe to the
+    // DOM, otherwise errors in the iframe will not be propagated via `error`
+    // and `unhandledrejection` events, and we cannot catch and handle them.
+    // We wish we knew why this was the case.
+    //
+    // We set this property after adding the `load` listener because it
+    // appears to work dependably. ¯\_(ツ)_/¯
+    //
+    // We apply this property as a principle of least authority (POLA)
+    // measure.
+    // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
+    iframe.setAttribute('sandbox', 'allow-scripts');
+  });
+}

--- a/packages/snaps-utils/src/iframe.ts
+++ b/packages/snaps-utils/src/iframe.ts
@@ -11,7 +11,7 @@ export async function createWindow(
   uri: string,
   jobId: string,
 ): Promise<Window> {
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     const iframe = document.createElement('iframe');
     // The order of operations appears to matter for everything except this
     // attribute. We may as well set it here.

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -4,6 +4,7 @@ export * from './default-endowments';
 export * from './entropy';
 export * from './flatMap';
 export * from './handlers';
+export * from './iframe';
 export * from './json-rpc';
 export * from './manifest/index.browser';
 export * from './namespace';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -7,6 +7,7 @@ export * from './eval';
 export * from './flatMap';
 export * from './fs';
 export * from './handlers';
+export * from './iframe';
 export * from './json-rpc';
 export * from './manifest';
 export * from './mock';

--- a/packages/snaps-utils/src/test-utils/index.ts
+++ b/packages/snaps-utils/src/test-utils/index.ts
@@ -6,4 +6,6 @@
 
 export * from './common';
 export * from './manifest';
+export * from './server';
 export * from './snap';
+export * from './stream';

--- a/packages/snaps-utils/src/test-utils/server.ts
+++ b/packages/snaps-utils/src/test-utils/server.ts
@@ -2,16 +2,14 @@ import http from 'http';
 import path from 'path';
 import serveHandler from 'serve-handler';
 
-export const PORT = 6364;
-
-let server: http.Server;
 /**
  * Starts a local server that serves the iframe execution environment.
  *
  * @param port - The port to start the server on.
+ * @returns The server instance.
  */
-export async function start(port = PORT) {
-  return new Promise<void>((resolve, reject) => {
+export async function startServer(port: number) {
+  return new Promise<http.Server>((resolve, reject) => {
     if (!Number.isSafeInteger(port) || port < 0) {
       reject(new Error(`Invalid port: "${port}"`));
     }
@@ -21,7 +19,7 @@ export async function start(port = PORT) {
     );
     const publicPath = path.resolve(bundlePath, '../');
 
-    server = http.createServer((req, res) => {
+    const server = http.createServer((req, res) => {
       serveHandler(req, res, {
         public: publicPath,
         headers: [
@@ -40,7 +38,7 @@ export async function start(port = PORT) {
 
     server.listen({ port }, () => {
       console.log(`Server listening on: http://localhost:${port}`);
-      resolve();
+      resolve(server);
     });
 
     server.on('error', (error) => {
@@ -57,8 +55,10 @@ export async function start(port = PORT) {
 
 /**
  * Stops the local server.
+ *
+ * @param server - The server to stop.
  */
-export async function stop() {
+export async function stopServer(server: http.Server) {
   await new Promise<void>((resolve, reject) => {
     server.close((error) => {
       if (error) {

--- a/packages/snaps-utils/src/test-utils/server.ts
+++ b/packages/snaps-utils/src/test-utils/server.ts
@@ -6,17 +6,21 @@ import serveHandler from 'serve-handler';
  * Starts a local server that serves the iframe execution environment.
  *
  * @param port - The port to start the server on.
+ * @param bundlePath - The path to the bundle to serve. Defaults to the iframe
+ * test bundle.
  * @returns The server instance.
  */
-export async function startServer(port: number) {
+export async function startServer(
+  port: number,
+  bundlePath: string = require.resolve(
+    '@metamask/snaps-execution-environments/__test__/iframe-test/bundle.js',
+  ),
+) {
   return new Promise<http.Server>((resolve, reject) => {
     if (!Number.isSafeInteger(port) || port < 0) {
       reject(new Error(`Invalid port: "${port}"`));
     }
 
-    const bundlePath = require.resolve(
-      '@metamask/snaps-execution-environments/__test__/iframe-test/bundle.js',
-    );
     const publicPath = path.resolve(bundlePath, '../');
 
     const server = http.createServer((req, res) => {

--- a/packages/snaps-utils/src/test-utils/stream.ts
+++ b/packages/snaps-utils/src/test-utils/stream.ts
@@ -1,0 +1,29 @@
+import { BasePostMessageStream } from '@metamask/post-message-stream';
+import { isJsonRpcResponse, isPlainObject } from '@metamask/utils';
+
+export class MockPostMessageStream extends BasePostMessageStream {
+  readonly #write: (...args: unknown[]) => unknown;
+
+  constructor(write: () => void = jest.fn()) {
+    super();
+
+    this.#write = write;
+  }
+
+  protected _postMessage(data: unknown): void {
+    this.#write(data);
+
+    // Responses shouldn't be written back to the stream, as it would create a
+    // cycle. Instead, we emit them as an arbitrary `response` event.
+    if (
+      isPlainObject(data) &&
+      isPlainObject(data.data) &&
+      isJsonRpcResponse(data.data.data)
+    ) {
+      this.emit('response', data.data.data);
+      return;
+    }
+
+    this.emit('data', data);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,7 +2929,6 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
     eth-rpc-errors: ^4.0.3
-    http-server: ^14.1.1
     jest: ^29.0.2
     jest-environment-jsdom: ^29.0.2
     jest-fetch-mock: ^3.0.3
@@ -4979,15 +4978,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^2.6.4":
-  version: 2.6.4
-  resolution: "async@npm:2.6.4"
-  dependencies:
-    lodash: ^4.17.14
-  checksum: a52083fb32e1ebe1d63e5c5624038bb30be68ff07a6c8d7dfe35e47c93fc144bd8652cbec869e0ac07d57dde387aa5f1386be3559cdee799cb1f789678d88e19
-  languageName: node
-  linkType: hard
-
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -5307,15 +5297,6 @@ __metadata:
     mixin-deep: ^1.2.0
     pascalcase: ^0.1.1
   checksum: a4a146b912e27eea8f66d09cb0c9eab666f32ce27859a7dfd50f38cd069a2557b39f16dba1bc2aecb3b44bf096738dd207b7970d99b0318423285ab1b1994edd
-  languageName: node
-  linkType: hard
-
-"basic-auth@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "basic-auth@npm:2.0.1"
-  dependencies:
-    safe-buffer: 5.1.2
-  checksum: 3419b805d5dfc518f3a05dcf42aa53aa9ce820e50b6df5097f9e186322e1bc733c36722b624802cd37e791035aa73b828ed814d8362333d42d7f5cd04d7a5e48
   languageName: node
   linkType: hard
 
@@ -6043,7 +6024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -6697,13 +6678,6 @@ __metadata:
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
   checksum: 7a4c925b497a2c91421e25bf76d6d8190f0b2359a9200dbeed136e63b2931d6294d3b1893eda378883ed363cd950f44a12a401384c609839ea616befb7927dab
-  languageName: node
-  linkType: hard
-
-"corser@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "corser@npm:2.0.1"
-  checksum: 9ff6944eda760c8c3118747a636afc3ede53b41e7b9960513a15b88032209a728e630ae4b41e20a941e34da129fe9094d1f5d95123ef64ac2e16cdad8dce9c87
   languageName: node
   linkType: hard
 
@@ -8216,13 +8190,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
-  languageName: node
-  linkType: hard
-
 "events@npm:^3.0.0, events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -8699,16 +8666,6 @@ __metadata:
     inherits: ^2.0.3
     readable-stream: ^2.3.6
   checksum: 42e07747f83bcd4e799da802e621d6039787749ffd41f5517f8c4f786ee967e31ba32b09f8b28a9c6f67bd4f5346772e604202df350e8d99f4141771bae31279
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.2
-  resolution: "follow-redirects@npm:1.15.2"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
   languageName: node
   linkType: hard
 
@@ -9579,40 +9536,6 @@ __metadata:
     agent-base: 6
     debug: 4
   checksum: e2ee1ff1656a131953839b2a19cd1f3a52d97c25ba87bd2559af6ae87114abf60971e498021f9b73f9fd78aea8876d1fb0d4656aac8a03c6caa9fc175f22b786
-  languageName: node
-  linkType: hard
-
-"http-proxy@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "http-proxy@npm:1.18.1"
-  dependencies:
-    eventemitter3: ^4.0.0
-    follow-redirects: ^1.0.0
-    requires-port: ^1.0.0
-  checksum: f5bd96bf83e0b1e4226633dbb51f8b056c3e6321917df402deacec31dd7fe433914fc7a2c1831cf7ae21e69c90b3a669b8f434723e9e8b71fd68afe30737b6a5
-  languageName: node
-  linkType: hard
-
-"http-server@npm:^14.1.1":
-  version: 14.1.1
-  resolution: "http-server@npm:14.1.1"
-  dependencies:
-    basic-auth: ^2.0.1
-    chalk: ^4.1.2
-    corser: ^2.0.1
-    he: ^1.2.0
-    html-encoding-sniffer: ^3.0.0
-    http-proxy: ^1.18.1
-    mime: ^1.6.0
-    minimist: ^1.2.6
-    opener: ^1.5.1
-    portfinder: ^1.0.28
-    secure-compare: 3.0.1
-    union: ~0.5.0
-    url-join: ^4.0.1
-  bin:
-    http-server: bin/http-server
-  checksum: 4f9674289195eaf9f3e408e093d2080b0d4647559a32c9e7868639c327cab62efd0bb8bc9ded9a625d9ce982cbb03517d4472400af5ecf36eeb5b4fa62d113fe
   languageName: node
   linkType: hard
 
@@ -11650,7 +11573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -11974,15 +11897,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "mime@npm:1.6.0"
-  bin:
-    mime: cli.js
-  checksum: fef25e39263e6d207580bdc629f8872a3f9772c923c7f8c7e793175cee22777bbe8bba95e5d509a40aaa292d8974514ce634ae35769faa45f22d17edda5e8557
-  languageName: node
-  linkType: hard
-
 "mimic-fn@npm:^2.1.0":
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
@@ -12120,17 +12034,6 @@ __metadata:
   version: 0.5.3
   resolution: "mkdirp-classic@npm:0.5.3"
   checksum: 3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
-  languageName: node
-  linkType: hard
-
-"mkdirp@npm:^0.5.6":
-  version: 0.5.6
-  resolution: "mkdirp@npm:0.5.6"
-  dependencies:
-    minimist: ^1.2.6
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
   languageName: node
   linkType: hard
 
@@ -12785,15 +12688,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"opener@npm:^1.5.1":
-  version: 1.5.2
-  resolution: "opener@npm:1.5.2"
-  bin:
-    opener: bin/opener-bin.js
-  checksum: 33b620c0d53d5b883f2abc6687dd1c5fd394d270dbe33a6356f2d71e0a2ec85b100d5bac94694198ccf5c30d592da863b2292c5539009c715a9c80c697b4f6cc
-  languageName: node
-  linkType: hard
-
 "optionator@npm:^0.8.1":
   version: 0.8.3
   resolution: "optionator@npm:0.8.3"
@@ -13368,17 +13262,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"portfinder@npm:^1.0.28":
-  version: 1.0.32
-  resolution: "portfinder@npm:1.0.32"
-  dependencies:
-    async: ^2.6.4
-    debug: ^3.2.7
-    mkdirp: ^0.5.6
-  checksum: 116b4aed1b9e16f6d5503823d966d9ffd41b1c2339e27f54c06cd2f3015a9d8ef53e2a53b57bc0a25af0885977b692007353aa28f9a0a98a44335cb50487240d
-  languageName: node
-  linkType: hard
-
 "posix-character-classes@npm:^0.1.0":
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"
@@ -13652,15 +13535,6 @@ __metadata:
   version: 1.1.3
   resolution: "pvutils@npm:1.1.3"
   checksum: 2ee26a9e5176c348977d6ec00d8ee80bff62f51743b1c5fe8abeeb4c5d29d9959cdfe0ce146707a9e6801bce88190fed3002d720b072dc87d031c692820b44c9
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.4.0":
-  version: 6.11.0
-  resolution: "qs@npm:6.11.0"
-  dependencies:
-    side-channel: ^1.0.4
-  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
   languageName: node
   linkType: hard
 
@@ -14103,13 +13977,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"requires-port@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "requires-port@npm:1.0.0"
-  checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
-  languageName: node
-  linkType: hard
-
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -14383,7 +14250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
@@ -14500,13 +14367,6 @@ __metadata:
     node-gyp: latest
     node-gyp-build: ^4.2.0
   checksum: 21e219adc0024fbd75021001358780a3cc6ac21273c3fcaef46943af73969729709b03f1df7c012a0baab0830fb9a06ccc6b42f8d50050c665cb98078eab477b
-  languageName: node
-  linkType: hard
-
-"secure-compare@npm:3.0.1":
-  version: 3.0.1
-  resolution: "secure-compare@npm:3.0.1"
-  checksum: 0a8d8d3e54d5772d2cf1c02325f01fc7366d0bd33f964a08a84fe3ee5f34d46435a6ae729c1d239c750e160ef9b58c764d3efb945a1d07faf47978a8e4161594
   languageName: node
   linkType: hard
 
@@ -16246,15 +16106,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"union@npm:~0.5.0":
-  version: 0.5.0
-  resolution: "union@npm:0.5.0"
-  dependencies:
-    qs: ^6.4.0
-  checksum: 021530d02363fb7470ce45d4cb06ae28a97d5a245666e6d0fca6bab0673bea8c7988e7d2f8046acfbab120908cedcb099ca216b357d4483bcd96518b39101be0
-  languageName: node
-  linkType: hard
-
 "unique-filename@npm:^1.1.1":
   version: 1.1.1
   resolution: "unique-filename@npm:1.1.1"
@@ -16334,13 +16185,6 @@ __metadata:
   version: 0.1.0
   resolution: "urix@npm:0.1.0"
   checksum: 4c076ecfbf3411e888547fe844e52378ab5ada2d2f27625139011eada79925e77f7fbf0e4016d45e6a9e9adb6b7e64981bd49b22700c7c401c5fc15f423303b3
-  languageName: node
-  linkType: hard
-
-"url-join@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "url-join@npm:4.0.1"
-  checksum: f74e868bf25dbc8be6a8d7237d4c36bb5b6c62c72e594d5ab1347fe91d6af7ccd9eb5d621e30152e4da45c2e9a26bec21390e911ab54a62d4d82e76028374ee5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,14 +2645,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/post-message-stream@portal:/Users/morten/Development/MetaMask/post-message-stream::locator=root%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@metamask/post-message-stream@portal:/Users/morten/Development/MetaMask/post-message-stream::locator=root%40workspace%3A."
+"@metamask/post-message-stream@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/post-message-stream@npm:6.1.0"
   dependencies:
     "@metamask/utils": ^3.0.1
     readable-stream: 2.3.3
+  checksum: 2503f3fbce7f9c8372ccc429253688f296876ccb83e7c55e8cbc512e7004d84555f111c75c0f81444a6f8148533a86d537bffa9fad9b5c8b13727615a96b32fe
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@metamask/providers@npm:^10.2.0, @metamask/providers@npm:^10.2.1":
   version: 10.2.1
@@ -2906,7 +2907,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/object-multiplex": ^1.2.0
-    "@metamask/post-message-stream": ^6.0.0
+    "@metamask/post-message-stream": ^6.1.0
     "@metamask/providers": ^10.2.0
     "@metamask/snaps-utils": ^0.27.1
     "@metamask/utils": ^3.4.1
@@ -2928,6 +2929,7 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
     eth-rpc-errors: ^4.0.3
+    http-server: ^14.1.1
     jest: ^29.0.2
     jest-environment-jsdom: ^29.0.2
     jest-fetch-mock: ^3.0.3
@@ -4977,6 +4979,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^2.6.4":
+  version: 2.6.4
+  resolution: "async@npm:2.6.4"
+  dependencies:
+    lodash: ^4.17.14
+  checksum: a52083fb32e1ebe1d63e5c5624038bb30be68ff07a6c8d7dfe35e47c93fc144bd8652cbec869e0ac07d57dde387aa5f1386be3559cdee799cb1f789678d88e19
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -5296,6 +5307,15 @@ __metadata:
     mixin-deep: ^1.2.0
     pascalcase: ^0.1.1
   checksum: a4a146b912e27eea8f66d09cb0c9eab666f32ce27859a7dfd50f38cd069a2557b39f16dba1bc2aecb3b44bf096738dd207b7970d99b0318423285ab1b1994edd
+  languageName: node
+  linkType: hard
+
+"basic-auth@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "basic-auth@npm:2.0.1"
+  dependencies:
+    safe-buffer: 5.1.2
+  checksum: 3419b805d5dfc518f3a05dcf42aa53aa9ce820e50b6df5097f9e186322e1bc733c36722b624802cd37e791035aa73b828ed814d8362333d42d7f5cd04d7a5e48
   languageName: node
   linkType: hard
 
@@ -6023,7 +6043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -6677,6 +6697,13 @@ __metadata:
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
   checksum: 7a4c925b497a2c91421e25bf76d6d8190f0b2359a9200dbeed136e63b2931d6294d3b1893eda378883ed363cd950f44a12a401384c609839ea616befb7927dab
+  languageName: node
+  linkType: hard
+
+"corser@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "corser@npm:2.0.1"
+  checksum: 9ff6944eda760c8c3118747a636afc3ede53b41e7b9960513a15b88032209a728e630ae4b41e20a941e34da129fe9094d1f5d95123ef64ac2e16cdad8dce9c87
   languageName: node
   linkType: hard
 
@@ -8189,6 +8216,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^4.0.0":
+  version: 4.0.7
+  resolution: "eventemitter3@npm:4.0.7"
+  checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
+  languageName: node
+  linkType: hard
+
 "events@npm:^3.0.0, events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -8665,6 +8699,16 @@ __metadata:
     inherits: ^2.0.3
     readable-stream: ^2.3.6
   checksum: 42e07747f83bcd4e799da802e621d6039787749ffd41f5517f8c4f786ee967e31ba32b09f8b28a9c6f67bd4f5346772e604202df350e8d99f4141771bae31279
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.0.0":
+  version: 1.15.2
+  resolution: "follow-redirects@npm:1.15.2"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
   languageName: node
   linkType: hard
 
@@ -9535,6 +9579,40 @@ __metadata:
     agent-base: 6
     debug: 4
   checksum: e2ee1ff1656a131953839b2a19cd1f3a52d97c25ba87bd2559af6ae87114abf60971e498021f9b73f9fd78aea8876d1fb0d4656aac8a03c6caa9fc175f22b786
+  languageName: node
+  linkType: hard
+
+"http-proxy@npm:^1.18.1":
+  version: 1.18.1
+  resolution: "http-proxy@npm:1.18.1"
+  dependencies:
+    eventemitter3: ^4.0.0
+    follow-redirects: ^1.0.0
+    requires-port: ^1.0.0
+  checksum: f5bd96bf83e0b1e4226633dbb51f8b056c3e6321917df402deacec31dd7fe433914fc7a2c1831cf7ae21e69c90b3a669b8f434723e9e8b71fd68afe30737b6a5
+  languageName: node
+  linkType: hard
+
+"http-server@npm:^14.1.1":
+  version: 14.1.1
+  resolution: "http-server@npm:14.1.1"
+  dependencies:
+    basic-auth: ^2.0.1
+    chalk: ^4.1.2
+    corser: ^2.0.1
+    he: ^1.2.0
+    html-encoding-sniffer: ^3.0.0
+    http-proxy: ^1.18.1
+    mime: ^1.6.0
+    minimist: ^1.2.6
+    opener: ^1.5.1
+    portfinder: ^1.0.28
+    secure-compare: 3.0.1
+    union: ~0.5.0
+    url-join: ^4.0.1
+  bin:
+    http-server: bin/http-server
+  checksum: 4f9674289195eaf9f3e408e093d2080b0d4647559a32c9e7868639c327cab62efd0bb8bc9ded9a625d9ce982cbb03517d4472400af5ecf36eeb5b4fa62d113fe
   languageName: node
   linkType: hard
 
@@ -11572,7 +11650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -11896,6 +11974,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "mime@npm:1.6.0"
+  bin:
+    mime: cli.js
+  checksum: fef25e39263e6d207580bdc629f8872a3f9772c923c7f8c7e793175cee22777bbe8bba95e5d509a40aaa292d8974514ce634ae35769faa45f22d17edda5e8557
+  languageName: node
+  linkType: hard
+
 "mimic-fn@npm:^2.1.0":
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
@@ -12033,6 +12120,17 @@ __metadata:
   version: 0.5.3
   resolution: "mkdirp-classic@npm:0.5.3"
   checksum: 3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "mkdirp@npm:0.5.6"
+  dependencies:
+    minimist: ^1.2.6
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
   languageName: node
   linkType: hard
 
@@ -12687,6 +12785,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"opener@npm:^1.5.1":
+  version: 1.5.2
+  resolution: "opener@npm:1.5.2"
+  bin:
+    opener: bin/opener-bin.js
+  checksum: 33b620c0d53d5b883f2abc6687dd1c5fd394d270dbe33a6356f2d71e0a2ec85b100d5bac94694198ccf5c30d592da863b2292c5539009c715a9c80c697b4f6cc
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.8.1":
   version: 0.8.3
   resolution: "optionator@npm:0.8.3"
@@ -13261,6 +13368,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"portfinder@npm:^1.0.28":
+  version: 1.0.32
+  resolution: "portfinder@npm:1.0.32"
+  dependencies:
+    async: ^2.6.4
+    debug: ^3.2.7
+    mkdirp: ^0.5.6
+  checksum: 116b4aed1b9e16f6d5503823d966d9ffd41b1c2339e27f54c06cd2f3015a9d8ef53e2a53b57bc0a25af0885977b692007353aa28f9a0a98a44335cb50487240d
+  languageName: node
+  linkType: hard
+
 "posix-character-classes@npm:^0.1.0":
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"
@@ -13534,6 +13652,15 @@ __metadata:
   version: 1.1.3
   resolution: "pvutils@npm:1.1.3"
   checksum: 2ee26a9e5176c348977d6ec00d8ee80bff62f51743b1c5fe8abeeb4c5d29d9959cdfe0ce146707a9e6801bce88190fed3002d720b072dc87d031c692820b44c9
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.4.0":
+  version: 6.11.0
+  resolution: "qs@npm:6.11.0"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
   languageName: node
   linkType: hard
 
@@ -13976,6 +14103,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"requires-port@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "requires-port@npm:1.0.0"
+  checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -14249,7 +14383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
@@ -14366,6 +14500,13 @@ __metadata:
     node-gyp: latest
     node-gyp-build: ^4.2.0
   checksum: 21e219adc0024fbd75021001358780a3cc6ac21273c3fcaef46943af73969729709b03f1df7c012a0baab0830fb9a06ccc6b42f8d50050c665cb98078eab477b
+  languageName: node
+  linkType: hard
+
+"secure-compare@npm:3.0.1":
+  version: 3.0.1
+  resolution: "secure-compare@npm:3.0.1"
+  checksum: 0a8d8d3e54d5772d2cf1c02325f01fc7366d0bd33f964a08a84fe3ee5f34d46435a6ae729c1d239c750e160ef9b58c764d3efb945a1d07faf47978a8e4161594
   languageName: node
   linkType: hard
 
@@ -16105,6 +16246,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"union@npm:~0.5.0":
+  version: 0.5.0
+  resolution: "union@npm:0.5.0"
+  dependencies:
+    qs: ^6.4.0
+  checksum: 021530d02363fb7470ce45d4cb06ae28a97d5a245666e6d0fca6bab0673bea8c7988e7d2f8046acfbab120908cedcb099ca216b357d4483bcd96518b39101be0
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^1.1.1":
   version: 1.1.1
   resolution: "unique-filename@npm:1.1.1"
@@ -16184,6 +16334,13 @@ __metadata:
   version: 0.1.0
   resolution: "urix@npm:0.1.0"
   checksum: 4c076ecfbf3411e888547fe844e52378ab5ada2d2f27625139011eada79925e77f7fbf0e4016d45e6a9e9adb6b7e64981bd49b22700c7c401c5fc15f423303b3
+  languageName: node
+  linkType: hard
+
+"url-join@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "url-join@npm:4.0.1"
+  checksum: f74e868bf25dbc8be6a8d7237d4c36bb5b6c62c72e594d5ab1347fe91d6af7ccd9eb5d621e30152e4da45c2e9a26bec21390e911ab54a62d4d82e76028374ee5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,14 +3181,14 @@ __metadata:
   linkType: hard
 
 "@metamask/utils@npm:^3.0.1":
-  version: 3.3.1
-  resolution: "@metamask/utils@npm:3.3.1"
+  version: 3.4.0
+  resolution: "@metamask/utils@npm:3.4.0"
   dependencies:
     "@types/debug": ^4.1.7
     debug: ^4.3.4
     semver: ^7.3.8
-    superstruct: ^0.16.7
-  checksum: 5b6b6b54fdff4bc3f77b31ef50c23adca8fdf21d81d4f68d3d9c2b383b145cd61c2435f5ba0a11344484ae1f6d2355fab82eec58ce6b19eb35b476928b2e4ee6
+    superstruct: ^1.0.3
+  checksum: 7d2b2e5e666587a429b274c1a00a9b89787bf0b590fc594d6a3d2900f0d73bf514191e6a371fa8bfa497ccded8abab0e1fa80606efa3849067aa9ba29891e034
   languageName: node
   linkType: hard
 
@@ -15267,13 +15267,6 @@ __metadata:
   dependencies:
     minimist: ^1.1.0
   checksum: 8359df72e9a2d03c35702ba58e49cac04daae8f27dff26837e12687c7d10cb800a036fd33fdc5eb0e8c24fb25d804f657fe8bde18dd3dd6ec7dab8eff7aac27e
-  languageName: node
-  linkType: hard
-
-"superstruct@npm:^0.16.7":
-  version: 0.16.7
-  resolution: "superstruct@npm:0.16.7"
-  checksum: c8c855ff6945da8a41048c6d236de7b1af5d4d9c31742b3ee54d65647c31597488620281f65e095d5efc9e2fbdaad529b8c8f2506c12569d428467c835a21477
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,19 +3180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^3.0.1":
-  version: 3.4.0
-  resolution: "@metamask/utils@npm:3.4.0"
-  dependencies:
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    semver: ^7.3.8
-    superstruct: ^1.0.3
-  checksum: 7d2b2e5e666587a429b274c1a00a9b89787bf0b590fc594d6a3d2900f0d73bf514191e6a371fa8bfa497ccded8abab0e1fa80606efa3849067aa9ba29891e034
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^3.3.0, @metamask/utils@npm:^3.4.0, @metamask/utils@npm:^3.4.1":
+"@metamask/utils@npm:^3.0.1, @metamask/utils@npm:^3.3.0, @metamask/utils@npm:^3.4.0, @metamask/utils@npm:^3.4.1":
   version: 3.4.1
   resolution: "@metamask/utils@npm:3.4.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,6 +3077,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
+    "@metamask/post-message-stream": ^6.1.0
     "@metamask/providers": ^10.2.1
     "@metamask/snaps-registry": ^1.0.0
     "@metamask/snaps-ui": ^0.27.1
@@ -3107,6 +3108,7 @@ __metadata:
     rfdc: ^1.3.0
     rimraf: ^3.0.2
     semver: ^7.3.7
+    serve-handler: ^6.1.5
     ses: ^0.18.1
     superstruct: ^1.0.3
     ts-jest: ^29.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,15 +2645,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/post-message-stream@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/post-message-stream@npm:6.0.0"
+"@metamask/post-message-stream@portal:/Users/morten/Development/MetaMask/post-message-stream::locator=root%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@metamask/post-message-stream@portal:/Users/morten/Development/MetaMask/post-message-stream::locator=root%40workspace%3A."
   dependencies:
-    "@metamask/utils": ^2.0.0
+    "@metamask/utils": ^3.0.1
     readable-stream: 2.3.3
-  checksum: 2909b92b1372f88e072d22ea833c8d722c20e5584e11d765705193641bdb37f0cbbdb8ba1923f6a6d511771daef8c877b7ef874d7413d75ea5184ab57078c82b
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@metamask/providers@npm:^10.2.0, @metamask/providers@npm:^10.2.1":
   version: 10.2.1
@@ -2841,7 +2840,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/object-multiplex": ^1.1.0
     "@metamask/permission-controller": ^1.0.1
-    "@metamask/post-message-stream": ^6.0.0
+    "@metamask/post-message-stream": ^6.1.0
     "@metamask/rpc-methods": ^0.27.1
     "@metamask/snaps-execution-environments": ^0.27.1
     "@metamask/snaps-registry": ^1.0.0
@@ -3178,12 +3177,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "@metamask/utils@npm:2.1.0"
+"@metamask/utils@npm:^3.0.1":
+  version: 3.3.1
+  resolution: "@metamask/utils@npm:3.3.1"
   dependencies:
-    fast-deep-equal: ^3.1.3
-  checksum: 50970fe28cbf98fbc34fb4f69d9bc90f5db94929c69ab532f57b48f42163ea77fb080ab31854efd984361c3e29e67831a78d94d1211ac3bcc6b9557769c73127
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    semver: ^7.3.8
+    superstruct: ^0.16.7
+  checksum: 5b6b6b54fdff4bc3f77b31ef50c23adca8fdf21d81d4f68d3d9c2b383b145cd61c2435f5ba0a11344484ae1f6d2355fab82eec58ce6b19eb35b476928b2e4ee6
   languageName: node
   linkType: hard
 
@@ -15262,6 +15264,13 @@ __metadata:
   dependencies:
     minimist: ^1.1.0
   checksum: 8359df72e9a2d03c35702ba58e49cac04daae8f27dff26837e12687c7d10cb800a036fd33fdc5eb0e8c24fb25d804f657fe8bde18dd3dd6ec7dab8eff7aac27e
+  languageName: node
+  linkType: hard
+
+"superstruct@npm:^0.16.7":
+  version: 0.16.7
+  resolution: "superstruct@npm:0.16.7"
+  checksum: c8c855ff6945da8a41048c6d236de7b1af5d4d9c31742b3ee54d65647c31597488620281f65e095d5efc9e2fbdaad529b8c8f2506c12569d428467c835a21477
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds a new execution environment that runs snaps using Chrome's `offscreen` API. It behaves similar to the iframe execution environment, but uses a proxy between the extension and the iframes, which runs in an offscreen document. This makes it compatible with MV3.

Closes #1088.