### PR TITLE
Bump `@metamask/key-tree` version

### DIFF
--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@metamask/browser-passworder": "^4.0.2",
-    "@metamask/key-tree": "^6.0.0",
+    "@metamask/key-tree": "^6.1.0",
     "@metamask/permission-controller": "^1.0.1",
     "@metamask/snaps-ui": "^0.27.1",
     "@metamask/snaps-utils": "^0.27.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,17 +2563,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/key-tree@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/key-tree@npm:6.0.0"
+"@metamask/key-tree@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/key-tree@npm:6.1.0"
   dependencies:
+    "@metamask/scure-bip39": ^2.1.0
     "@metamask/utils": ^3.3.0
     "@noble/ed25519": ^1.6.0
     "@noble/hashes": ^1.0.0
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
-    "@scure/bip39": ^1.0.0
-  checksum: 124e1c8195c7a50b8f1fbdc1762c79e024efa3feee921142c64c547963e94ca746f508d41286b57ea0decafa0923ec835c59da3ec4be88b2cb44c4b844a241ac
+  checksum: 552fb8e59c4972521154ec45c0dc43e561c2cf248e8e4e730fd0a70c3890c69f0e89509387ba3ec64def973a53ad6af1c40b50f950aa1f22674d22d4a79cbf88
   languageName: node
   linkType: hard
 
@@ -2686,7 +2686,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/key-tree": ^6.0.0
+    "@metamask/key-tree": ^6.1.0
     "@metamask/permission-controller": ^1.0.1
     "@metamask/snaps-ui": ^0.27.1
     "@metamask/snaps-utils": ^0.27.1
@@ -2722,6 +2722,16 @@ __metadata:
   version: 2.0.0
   resolution: "@metamask/safe-event-emitter@npm:2.0.0"
   checksum: 8b717ac5d53df0027c05509f03d0534700b5898dd1c3a53fb2dc4c0499ca5971b14aae67f522d09eb9f509e77f50afa95fdb3eda1afbff8b071c18a3d2905e93
+  languageName: node
+  linkType: hard
+
+"@metamask/scure-bip39@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/scure-bip39@npm:2.1.0"
+  dependencies:
+    "@noble/hashes": ~1.1.1
+    "@scure/base": ~1.1.0
+  checksum: 13e07f03077472e9b230f702cbba7848ecac752028396647ccdeedd7bc280ceb50ee15203e25603f05c4c6ca5d4dc7277825f7004beb113e1a415adc91f059f9
   languageName: node
   linkType: hard
 
@@ -3365,16 +3375,6 @@ __metadata:
   version: 1.1.1
   resolution: "@scure/base@npm:1.1.1"
   checksum: b4fc810b492693e7e8d0107313ac74c3646970c198bbe26d7332820886fa4f09441991023ec9aa3a2a51246b74409ab5ebae2e8ef148bbc253da79ac49130309
-  languageName: node
-  linkType: hard
-
-"@scure/bip39@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@scure/bip39@npm:1.1.0"
-  dependencies:
-    "@noble/hashes": ~1.1.1
-    "@scure/base": ~1.1.0
-  checksum: c4361406f092a45e511dc572c89f497af6665ad81cb3fd7bf78e6772f357f7ae885e129ef0b985cb3496a460b4811318f77bc61634d9b0a8446079a801b6003c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pulls in update to `@metamask/key-tree` in which BIP-39 implementation is updated from `@scure/bip39` to MetaMask fork version `@metamask/scure-bip39`. The `@metamask/scure-bip39` fork accepts secret recovery phrases in `Uint8Array` format making it possible to use more secure patterns of passing secret recovery phrases around. This change is non-breaking however, as the mnemonicToSeed function used in this package still accepts secret recovery phrases in string format.

Even before Snaps switches to passing SRPs as Uint8Arrays this change will be useful by unifying the extension on one BIP-39 implementation reducing redundant code.