### PR TITLE
Constrain Date and timeouts

### DIFF
--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -6,10 +6,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/index.ts', '.ava.test.ts'],
   coverageThreshold: {
     global: {
-      branches: 82.03,
+      branches: 82.26,
       functions: 90.09,
-      lines: 90.53,
-      statements: 90.61,
+      lines: 90.49,
+      statements: 90.57,
     },
   },
   projects: [

--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -7,9 +7,9 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 82.03,
-      functions: 89.71,
-      lines: 90.12,
-      statements: 90.21,
+      functions: 90.09,
+      lines: 90.53,
+      statements: 90.61,
     },
   },
   projects: [

--- a/packages/snaps-execution-environments/src/common/endowments/date.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.test.ts
@@ -1,0 +1,23 @@
+import { rootRealmGlobal } from '../globalObject';
+import date from './date';
+
+describe('Date endowment', () => {
+  it('has expected properties', () => {
+    expect(date).toMatchObject({
+      names: ['Date'],
+      factory: expect.any(Function),
+    });
+  });
+
+  it('returns Date from rootRealmGlobal', () => {
+    const { Date } = date.factory();
+    expect(Date.UTC).toStrictEqual(rootRealmGlobal.Date.UTC);
+  });
+
+  describe('now', () => {
+    it('does not return the original Date.now', () => {
+      const { Date } = date.factory();
+      expect(Date.now).not.toStrictEqual(rootRealmGlobal.Date.now);
+    });
+  });
+});

--- a/packages/snaps-execution-environments/src/common/endowments/date.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.test.ts
@@ -17,9 +17,11 @@ describe('Date endowment', () => {
     });
   });
 
-  it('returns Date from rootRealmGlobal', () => {
+  it('has same properties as rootRealmGlobal.Date', () => {
     const { Date } = date.factory();
-    expect(Date.UTC).toStrictEqual(rootRealmGlobal.Date.UTC);
+    expect(Object.getOwnPropertyNames(Date)).toStrictEqual(
+      Object.getOwnPropertyNames(rootRealmGlobal.Date),
+    );
   });
 
   describe('constructor', () => {
@@ -29,12 +31,18 @@ describe('Date endowment', () => {
       const newDate = new Date();
       expect(newDate.getTime()).not.toBe(actual.getTime());
     });
+
+    it('new constructor still supports arguments', () => {
+      const { Date } = date.factory();
+      expect(new Date(0).getTime()).toBe(0);
+    });
   });
 
   describe('now', () => {
     it('does not return the original Date.now', () => {
       const { Date } = date.factory();
       expect(Date.now).not.toStrictEqual(rootRealmGlobal.Date.now);
+      expect(Date.now()).not.toBe(rootRealmGlobal.Date.now());
     });
   });
 });

--- a/packages/snaps-execution-environments/src/common/endowments/date.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.test.ts
@@ -26,6 +26,9 @@ describe('Date endowment', () => {
 
   describe('constructor', () => {
     it('does not return the original constructor', () => {
+      jest
+        .spyOn(rootRealmGlobal.crypto, 'getRandomValues')
+        .mockImplementation(() => new Uint32Array([42]));
       const { Date } = date.factory();
       const actual = new rootRealmGlobal.Date();
       const newDate = new Date();
@@ -40,6 +43,9 @@ describe('Date endowment', () => {
 
   describe('now', () => {
     it('does not return the original Date.now', () => {
+      jest
+        .spyOn(rootRealmGlobal.crypto, 'getRandomValues')
+        .mockImplementation(() => new Uint32Array([42]));
       const { Date } = date.factory();
       expect(Date.now).not.toStrictEqual(rootRealmGlobal.Date.now);
       expect(Date.now()).not.toBe(rootRealmGlobal.Date.now());

--- a/packages/snaps-execution-environments/src/common/endowments/date.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.test.ts
@@ -26,9 +26,7 @@ describe('Date endowment', () => {
 
   describe('constructor', () => {
     it('does not return the original constructor', () => {
-      jest
-        .spyOn(rootRealmGlobal.crypto, 'getRandomValues')
-        .mockImplementation(() => new Uint32Array([42]));
+      jest.spyOn(rootRealmGlobal.Math, 'random').mockImplementation(() => 0.5);
       const { Date } = date.factory();
       const actual = new rootRealmGlobal.Date();
       const newDate = new Date();
@@ -43,9 +41,7 @@ describe('Date endowment', () => {
 
   describe('now', () => {
     it('does not return the original Date.now', () => {
-      jest
-        .spyOn(rootRealmGlobal.crypto, 'getRandomValues')
-        .mockImplementation(() => new Uint32Array([42]));
+      jest.spyOn(rootRealmGlobal.Math, 'random').mockImplementation(() => 0.5);
       const { Date } = date.factory();
       expect(Date.now).not.toStrictEqual(rootRealmGlobal.Date.now);
       expect(Date.now()).not.toBe(rootRealmGlobal.Date.now());

--- a/packages/snaps-execution-environments/src/common/endowments/date.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.test.ts
@@ -2,6 +2,14 @@ import { rootRealmGlobal } from '../globalObject';
 import date from './date';
 
 describe('Date endowment', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-01'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('has expected properties', () => {
     expect(date).toMatchObject({
       names: ['Date'],
@@ -12,6 +20,15 @@ describe('Date endowment', () => {
   it('returns Date from rootRealmGlobal', () => {
     const { Date } = date.factory();
     expect(Date.UTC).toStrictEqual(rootRealmGlobal.Date.UTC);
+  });
+
+  describe('constructor', () => {
+    it('does not return the original constructor', () => {
+      const { Date } = date.factory();
+      const actual = new rootRealmGlobal.Date();
+      const newDate = new Date();
+      expect(newDate.getTime()).not.toBe(actual.getTime());
+    });
   });
 
   describe('now', () => {

--- a/packages/snaps-execution-environments/src/common/endowments/date.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.ts
@@ -20,9 +20,9 @@ function createDate() {
     const noise =
       rootRealmGlobal.crypto.getRandomValues(new Uint32Array(1))[0] %
       MAXIMUM_NOISE;
-    const newRounded = Math.round(actual + noise);
-    if (newRounded > currentTime) {
-      currentTime = newRounded;
+    const newTime = actual + noise;
+    if (newTime > currentTime) {
+      currentTime = newTime;
     }
     return currentTime;
   };

--- a/packages/snaps-execution-environments/src/common/endowments/date.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.ts
@@ -1,7 +1,5 @@
 import { rootRealmGlobal } from '../globalObject';
 
-const MAXIMUM_NOISE = 5;
-
 /**
  * Creates a {@link Date} constructor, with most of the same properties as the global object.
  * The Date.now() function has added noise as to limit its precision and prevent potential timing attacks.
@@ -17,10 +15,7 @@ function createDate() {
   let currentTime = 0;
   const now = () => {
     const actual = rootRealmGlobal.Date.now();
-    const noise =
-      rootRealmGlobal.crypto.getRandomValues(new Uint32Array(1))[0] %
-      MAXIMUM_NOISE;
-    const newTime = actual + noise;
+    const newTime = Math.round(actual + Math.random());
     if (newTime > currentTime) {
       currentTime = newTime;
     }

--- a/packages/snaps-execution-environments/src/common/endowments/date.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/date.ts
@@ -1,0 +1,54 @@
+import { rootRealmGlobal } from '../globalObject';
+
+const MAXIMUM_NOISE = 5;
+
+/**
+ * Creates a {@link Date} constructor, with most of the same properties as the global object.
+ * The Date.now() function has added noise as to limit its precision and prevent potential timing attacks.
+ * The Date constructor uses this now() function to seed itself if no arguments are given to the constructor.
+ *
+ * @returns A modified {@link Date} constructor with limited precision.
+ */
+function createDate() {
+  const keys = Object.getOwnPropertyNames(
+    rootRealmGlobal.Date,
+  ) as (keyof typeof Date)[];
+
+  let currentTime = 0;
+  const now = () => {
+    const actual = rootRealmGlobal.Date.now();
+    const noise =
+      rootRealmGlobal.crypto.getRandomValues(new Uint32Array(1))[0] %
+      MAXIMUM_NOISE;
+    const newRounded = Math.round(actual + noise);
+    if (newRounded > currentTime) {
+      currentTime = newRounded;
+    }
+    return currentTime;
+  };
+
+  const NewDate = function (...args: unknown[]) {
+    return Reflect.construct(
+      rootRealmGlobal.Date,
+      args.length === 0 ? [now()] : args,
+      new.target,
+    );
+  } as DateConstructor;
+
+  keys.forEach((key) => {
+    Reflect.defineProperty(NewDate, key, {
+      configurable: false,
+      writable: false,
+      value: key === 'now' ? now : rootRealmGlobal.Date[key],
+    });
+  });
+
+  return { Date: NewDate };
+}
+
+const endowmentModule = {
+  names: ['Date'] as const,
+  factory: createDate,
+};
+
+export default endowmentModule;

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -38,16 +38,14 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
-        ['Uint8Array', 'Date'],
+        ['Uint8Array'],
       );
 
       expect(endowments).toStrictEqual({
         snap: mockSnapAPI,
         Uint8Array,
-        Date,
       });
       expect(endowments.Uint8Array).toBe(Uint8Array);
-      expect(endowments.Date).toBe(Date);
     });
 
     it('handles special cases where endowment is a function but not a constructor', () => {
@@ -58,9 +56,8 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
-        ['Date', 'mockEndowment'],
+        ['mockEndowment'],
       );
-      expect(endowments.Date).toBe(Date);
       expect(endowments.mockEndowment).toBeDefined();
     });
 

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -4,6 +4,7 @@ import { hasProperty } from '@metamask/utils';
 
 import { rootRealmGlobal } from '../globalObject';
 import crypto from './crypto';
+import date from './date';
 import interval from './interval';
 import math from './math';
 import network from './network';
@@ -27,15 +28,19 @@ type EndowmentFactoryResult = {
  * the same factory function, but we only call each factory once for each snap.
  * See {@link createEndowments} for details.
  */
-const endowmentFactories = [timeout, interval, network, crypto, math].reduce(
-  (factories, builder) => {
-    builder.names.forEach((name) => {
-      factories.set(name, builder.factory);
-    });
-    return factories;
-  },
-  new Map<string, () => EndowmentFactoryResult>(),
-);
+const endowmentFactories = [
+  timeout,
+  interval,
+  network,
+  crypto,
+  math,
+  date,
+].reduce((factories, builder) => {
+  builder.names.forEach((name) => {
+    factories.set(name, builder.factory);
+  });
+  return factories;
+}, new Map<string, () => EndowmentFactoryResult>());
 
 /**
  * Gets the endowments for a particular Snap. Some endowments, like `setTimeout`

--- a/packages/snaps-execution-environments/src/common/endowments/interval.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/interval.ts
@@ -1,3 +1,5 @@
+const MINIMUM_INTERVAL = 10;
+
 /**
  * Creates a pair of `setInterval` and `clearInterval` functions attenuated such
  * that:
@@ -18,7 +20,10 @@ const createInterval = () => {
       );
     }
     const handle = Object.freeze({});
-    const platformHandle = setInterval(handler, timeout);
+    const platformHandle = setInterval(
+      handler,
+      Math.max(MINIMUM_INTERVAL, timeout ?? 0),
+    );
     registeredHandles.set(handle, platformHandle);
     return handle;
   };

--- a/packages/snaps-execution-environments/src/common/endowments/timeout.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/timeout.ts
@@ -1,3 +1,5 @@
+const MINIMUM_TIMEOUT = 10;
+
 /**
  * Creates a pair of `setTimeout` and `clearTimeout` functions attenuated such
  * that:
@@ -22,7 +24,7 @@ const createTimeout = () => {
     const platformHandle = setTimeout(() => {
       registeredHandles.delete(handle);
       handler();
-    }, timeout);
+    }, Math.max(MINIMUM_TIMEOUT, timeout ?? 0));
 
     registeredHandles.set(handle, platformHandle);
     return handle;


### PR DESCRIPTION
Added a custom Date endowment where:
- The Date.now() function has added noise as to limit its precision (down to 1 ms) and prevent potential timing attacks.
- The Date constructor uses this now() function to seed itself if no arguments are given to the constructor.

Also set a minimum value for `setTimeout` and `setInterval` to be at least `10` ms.

Fixes #211
