### PR TITLE
Add proxy for `ethereum` global

### DIFF
--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -6,7 +6,7 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts', '.ava.test.ts'],
   coverageThreshold: {
     global: {
-      branches: 83.41,
+      branches: 83.93,
       functions: 92.25,
       lines: 87.07,
       statements: 87.18,

--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts', '.ava.test.ts'],
   coverageThreshold: {
     global: {
-      branches: 83.68,
-      functions: 92.19,
-      lines: 87.11,
-      statements: 87.22,
+      branches: 83.41,
+      functions: 92.25,
+      lines: 87.07,
+      statements: 87.18,
     },
   },
   testEnvironment: '<rootDir>/jest.environment.js',


### PR DESCRIPTION
Add proxy for `ethereum` global so a snap cannot access the internals of the object. We instead only allow access to our custom `request` function as well as EIP-1193 defaults.