### PR TITLE
Fix `snap_manageState` with empty state

### DIFF
--- a/packages/rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/rpc-methods/src/restricted/manageState.test.ts
@@ -90,6 +90,29 @@ describe('snap_manageState', () => {
       expect(result).toStrictEqual(mockSnapState);
     });
 
+    it('supports empty state', async () => {
+      const clearSnapState = jest.fn().mockResolvedValueOnce(true);
+      const getSnapState = jest.fn().mockResolvedValueOnce(null);
+      const updateSnapState = jest.fn().mockResolvedValueOnce(true);
+
+      const manageStateImplementation = getManageStateImplementation({
+        clearSnapState,
+        getSnapState,
+        updateSnapState,
+        getMnemonic: jest.fn().mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE),
+        getUnlockPromise: jest.fn(),
+      });
+
+      const result = await manageStateImplementation({
+        context: { origin: MOCK_SNAP_ID },
+        method: 'snap_manageState',
+        params: { operation: ManageStateOperation.GetState },
+      });
+
+      expect(getSnapState).toHaveBeenCalledWith(MOCK_SNAP_ID);
+      expect(result).toBeNull();
+    });
+
     it('clears snap state', async () => {
       const clearSnapState = jest.fn().mockResolvedValueOnce(true);
       const getSnapState = jest.fn().mockResolvedValueOnce(true);

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -245,6 +245,9 @@ export function getManageStateImplementation({
 
       case ManageStateOperation.GetState: {
         const state = await getSnapState(origin);
+        if (state === null) {
+          return state;
+        }
         return await decryptState({
           state,
           mnemonicPhrase,


### PR DESCRIPTION
Fixes `snap_manageState` throwing in case of empty state.