### PR TITLE
Update `wallet_snap_*` rpc method to `wallet_snap`

### DIFF
--- a/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
+++ b/packages/rpc-methods/src/permitted/invokeSnapSugar.ts
@@ -1,4 +1,3 @@
-import { SNAP_PREFIX } from '@metamask/snaps-utils';
 import {
   PermittedHandlerExport,
   JsonRpcRequest,
@@ -51,8 +50,8 @@ export function invokeSnapSugar(
     return end(error);
   }
 
-  req.method = `${SNAP_PREFIX}${params.snapId}`;
-  req.params = params.request;
+  req.method = 'wallet_snap';
+  req.params = params;
   return next();
 }
 

--- a/packages/rpc-methods/src/permitted/requestSnaps.test.ts
+++ b/packages/rpc-methods/src/permitted/requestSnaps.test.ts
@@ -1,8 +1,5 @@
 import { RequestedPermissions } from '@metamask/permission-controller';
-import {
-  getSnapPermissionName,
-  InstallSnapsResult,
-} from '@metamask/snaps-utils';
+import { InstallSnapsResult, SnapCaveatType } from '@metamask/snaps-utils';
 import {
   MOCK_SNAP_ID,
   getTruncatedSnap,
@@ -15,6 +12,8 @@ import {
 import { JsonRpcEngine } from 'json-rpc-engine';
 
 import { requestSnapsHandler } from './requestSnaps';
+
+const permissionName = 'wallet_snap';
 
 describe('requestSnapsHandler', () => {
   it('has the expected shape', () => {
@@ -45,11 +44,13 @@ describe('implementation', () => {
 
     hooks.requestPermissions.mockImplementation(() => [
       {
-        caveats: null,
+        caveats: [
+          { type: SnapCaveatType.SnapIds, value: { [MOCK_SNAP_ID]: {} } },
+        ],
         date: 1661166080905,
         id: 'VyAsBJiDDKawv_XlNcm13',
         invoker: 'https://metamask.github.io',
-        parentCapability: getSnapPermissionName(MOCK_SNAP_ID),
+        parentCapability: permissionName,
       },
     ]);
 
@@ -80,7 +81,11 @@ describe('implementation', () => {
     })) as JsonRpcSuccess<InstallSnapsResult>;
 
     expect(hooks.requestPermissions).toHaveBeenCalledWith({
-      [getSnapPermissionName(MOCK_SNAP_ID)]: {},
+      [permissionName]: {
+        caveats: [
+          { type: SnapCaveatType.SnapIds, value: { [MOCK_SNAP_ID]: {} } },
+        ],
+      },
     });
 
     expect(hooks.installSnaps).toHaveBeenCalledWith({
@@ -98,12 +103,14 @@ describe('implementation', () => {
     const hooks = getMockHooks();
 
     hooks.getPermissions.mockImplementation(() => ({
-      [getSnapPermissionName(MOCK_SNAP_ID)]: {
-        caveats: null,
+      [permissionName]: {
+        caveats: [
+          { type: SnapCaveatType.SnapIds, value: { [MOCK_SNAP_ID]: {} } },
+        ],
         date: 1661166080905,
         id: 'VyAsBJiDDKawv_XlNcm13',
         invoker: 'https://metamask.github.io',
-        parentCapability: getSnapPermissionName(MOCK_SNAP_ID),
+        parentCapability: permissionName,
       },
     }));
 
@@ -134,7 +141,11 @@ describe('implementation', () => {
     })) as JsonRpcSuccess<InstallSnapsResult>;
 
     expect(hooks.requestPermissions).not.toHaveBeenCalledWith({
-      [getSnapPermissionName(MOCK_SNAP_ID)]: {},
+      [permissionName]: {
+        caveats: [
+          { type: SnapCaveatType.SnapIds, value: { [MOCK_SNAP_ID]: {} } },
+        ],
+      },
     });
 
     expect(hooks.installSnaps).toHaveBeenCalledWith({

--- a/packages/rpc-methods/src/permitted/requestSnaps.ts
+++ b/packages/rpc-methods/src/permitted/requestSnaps.ts
@@ -2,7 +2,7 @@ import {
   PermissionConstraint,
   RequestedPermissions,
 } from '@metamask/permission-controller';
-import { getSnapPermissionName } from '@metamask/snaps-utils';
+import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   PermittedHandlerExport,
   JsonRpcRequest,
@@ -61,30 +61,27 @@ export type RequestSnapsHooks = {
 };
 
 /**
- * Checks whether existing permissions satisfy the requested permissions
- *
- * Note: Currently, we don't compare caveats, if any caveats are requested, we always return false.
+ * Checks whether an origin has existing `wallet_snap` permission and
+ * whether or not it has the requested snapIds.
  *
  * @param existingPermissions - The existing permissions for the origin.
- * @param requestedPermissions - The requested permissions for the origin.
- * @returns True if the existing permissions satisfy the requested permissions, otherwise false.
+ * @param requestedSnaps - The requested snaps.
+ * @returns True if the existing permissions satisfy the requested snaps, otherwise false.
  */
-function hasPermissions(
+function hasSnaps(
   existingPermissions: Record<string, PermissionConstraint>,
-  requestedPermissions: RequestedPermissions,
+  requestedSnaps: RequestedPermissions,
 ): boolean {
-  return Object.entries(requestedPermissions).every(
-    ([target, requestedPermission]) => {
-      if (
-        requestedPermission?.caveats &&
-        requestedPermission.caveats.length > 0
-      ) {
-        return false;
-      }
-
-      return hasProperty(existingPermissions, target);
-    },
+  const snapIdCaveat = existingPermissions.wallet_snap?.caveats?.find(
+    (caveat) => caveat.type === SnapCaveatType.SnapIds,
   );
+  const permittedSnaps = snapIdCaveat?.value;
+  if (isObject(permittedSnaps)) {
+    return Object.keys(requestedSnaps).every((requestedSnap) =>
+      hasProperty(permittedSnaps, requestedSnap),
+    );
+  }
+  return false;
 }
 
 /**
@@ -124,17 +121,17 @@ async function requestSnapsImplementation(
   // TODO: Should this be part of the install flow?
 
   try {
-    // We expect the params to be the same as wallet_requestPermissions
-    const requestedPermissions = Object.keys(requestedSnaps).reduce<
-      Record<string, Partial<PermissionConstraint>>
-    >((acc, key) => {
-      acc[getSnapPermissionName(key)] = requestedSnaps[key];
-      return acc;
-    }, {});
+    const permissionKey = 'wallet_snap';
+    const requestedPermissions = {
+      [permissionKey]: {
+        caveats: [{ type: 'snapIds', value: requestedSnaps }],
+      },
+    } as RequestedPermissions;
     const existingPermissions = await getPermissions();
+
     if (
       !existingPermissions ||
-      !hasPermissions(existingPermissions, requestedPermissions)
+      !hasSnaps(existingPermissions, requestedSnaps)
     ) {
       const approvedPermissions = await requestPermissions(
         requestedPermissions,

--- a/packages/rpc-methods/src/restricted/index.ts
+++ b/packages/rpc-methods/src/restricted/index.ts
@@ -20,7 +20,11 @@ import {
   GetBip44EntropyMethodHooks,
 } from './getBip44Entropy';
 import { getEntropyBuilder, GetEntropyHooks } from './getEntropy';
-import { invokeSnapBuilder, InvokeSnapMethodHooks } from './invokeSnap';
+import {
+  getInvokeSnapCaveatSpecifications,
+  invokeSnapBuilder,
+  InvokeSnapMethodHooks,
+} from './invokeSnap';
 import { manageStateBuilder, ManageStateMethodHooks } from './manageState';
 import { notifyBuilder, NotifyMethodHooks } from './notify';
 
@@ -55,6 +59,7 @@ export const restrictedMethodPermissionBuilders = {
 export const caveatSpecifications = {
   ...getBip32EntropyCaveatSpecifications,
   ...getBip44EntropyCaveatSpecifications,
+  ...getInvokeSnapCaveatSpecifications,
 } as const;
 
 export const caveatMappers: Record<

--- a/packages/rpc-methods/src/restricted/invokeSnap.test.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.test.ts
@@ -1,4 +1,5 @@
 import { PermissionType } from '@metamask/permission-controller';
+import { SnapCaveatType } from '@metamask/snaps-utils';
 import {
   MOCK_SNAP_ID,
   MOCK_ORIGIN,
@@ -10,7 +11,7 @@ import { invokeSnapBuilder, getInvokeSnapImplementation } from './invokeSnap';
 describe('builder', () => {
   it('has the expected shape', () => {
     expect(invokeSnapBuilder).toMatchObject({
-      targetKey: 'wallet_snap_*',
+      targetKey: 'wallet_snap',
       specificationBuilder: expect.any(Function),
       methodHooks: {
         getSnap: true,
@@ -29,8 +30,8 @@ describe('builder', () => {
       }),
     ).toMatchObject({
       permissionType: PermissionType.RestrictedMethod,
-      targetKey: 'wallet_snap_*',
-      allowedCaveats: null,
+      targetKey: 'wallet_snap',
+      allowedCaveats: [SnapCaveatType.SnapIds],
       methodImplementation: expect.any(Function),
     });
   });
@@ -48,8 +49,11 @@ describe('implementation', () => {
     const implementation = getInvokeSnapImplementation(hooks);
     await implementation({
       context: { origin: MOCK_ORIGIN },
-      method: `wallet_snap_${MOCK_SNAP_ID}`,
-      params: { method: 'foo', params: {} },
+      method: 'wallet_snap',
+      params: {
+        snapId: MOCK_SNAP_ID,
+        request: { method: 'hello', params: {} },
+      },
     });
 
     expect(hooks.getSnap).toHaveBeenCalledTimes(1);
@@ -60,7 +64,7 @@ describe('implementation', () => {
       request: {
         jsonrpc: '2.0',
         id: expect.any(String),
-        method: 'foo',
+        method: 'hello',
         params: {},
       },
       snapId: MOCK_SNAP_ID,
@@ -73,8 +77,11 @@ describe('implementation', () => {
     await expect(
       implementation({
         context: { origin: MOCK_ORIGIN },
-        method: `wallet_snap_${MOCK_SNAP_ID}`,
-        params: { method: 'foo', params: {} },
+        method: 'wallet_snap',
+        params: {
+          snapId: MOCK_SNAP_ID,
+          request: { method: 'hello', params: {} },
+        },
       }),
     ).rejects.toThrow(
       `The snap "${MOCK_SNAP_ID}" is not installed. This is a bug, please report it.`,
@@ -92,7 +99,7 @@ describe('implementation', () => {
     await expect(
       implementation({
         context: { origin: MOCK_ORIGIN },
-        method: `wallet_snap_${MOCK_SNAP_ID}`,
+        method: 'wallet_snap',
         params: {},
       }),
     ).rejects.toThrow(

--- a/packages/snaps-utils/src/caveats.ts
+++ b/packages/snaps-utils/src/caveats.ts
@@ -28,4 +28,9 @@ export enum SnapCaveatType {
    * The origins that a Snap can receive JSON-RPC messages from.
    */
   RpcOrigin = 'rpcOrigin',
+
+  /**
+   * Caveat specifying a specific snap to be installed
+   */
+  SnapIds = 'snapIds',
 }


### PR DESCRIPTION
Closes #1117 

This gets rid of the wildcard method in favor of the use of a caveat of type `snapIds`.