### PR TITLE
Require `location` for `SnapController.updateSnap`

### DIFF
--- a/packages/snaps-controllers/jest.config.js
+++ b/packages/snaps-controllers/jest.config.js
@@ -5,7 +5,7 @@ const baseConfig = require('../../jest.config.base');
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 88.99,
+      branches: 88.92,
       functions: 94.67,
       lines: 96,
       statements: 95.92,

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2198,6 +2198,8 @@ describe('SnapController', () => {
         initialPermissions,
       };
 
+      const detectSnapLocation = loopbackDetect({ manifest });
+
       const rootMessenger = getControllerMessenger();
       const messenger = getSnapControllerMessenger(rootMessenger);
       const snapController = getSnapController(
@@ -2206,7 +2208,7 @@ describe('SnapController', () => {
           state: {
             snaps: getPersistedSnapsState(),
           },
-          detectSnapLocation: loopbackDetect({ manifest }),
+          detectSnapLocation,
         }),
       );
 
@@ -2215,7 +2217,11 @@ describe('SnapController', () => {
         () => ({}),
       );
 
-      await snapController.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      await snapController.updateSnap(
+        MOCK_ORIGIN,
+        MOCK_SNAP_ID,
+        detectSnapLocation(),
+      );
 
       expect(messenger.call).toHaveBeenNthCalledWith(
         3,
@@ -2632,12 +2638,18 @@ describe('SnapController', () => {
 
   describe('updateSnap', () => {
     it('throws an error on invalid snap id', async () => {
+      const detectSnapLocation = loopbackDetect();
       await expect(async () =>
-        getSnapController().updateSnap(MOCK_ORIGIN, 'local:foo'),
+        getSnapController().updateSnap(
+          MOCK_ORIGIN,
+          'local:foo',
+          detectSnapLocation(),
+        ),
       ).rejects.toThrow('Snap "local:foo" not found');
     });
 
     it('throws an error if the specified SemVer range is invalid', async () => {
+      const detectSnapLocation = loopbackDetect();
       const controller = getSnapController(
         getSnapControllerOptions({
           state: {
@@ -2650,6 +2662,7 @@ describe('SnapController', () => {
         controller.updateSnap(
           MOCK_ORIGIN,
           MOCK_SNAP_ID,
+          detectSnapLocation(),
           'this is not a version' as SemVerRange,
         ),
       ).rejects.toThrow(
@@ -2658,6 +2671,9 @@ describe('SnapController', () => {
     });
 
     it('throws an error if the new version of the snap is blocked', async () => {
+      const detectSnapLocation = loopbackDetect({
+        manifest: getSnapManifest({ version: '1.1.0' as SemVerVersion }),
+      });
       const registry = new MockSnapsRegistry();
       const controller = getSnapController(
         getSnapControllerOptions({
@@ -2665,9 +2681,7 @@ describe('SnapController', () => {
           state: {
             snaps: getPersistedSnapsState(),
           },
-          detectSnapLocation: loopbackDetect({
-            manifest: getSnapManifest({ version: '1.1.0' as SemVerVersion }),
-          }),
+          detectSnapLocation,
         }),
       );
 
@@ -2676,11 +2690,14 @@ describe('SnapController', () => {
       });
 
       await expect(
-        controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID),
+        controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID, detectSnapLocation()),
       ).rejects.toThrow('Cannot install version "1.1.0" of snap');
     });
 
     it('does not update on older snap version downloaded', async () => {
+      const detectSnapLocation = loopbackDetect({
+        manifest: getSnapManifest({ version: '0.9.0' as SemVerVersion }),
+      });
       const messenger = getSnapControllerMessenger();
       const controller = getSnapController(
         getSnapControllerOptions({
@@ -2688,9 +2705,7 @@ describe('SnapController', () => {
           state: {
             snaps: getPersistedSnapsState(),
           },
-          detectSnapLocation: loopbackDetect({
-            manifest: getSnapManifest({ version: '0.9.0' as SemVerVersion }),
-          }),
+          detectSnapLocation,
         }),
       );
       const onSnapUpdated = jest.fn();
@@ -2701,7 +2716,11 @@ describe('SnapController', () => {
       messenger.subscribe('SnapController:snapUpdated', onSnapUpdated);
       messenger.subscribe('SnapController:snapAdded', onSnapAdded);
 
-      const result = await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      const result = await controller.updateSnap(
+        MOCK_ORIGIN,
+        MOCK_SNAP_ID,
+        detectSnapLocation(),
+      );
 
       const newSnap = controller.get(MOCK_SNAP_ID);
 
@@ -2712,21 +2731,22 @@ describe('SnapController', () => {
     });
 
     it('updates a snap', async () => {
+      const detectSnapLocation = jest
+        .fn()
+        .mockImplementationOnce(() => new LoopbackLocation())
+        .mockImplementationOnce(
+          () =>
+            new LoopbackLocation({
+              manifest: getSnapManifest({
+                version: '1.1.0' as SemVerVersion,
+              }),
+            }),
+        );
       const messenger = getSnapControllerMessenger();
       const controller = getSnapController(
         getSnapControllerOptions({
           messenger,
-          detectSnapLocation: jest
-            .fn()
-            .mockImplementationOnce(() => new LoopbackLocation())
-            .mockImplementationOnce(
-              () =>
-                new LoopbackLocation({
-                  manifest: getSnapManifest({
-                    version: '1.1.0' as SemVerVersion,
-                  }),
-                }),
-            ),
+          detectSnapLocation,
         }),
       );
       const callActionSpy = jest.spyOn(messenger, 'call');
@@ -2750,7 +2770,11 @@ describe('SnapController', () => {
       messenger.subscribe('SnapController:snapUpdated', onSnapUpdated);
       messenger.subscribe('SnapController:snapAdded', onSnapAdded);
 
-      const result = await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      const result = await controller.updateSnap(
+        MOCK_ORIGIN,
+        MOCK_SNAP_ID,
+        detectSnapLocation(),
+      );
 
       const newSnapTruncated = controller.getTruncated(MOCK_SNAP_ID);
 
@@ -2840,6 +2864,14 @@ describe('SnapController', () => {
     });
 
     it('can update crashed snap', async () => {
+      const detectSnapLocation = jest.fn().mockImplementation(
+        () =>
+          new LoopbackLocation({
+            manifest: getSnapManifest({
+              version: '1.1.0' as SemVerVersion,
+            }),
+          }),
+      );
       const messenger = getSnapControllerMessenger();
       const controller = getSnapController(
         getSnapControllerOptions({
@@ -2849,18 +2881,15 @@ describe('SnapController', () => {
               getPersistedSnapObject({ status: SnapStatus.Crashed }),
             ),
           },
-          detectSnapLocation: jest.fn().mockImplementation(
-            () =>
-              new LoopbackLocation({
-                manifest: getSnapManifest({
-                  version: '1.1.0' as SemVerVersion,
-                }),
-              }),
-          ),
+          detectSnapLocation,
         }),
       );
 
-      const result = await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      const result = await controller.updateSnap(
+        MOCK_ORIGIN,
+        MOCK_SNAP_ID,
+        detectSnapLocation(),
+      );
 
       const newSnapTruncated = controller.getTruncated(MOCK_SNAP_ID);
 
@@ -2884,6 +2913,9 @@ describe('SnapController', () => {
     });
 
     it('stops and restarts a running snap during an update', async () => {
+      const detectSnapLocation = loopbackDetect({
+        manifest: getSnapManifest({ version: '1.1.0' as SemVerVersion }),
+      });
       const messenger = getSnapControllerMessenger();
       const controller = getSnapController(
         getSnapControllerOptions({
@@ -2891,9 +2923,7 @@ describe('SnapController', () => {
           state: {
             snaps: getPersistedSnapsState(),
           },
-          detectSnapLocation: loopbackDetect({
-            manifest: getSnapManifest({ version: '1.1.0' as SemVerVersion }),
-          }),
+          detectSnapLocation,
         }),
       );
       const callActionSpy = jest.spyOn(messenger, 'call');
@@ -2914,7 +2944,11 @@ describe('SnapController', () => {
 
       const stopSnapSpy = jest.spyOn(controller as any, 'stopSnap');
 
-      await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      await controller.updateSnap(
+        MOCK_ORIGIN,
+        MOCK_SNAP_ID,
+        detectSnapLocation(),
+      );
 
       const isRunning = controller.isRunning(MOCK_SNAP_ID);
 
@@ -2980,6 +3014,9 @@ describe('SnapController', () => {
     });
 
     it('returns null on update request denied', async () => {
+      const detectSnapLocation = loopbackDetect({
+        manifest: getSnapManifest({ version: '1.1.0' as SemVerVersion }),
+      });
       const messenger = getSnapControllerMessenger();
       const controller = getSnapController(
         getSnapControllerOptions({
@@ -2987,9 +3024,7 @@ describe('SnapController', () => {
           state: {
             snaps: getPersistedSnapsState(),
           },
-          detectSnapLocation: loopbackDetect({
-            manifest: getSnapManifest({ version: '1.1.0' as SemVerVersion }),
-          }),
+          detectSnapLocation,
         }),
       );
       const callActionSpy = jest.spyOn(messenger, 'call');
@@ -3006,7 +3041,7 @@ describe('SnapController', () => {
       });
 
       await expect(
-        controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID),
+        controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID, detectSnapLocation()),
       ).rejects.toThrow('User rejected the request.');
 
       const newSnap = controller.get(MOCK_SNAP_ID);
@@ -3118,7 +3153,7 @@ describe('SnapController', () => {
       await controller.installSnaps(MOCK_ORIGIN, { [MOCK_SNAP_ID]: {} });
       await controller.stopSnap(MOCK_SNAP_ID);
 
-      await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID, detect());
 
       expect(callActionSpy).toHaveBeenCalledTimes(12);
       expect(callActionSpy).toHaveBeenNthCalledWith(
@@ -3281,10 +3316,17 @@ describe('SnapController', () => {
       });
 
       await snapController.installSnaps(MOCK_ORIGIN, { [MOCK_SNAP_ID]: {} });
-      await snapController.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      await snapController.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID, detect());
     });
 
     it('handles unnormalized paths correctly', async () => {
+      const detectSnapLocation = loopbackDetect({
+        manifest: getSnapManifest({
+          version: '1.2.0' as SemVerVersion,
+          filePath: './dist/bundle.js',
+          iconPath: './images/icon.svg',
+        }),
+      });
       const messenger = getSnapControllerMessenger();
       const controller = getSnapController(
         getSnapControllerOptions({
@@ -3292,17 +3334,15 @@ describe('SnapController', () => {
           state: {
             snaps: getPersistedSnapsState(),
           },
-          detectSnapLocation: loopbackDetect({
-            manifest: getSnapManifest({
-              version: '1.2.0' as SemVerVersion,
-              filePath: './dist/bundle.js',
-              iconPath: './images/icon.svg',
-            }),
-          }),
+          detectSnapLocation,
         }),
       );
 
-      await controller.updateSnap(MOCK_ORIGIN, MOCK_SNAP_ID);
+      await controller.updateSnap(
+        MOCK_ORIGIN,
+        MOCK_SNAP_ID,
+        detectSnapLocation(),
+      );
 
       const newSnap = controller.get(MOCK_SNAP_ID);
       expect(newSnap?.version).toBe('1.2.0');

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1616,8 +1616,8 @@ export class SnapController extends BaseController<
         const updateResult = await this.updateSnap(
           origin,
           snapId,
-          versionRange,
           location,
+          versionRange,
         );
         if (updateResult === null) {
           throw ethErrors.rpc.invalidParams(
@@ -1675,15 +1675,15 @@ export class SnapController extends BaseController<
    *
    * @param origin - The origin requesting the snap update.
    * @param snapId - The id of the Snap to be updated.
-   * @param newVersionRange - A semver version range in which the maximum version will be chosen.
    * @param location - Optional location that was already used during installation flow.
+   * @param newVersionRange - A semver version range in which the maximum version will be chosen.
    * @returns The snap metadata if updated, `null` otherwise.
    */
   async updateSnap(
     origin: string,
     snapId: ValidatedSnapId,
+    location: SnapLocation,
     newVersionRange: string = DEFAULT_REQUESTED_SNAP_VERSION,
-    location?: SnapLocation,
   ): Promise<TruncatedSnap | null> {
     const snap = this.getExpect(snapId);
 
@@ -1692,11 +1692,7 @@ export class SnapController extends BaseController<
         `Received invalid snap version range: "${newVersionRange}".`,
       );
     }
-    const newSnap = await this.#fetchSnap(
-      snapId,
-      location ??
-        this.#detectSnapLocation(snapId, { versionRange: newVersionRange }),
-    );
+    const newSnap = await this.#fetchSnap(snapId, location);
     const newVersion = newSnap.manifest.result.version;
     if (!gtVersion(newVersion, snap.version)) {
       console.warn(


### PR DESCRIPTION
Require `location` for calls to `updateSnap` to reduce code duplication. Also prevents an issue with the correct configuration not being passed to `detectSnapLocation`