### PR TITLE
Add `endowment:long-running` deprecation warning

### DIFF
--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2057,6 +2057,36 @@ describe('SnapController', () => {
       ).rejects.toThrow('One or more permissions are not allowed:\nfoobar');
     });
 
+    it('displays a warning if endowment:long-runnig is used', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const initialPermissions = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'endowment:long-running': {},
+      };
+
+      const manifest = {
+        ...getSnapManifest(),
+        initialPermissions,
+      };
+
+      const messenger = getSnapControllerMessenger();
+      const controller = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          detectSnapLocation: loopbackDetect({ manifest }),
+        }),
+      );
+
+      await controller.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: {},
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'endowment:long-running will soon be deprecated. For more informations please see https://github.com/MetaMask/snaps-monorepo/issues/945.',
+      );
+    });
+
     it('maps permission caveats to the proper format', async () => {
       const initialPermissions = {
         // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2057,7 +2057,7 @@ describe('SnapController', () => {
       ).rejects.toThrow('One or more permissions are not allowed:\nfoobar');
     });
 
-    it('displays a warning if endowment:long-runnig is used', async () => {
+    it('displays a warning if endowment:long-running is used', async () => {
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
       const rootMessenger = getControllerMessenger();
@@ -2089,7 +2089,7 @@ describe('SnapController', () => {
       snapController.destroy();
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'endowment:long-running will soon be deprecated. For more informations please see https://github.com/MetaMask/snaps-monorepo/issues/945.',
+        'endowment:long-running will soon be deprecated. For more information please see https://github.com/MetaMask/snaps-monorepo/issues/945.',
       );
     });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2134,6 +2134,12 @@ export class SnapController extends BaseController<
       const processedPermissions =
         this.#processSnapPermissions(initialPermissions);
 
+      if (hasProperty(processedPermissions, SnapEndowments.LongRunning)) {
+        console.warn(
+          `${SnapEndowments.LongRunning} will soon be deprecated. For more informations please see https://github.com/MetaMask/snaps-monorepo/issues/945.`,
+        );
+      }
+
       const excludedPermissionErrors = Object.keys(processedPermissions).reduce<
         string[]
       >((errors, permission) => {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2389,7 +2389,7 @@ export class SnapController extends BaseController<
     // Long running snaps have timeouts disabled
     if (isLongRunning) {
       console.warn(
-        `${SnapEndowments.LongRunning} will soon be deprecated. For more informations please see https://github.com/MetaMask/snaps-monorepo/issues/945.`,
+        `${SnapEndowments.LongRunning} will soon be deprecated. For more information please see https://github.com/MetaMask/snaps-monorepo/issues/945.`,
       );
       return promise;
     }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2134,12 +2134,6 @@ export class SnapController extends BaseController<
       const processedPermissions =
         this.#processSnapPermissions(initialPermissions);
 
-      if (hasProperty(processedPermissions, SnapEndowments.LongRunning)) {
-        console.warn(
-          `${SnapEndowments.LongRunning} will soon be deprecated. For more informations please see https://github.com/MetaMask/snaps-monorepo/issues/945.`,
-        );
-      }
-
       const excludedPermissionErrors = Object.keys(processedPermissions).reduce<
         string[]
       >((errors, permission) => {
@@ -2394,6 +2388,9 @@ export class SnapController extends BaseController<
 
     // Long running snaps have timeouts disabled
     if (isLongRunning) {
+      console.warn(
+        `${SnapEndowments.LongRunning} will soon be deprecated. For more informations please see https://github.com/MetaMask/snaps-monorepo/issues/945.`,
+      );
       return promise;
     }
 


### PR DESCRIPTION
Progresses: #1103

`console.warn()` a deprecation warning if a snap with `endowment:long-running` is started.