### PR TITLE
BREAKING: Disallow local snaps by default

### DIFF
--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,7 +5,7 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 88.64,
+      branches: 88.99,
       functions: 94.67,
       lines: 96,
       statements: 95.92,

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -477,6 +477,7 @@ type FeatureFlags = {
    */
   dappsCanUpdateSnaps?: true;
   requireAllowlist?: true;
+  allowLocalSnaps?: true;
 };
 
 type SnapControllerArgs = {
@@ -1601,6 +1602,7 @@ export class SnapController extends BaseController<
     const location = this.#detectSnapLocation(snapId, {
       versionRange,
       fetch: this.#fetchFunction,
+      allowLocal: this.#featureFlags.allowLocalSnaps,
     });
 
     const existingSnap = this.getTruncated(snapId);

--- a/packages/snaps-controllers/src/snaps/location/location.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/location.test.ts
@@ -21,6 +21,12 @@ describe('detectSnapLocation', () => {
     );
   });
 
+  it('disallows local snaps by default', () => {
+    expect(() =>
+      detectSnapLocation('local:http://localhost', { fetch: jest.fn() }),
+    ).toThrow('Fetching local snaps is disabled.');
+  });
+
   it.each([
     ['npm:package', NpmLocation],
     ['local:http://localhost', LocalLocation],
@@ -31,6 +37,7 @@ describe('detectSnapLocation', () => {
       detectSnapLocation(url, {
         fetch: jest.fn(),
         allowHttp: true,
+        allowLocal: true,
         allowCustomRegistries: true,
       }),
     ).toBeInstanceOf(classObj);

--- a/packages/snaps-controllers/src/snaps/location/location.ts
+++ b/packages/snaps-controllers/src/snaps/location/location.ts
@@ -35,6 +35,10 @@ export type DetectSnapLocationOptions = NpmOptions & {
    * @default false
    */
   allowHttp?: boolean;
+  /**
+   * @default false
+   */
+  allowLocal?: boolean;
 };
 
 /**
@@ -49,11 +53,13 @@ export function detectSnapLocation(
   opts?: DetectSnapLocationOptions,
 ): SnapLocation {
   const allowHttp = opts?.allowHttp ?? false;
+  const allowLocal = opts?.allowLocal ?? false;
   const root = new URL(location);
   switch (root.protocol) {
     case 'npm:':
       return new NpmLocation(root, opts);
     case 'local:':
+      assert(allowLocal, new TypeError('Fetching local snaps is disabled.'));
       return new LocalLocation(root, opts);
     case 'http:':
     case 'https:':


### PR DESCRIPTION
Disallows `local` snaps by default, requiring a feature flag to be enabled for them to be installable.

Fixes #896 