### PR TITLE
Add safety measures for malicious tarballs 

### DIFF
--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -186,8 +186,8 @@ export class NpmLocation implements SnapLocation {
         getNodeStream(tarballResponse),
         // The "gz" in "tgz" stands for "gzip". The tarball needs to be decompressed
         // before we can actually grab any files from it.
-        // To prevent recursion-based zip bombs, we set a maximum recursion depth of 3.
-        createGunzipStream(3),
+        // To prevent recursion-based zip bombs, we set a maximum recursion depth of 1.
+        createGunzipStream(1),
         createTarballStream(
           `${canonicalBase}/${this.meta.packageName}/`,
           this.files,


### PR DESCRIPTION
Adds safety measure for large tarballs, reduces recursion limit for `gunzip` and adds some comments regarding tarball security. 

Also restores error handling for errors that occur in the tarball stream.

Fixes https://github.com/MetaMask/MetaMask-planning/issues/272