### PR TITLE
BREAKING: Remove Date from default endowments

### DIFF
--- a/packages/snaps-utils/src/default-endowments.ts
+++ b/packages/snaps-utils/src/default-endowments.ts
@@ -7,7 +7,6 @@ export const DEFAULT_ENDOWMENTS: readonly string[] = Object.freeze([
   'BigInt',
   'console',
   'crypto',
-  'Date',
   'Math',
   'setTimeout',
   'clearTimeout',


### PR DESCRIPTION
There's no snaps that we know of that use Date and `Date.now()` is a big security risk of establishing side-channels due to being high-precision timer.

We can come back and add a `Date` in the future after we secure it enough, but for now we don't have the bandwidth to do that. Removing it is good enough for now.

fixes #211.