### PR TITLE
Allow updating crashed snaps

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -813,6 +813,7 @@ export class SnapController extends BaseController<
               target: SnapStatus.Running,
               cond: disableGuard,
             },
+            [SnapStatusEvents.Update]: SnapStatus.Updating,
           },
         },
       },


### PR DESCRIPTION
Allow updating of crashed snaps by allowing state transition from `Crashed` to `Updating`. 