### PR TITLE
Bump `@metamask/key-tree` to 6.2.1

### DIFF
--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@metamask/browser-passworder": "^4.0.2",
-    "@metamask/key-tree": "^6.2.0",
+    "@metamask/key-tree": "^6.2.1",
     "@metamask/permission-controller": "^1.0.1",
     "@metamask/snaps-ui": "^0.28.0",
     "@metamask/snaps-utils": "^0.28.0",

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.test.ts
@@ -314,5 +314,33 @@ describe('getBip32EntropyImplementation', () => {
         }
       `);
     });
+
+    it('derives a path using ed25519', async () => {
+      const getUnlockPromise = jest.fn().mockResolvedValue(undefined);
+      const getMnemonic = jest
+        .fn()
+        .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES);
+
+      expect(
+        // @ts-expect-error Missing other required properties.
+        await getBip32EntropyImplementation({ getUnlockPromise, getMnemonic })({
+          params: {
+            path: ['m', "44'", "60'", "0'", "0'", "1'"],
+            curve: 'ed25519',
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "chainCode": "0xc258fb2565397094f6fbc5b21b5a51a2dd573748ba752b192babadcd21426015",
+          "curve": "ed25519",
+          "depth": 5,
+          "index": 2147483649,
+          "masterFingerprint": 650419359,
+          "parentFingerprint": 497597606,
+          "privateKey": "0x4ef4bf3da2c6a47495d24303b7c463dca03fe164ca1550f2d60aa68e5134d6c1",
+          "publicKey": "0x009e76714baba27091db7a5abee8e1cd8416a5d78580e8dde15d68fb78ed930097",
+        }
+      `);
+    });
   });
 });

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -74,7 +74,7 @@
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.1",
     "@metamask/eslint-config-typescript": "^11.0.0",
-    "@metamask/key-tree": "^6.2.0",
+    "@metamask/key-tree": "^6.2.1",
     "@metamask/post-message-stream": "^6.1.0",
     "@types/jest": "^27.5.1",
     "@types/semver": "^7.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,9 +2563,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/key-tree@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "@metamask/key-tree@npm:6.2.0"
+"@metamask/key-tree@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "@metamask/key-tree@npm:6.2.1"
   dependencies:
     "@metamask/scure-bip39": ^2.1.0
     "@metamask/utils": ^3.3.0
@@ -2573,7 +2573,7 @@ __metadata:
     "@noble/hashes": ^1.0.0
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
-  checksum: d1f6839ac63c7bee2ece7fcd39c29b7e3f054568d93c07469b7cb28b9dfc3dd1d5c3fbec07702b2029310d96356a7dbbb55bafc66c6fc817b2235a8e0994ec38
+  checksum: 78931e20a2c933535c17d21e092dbc66e3e96f3c171a6814af51830b7774dd3b4059326180a3b1f52e48a258254a7ea70a31d0c335bf24a8c4250f8d196bc7ba
   languageName: node
   linkType: hard
 
@@ -2686,7 +2686,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/key-tree": ^6.2.0
+    "@metamask/key-tree": ^6.2.1
     "@metamask/permission-controller": ^1.0.1
     "@metamask/snaps-ui": ^0.28.0
     "@metamask/snaps-utils": ^0.28.0
@@ -3086,7 +3086,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/key-tree": ^6.2.0
+    "@metamask/key-tree": ^6.2.1
     "@metamask/post-message-stream": ^6.1.0
     "@metamask/providers": ^10.2.1
     "@metamask/snaps-registry": ^1.0.0


### PR DESCRIPTION
This bumps `@metamask/key-tree` to the latest version, to fix a regression bug introduced in version 6.2.0.