### PR TITLE
Make `authorize()` throw on excluded permissions

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2032,7 +2032,7 @@ describe('SnapController', () => {
     it('throws an error if a forbidden permission is requested', async () => {
       const initialPermissions = {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        'endowment:long-running': [],
+        'endowment:long-running': {},
       };
 
       const manifest = {
@@ -2054,7 +2054,7 @@ describe('SnapController', () => {
         controller.installSnaps(MOCK_ORIGIN, {
           [MOCK_SNAP_ID]: {},
         }),
-      ).rejects.toThrow('Permission not allowed:\nfoobar');
+      ).rejects.toThrow('One or more permissions are not allowed:\nfoobar');
     });
 
     it('maps permission caveats to the proper format', async () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2029,6 +2029,32 @@ describe('SnapController', () => {
       );
     });
 
+    it('throws an error if a forbidden permission is requested', async () => {
+      const initialPermissions = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'endowment:long-running': [],
+      };
+
+      const manifest = {
+        ...getSnapManifest(),
+        initialPermissions,
+      };
+
+      const messenger = getSnapControllerMessenger();
+      const controller = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          detectSnapLocation: loopbackDetect({ manifest }),
+        }),
+      );
+
+      await expect(
+        controller.installSnaps(MOCK_ORIGIN, {
+          [MOCK_SNAP_ID]: {},
+        }),
+      ).rejects.toThrow('Permission not allowed:\nendowment:long-running');
+    });
+
     it('maps permission caveats to the proper format', async () => {
       const initialPermissions = {
         // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2045,6 +2045,8 @@ describe('SnapController', () => {
         getSnapControllerOptions({
           messenger,
           detectSnapLocation: loopbackDetect({ manifest }),
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          excludedPermissions: { 'endowment:long-running': 'foobar' },
         }),
       );
 
@@ -2052,7 +2054,7 @@ describe('SnapController', () => {
         controller.installSnaps(MOCK_ORIGIN, {
           [MOCK_SNAP_ID]: {},
         }),
-      ).rejects.toThrow('Permission not allowed:\nendowment:long-running');
+      ).rejects.toThrow('Permission not allowed:\nfoobar');
     });
 
     it('maps permission caveats to the proper format', async () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2137,8 +2137,8 @@ export class SnapController extends BaseController<
       const excludedPermissionErrors = Object.keys(processedPermissions).reduce<
         string[]
       >((errors, permission) => {
-        if (Object.keys(this.#excludedPermissions).includes(permission)) {
-          return [...errors, this.#excludedPermissions[permission]];
+        if (hasProperty(this.#excludedPermissions, permission)) {
+          errors.push(this.#excludedPermissions[permission]);
         }
 
         return errors;
@@ -2146,7 +2146,9 @@ export class SnapController extends BaseController<
 
       assert(
         excludedPermissionErrors.length === 0,
-        `Permission not allowed:\n${excludedPermissionErrors.join('\n')}`,
+        `One or more permissions are not allowed:\n${excludedPermissionErrors.join(
+          '\n',
+        )}`,
       );
 
       const id = nanoid();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -478,7 +478,6 @@ type FeatureFlags = {
   dappsCanUpdateSnaps?: true;
   requireAllowlist?: true;
   allowLocalSnaps?: true;
-  allowLongRunning?: true;
 };
 
 type SnapControllerArgs = {


### PR DESCRIPTION
Required for: #1103 & #990

Uses a record of permissions with their associated error to forbid usage of according permissions. The list is passed to the controller params for ease of use between Flask and other versions.