### PR TITLE
Standardise logging across all packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,11 @@ module.exports = {
     // in `@metamask/eslint-config-nodejs` in the future.
     'import/no-nodejs-modules': 'off',
 
+    // This prevents using the `console.log` and similar functions. All logging
+    // should be done through the module logger, or `logError` function in
+    // `@metamask/snaps-utils`.
+    'no-console': 'error',
+
     // This prevents using Node.js and/or browser specific globals. We
     // currently use both in our codebase, so this rule is disabled.
     'no-restricted-globals': 'off',
@@ -70,6 +75,7 @@ module.exports = {
           { allow: ['describe', 'expect', 'it'] },
         ],
         '@typescript-eslint/unbound-method': 'off',
+        'no-console': 'off',
       },
     },
   ],

--- a/packages/examples/.eslintrc.js
+++ b/packages/examples/.eslintrc.js
@@ -5,6 +5,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
   },
 
+  rules: {
+    'no-console': 'off',
+  },
+
   overrides: [
     {
       files: ['examples/**/*.js', 'examples/**/*.ts'],

--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -12,8 +12,8 @@ module.exports = deepmerge(baseConfig, {
     global: {
       branches: 75.36,
       functions: 87.67,
-      lines: 88.8,
-      statements: 88.45,
+      lines: 88.56,
+      statements: 88.21,
     },
   },
   testTimeout: 2500,

--- a/packages/rpc-methods/src/restricted/confirm.ts
+++ b/packages/rpc-methods/src/restricted/confirm.ts
@@ -4,6 +4,7 @@ import {
   RestrictedMethodOptions,
   ValidPermissionSpecification,
 } from '@metamask/permission-controller';
+import { logWarning } from '@metamask/snaps-utils';
 import { isObject, NonEmptyArray } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
@@ -108,7 +109,7 @@ function getConfirmImplementation({ showConfirmation }: ConfirmMethodHooks) {
   return async function confirmImplementation(
     args: RestrictedMethodOptions<[LegacyConfirmFields]>,
   ): Promise<boolean> {
-    console.warn('snap_confirm is deprecated. Use snap_dialog instead.');
+    logWarning('snap_confirm is deprecated. Use snap_dialog instead.');
 
     const {
       params,

--- a/packages/snaps-browserify-plugin/src/plugin.test.ts
+++ b/packages/snaps-browserify-plugin/src/plugin.test.ts
@@ -4,6 +4,7 @@
 import {
   checkManifest,
   evalBundle,
+  logWarning,
   PostProcessWarning,
 } from '@metamask/snaps-utils';
 import {
@@ -24,6 +25,7 @@ jest.mock('@metamask/snaps-utils', () => ({
   ...jest.requireActual('@metamask/snaps-utils'),
   evalBundle: jest.fn(),
   checkManifest: jest.fn(),
+  logWarning: jest.fn(),
 }));
 
 /**
@@ -135,13 +137,11 @@ describe('plugin', () => {
   });
 
   it('logs post processing warnings', async () => {
-    jest.spyOn(console, 'log').mockImplementation(() => undefined);
-
     await bundle({
       code: 'console.log(Math.random());',
     });
 
-    expect(console.log).toHaveBeenCalledWith(
+    expect(logWarning).toHaveBeenCalledWith(
       `Bundle Warning: Processing of the Snap bundle completed with warnings.\n${PostProcessWarning.UnsafeMathRandom}`,
     );
   });
@@ -210,8 +210,6 @@ describe('plugin', () => {
   });
 
   it('logs manifest warnings', async () => {
-    jest.spyOn(console, 'log').mockImplementation(() => undefined);
-
     const mock = checkManifest as jest.MockedFunction<typeof checkManifest>;
     mock.mockResolvedValue({
       manifest: getSnapManifest(),
@@ -223,9 +221,9 @@ describe('plugin', () => {
       options: { eval: false, manifestPath: 'foo' },
     });
 
-    expect(console.log).toHaveBeenCalledTimes(3);
-    expect(console.log).toHaveBeenCalledWith('Manifest Warning: foo');
-    expect(console.log).toHaveBeenCalledWith('Manifest Warning: bar');
+    expect(logWarning).toHaveBeenCalledTimes(3);
+    expect(logWarning).toHaveBeenCalledWith('Manifest Warning: foo');
+    expect(logWarning).toHaveBeenCalledWith('Manifest Warning: bar');
   });
 
   it('forwards errors', async () => {

--- a/packages/snaps-browserify-plugin/src/plugin.ts
+++ b/packages/snaps-browserify-plugin/src/plugin.ts
@@ -1,6 +1,7 @@
 import {
   checkManifest,
   evalBundle,
+  logWarning,
   postProcessBundle,
   PostProcessOptions,
 } from '@metamask/snaps-utils';
@@ -54,13 +55,11 @@ async function postBundle(options: Partial<Options>, code: string) {
     }
 
     if (warnings.length > 0) {
-      console.log(
+      logWarning(
         'Manifest Warning: Validation of snap.manifest.json completed with warnings.',
       );
 
-      warnings.forEach((warning) =>
-        console.log(`Manifest Warning: ${warning}`),
-      );
+      warnings.forEach((warning) => logWarning(`Manifest Warning: ${warning}`));
     }
   }
 }
@@ -126,7 +125,7 @@ export class SnapsBrowserifyTransform extends Transform {
     });
 
     if (result.warnings.length > 0) {
-      console.log(
+      logWarning(
         `Bundle Warning: Processing of the Snap bundle completed with warnings.\n${result.warnings.join(
           '\n',
         )}`,

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -6,10 +6,10 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/types'],
   coverageThreshold: {
     global: {
-      branches: 98.09,
-      functions: 94.66,
-      lines: 98.5,
-      statements: 98.51,
+      branches: 97.97,
+      functions: 94.59,
+      lines: 98.49,
+      statements: 98.5,
     },
   },
   setupFiles: ['./test/setup.js'],

--- a/packages/snaps-cli/src/cmds/build/utils.ts
+++ b/packages/snaps-cli/src/cmds/build/utils.ts
@@ -1,8 +1,9 @@
+import { logInfo } from '@metamask/snaps-utils';
 import { promises as fs } from 'fs';
 
 import { TranspilationModes } from '../../builders';
 import { YargsArgs } from '../../types/yargs';
-import { writeError } from '../../utils/misc';
+import { writeError } from '../../utils';
 
 type WriteBundleFileArgs = {
   bundleError: Error;
@@ -39,7 +40,7 @@ export async function writeBundleFile({
 
   try {
     await fs.writeFile(dest, bundleBuffer?.toString());
-    console.log(`Build success: '${src}' bundled as '${dest}'!`);
+    logInfo(`Build success: '${src}' bundled as '${dest}'!`);
     resolve(true);
   } catch (error) {
     await writeError('Write error:', error.message, error, dest);

--- a/packages/snaps-cli/src/cmds/eval/evalHandler.ts
+++ b/packages/snaps-cli/src/cmds/eval/evalHandler.ts
@@ -1,4 +1,4 @@
-import { evalBundle } from '@metamask/snaps-utils';
+import { evalBundle, logInfo } from '@metamask/snaps-utils';
 import { assert } from '@metamask/utils';
 
 import { YargsArgs } from '../../types/yargs';
@@ -17,7 +17,7 @@ export async function evalHandler(argv: YargsArgs): Promise<void> {
 
   try {
     await evalBundle(bundlePath);
-    console.log(`Eval Success: evaluated '${bundlePath}' in SES!`);
+    logInfo(`Eval Success: evaluated '${bundlePath}' in SES!`);
   } catch (error) {
     throw new Error(`Snap evaluation error: ${error.message}`);
   }

--- a/packages/snaps-cli/src/cmds/init/index.ts
+++ b/packages/snaps-cli/src/cmds/init/index.ts
@@ -1,3 +1,4 @@
+import { logInfo } from '@metamask/snaps-utils';
 import yargs from 'yargs';
 
 import builders from '../../builders';
@@ -32,5 +33,5 @@ async function init(argv: YargsArgs): Promise<void> {
     eval: true,
   });
 
-  console.log('\nSnap project successfully initiated!');
+  logInfo('\nSnap project successfully initiated!');
 }

--- a/packages/snaps-cli/src/cmds/init/initHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/init/initHandler.test.ts
@@ -15,9 +15,12 @@ jest.mock('@metamask/utils', () => ({
   ...jest.requireActual('@metamask/utils'),
   satisfiesVersionRange: jest.fn(),
 }));
+
 jest.mock('@metamask/snaps-utils', () => ({
   ...jest.requireActual('@metamask/snaps-utils'),
   readJsonFile: jest.fn(),
+  logInfo: jest.fn(),
+  logError: jest.fn(),
 }));
 
 const getMockArgv = () => {

--- a/packages/snaps-cli/src/cmds/init/initHandler.ts
+++ b/packages/snaps-cli/src/cmds/init/initHandler.ts
@@ -3,6 +3,7 @@ import {
   readJsonFile,
   NpmSnapPackageJson,
   createSnapManifest,
+  logInfo,
 } from '@metamask/snaps-utils';
 import {
   satisfiesVersionRange,
@@ -60,12 +61,12 @@ export async function initHandler(argv: YargsArgs) {
     ? pathUtils.join(process.cwd(), directory)
     : process.cwd();
 
-  console.log(`Preparing ${directoryToUse}...`);
+  logInfo(`Preparing ${directoryToUse}...`);
 
   await prepareWorkingDirectory(directoryToUse);
 
   try {
-    console.log(`Cloning template...`);
+    logInfo(`Cloning template...`);
     cloneTemplate(directoryToUse);
 
     await fs.rm(pathUtils.join(directoryToUse, '.git'), {
@@ -76,11 +77,11 @@ export async function initHandler(argv: YargsArgs) {
     throw new Error('Init Error: Failed to create template.');
   }
 
-  console.log('Installing dependencies...');
+  logInfo('Installing dependencies...');
   yarnInstall(directoryToUse);
 
   if (!isInGitRepository(directoryToUse)) {
-    console.log('Initializing git repository...');
+    logInfo('Initializing git repository...');
     gitInit(directoryToUse);
   }
 

--- a/packages/snaps-cli/src/cmds/manifest/manifestHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifestHandler.test.ts
@@ -1,4 +1,9 @@
-import { checkManifest, CheckManifestResult } from '@metamask/snaps-utils';
+import {
+  checkManifest,
+  CheckManifestResult,
+  logError,
+  logWarning,
+} from '@metamask/snaps-utils';
 
 import { YargsArgs } from '../../types/yargs';
 import { manifestHandler } from './manifestHandler';
@@ -15,7 +20,6 @@ const checkManifestMock = checkManifest as jest.MockedFunction<
 
 describe('manifestHandler', () => {
   it('logs manifest errors if writeManifest is disabled', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => undefined);
     jest.spyOn(process, 'exit').mockImplementation((code) => {
       throw new Error(`exit ${code ?? '1'}`);
     });
@@ -29,9 +33,9 @@ describe('manifestHandler', () => {
       manifestHandler(getMockArgv({ writeManifest: false })),
     ).rejects.toThrow('exit 1');
 
-    expect(console.error).toHaveBeenCalledTimes(3);
-    expect(console.error).toHaveBeenCalledWith('Manifest Error: foo');
-    expect(console.error).toHaveBeenCalledWith('Manifest Error: bar');
+    expect(logError).toHaveBeenCalledTimes(3);
+    expect(logError).toHaveBeenCalledWith('Manifest Error: foo');
+    expect(logError).toHaveBeenCalledWith('Manifest Error: bar');
   });
 
   it('logs manifest warnings', async () => {
@@ -43,15 +47,13 @@ describe('manifestHandler', () => {
 
     await manifestHandler(getMockArgv());
 
-    expect(console.log).toHaveBeenCalledTimes(3);
-    expect(console.log).toHaveBeenCalledWith('Manifest Warning: foo');
-    expect(console.log).toHaveBeenCalledWith('Manifest Warning: bar');
+    expect(logWarning).toHaveBeenCalledTimes(3);
+    expect(logWarning).toHaveBeenCalledWith('Manifest Warning: foo');
+    expect(logWarning).toHaveBeenCalledWith('Manifest Warning: bar');
   });
 
   it('suppresses manifest warnings', async () => {
     global.snaps.suppressWarnings = true;
-
-    jest.spyOn(console, 'log').mockImplementation(() => undefined);
 
     checkManifestMock.mockResolvedValueOnce({
       errors: [],
@@ -60,7 +62,7 @@ describe('manifestHandler', () => {
 
     await manifestHandler(getMockArgv({ writeManifest: false }));
 
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(logWarning).toHaveBeenCalledTimes(1);
   });
 
   it('forwards manifest errors', async () => {

--- a/packages/snaps-cli/src/cmds/manifest/manifestHandler.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifestHandler.ts
@@ -1,4 +1,4 @@
-import { checkManifest } from '@metamask/snaps-utils';
+import { checkManifest, logError, logWarning } from '@metamask/snaps-utils';
 
 import { YargsArgs } from '../../types/yargs';
 
@@ -20,14 +20,14 @@ export async function manifestHandler({ writeManifest }: YargsArgs) {
     );
 
     if (!writeManifest && errors.length > 0) {
-      console.error(`${ERROR_PREFIX}The manifest is invalid.`);
+      logError(`${ERROR_PREFIX}The manifest is invalid.`);
       errors.forEach(logManifestError);
 
       process.exit(1);
     }
 
     if (warnings.length > 0) {
-      console.log(
+      logWarning(
         'Manifest Warning: Validation of snap.manifest.json completed with warnings.',
       );
       warnings.forEach(logManifestWarning);
@@ -44,7 +44,7 @@ export async function manifestHandler({ writeManifest }: YargsArgs) {
  */
 function logManifestWarning(message: string) {
   if (!global.snaps.suppressWarnings) {
-    console.log(`Manifest Warning: ${message}`);
+    logWarning(`Manifest Warning: ${message}`);
   }
 }
 
@@ -54,5 +54,5 @@ function logManifestWarning(message: string) {
  * @param message - The message to log.
  */
 function logManifestError(message: string) {
-  console.error(`${ERROR_PREFIX}${message}`);
+  logError(`${ERROR_PREFIX}${message}`);
 }

--- a/packages/snaps-cli/src/cmds/serve/serve.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.test.ts
@@ -1,4 +1,5 @@
 import * as snapUtils from '@metamask/snaps-utils';
+import { logInfo } from '@metamask/snaps-utils';
 import EventEmitter from 'events';
 import http from 'http';
 import path from 'path';
@@ -12,6 +13,8 @@ jest.mock('@metamask/snaps-utils', () => ({
   validateFilePath: jest.fn(),
   validateOutfileName: jest.fn(),
   getOutfilePath: () => path.normalize('dist/bundle.js'),
+  logInfo: jest.fn(),
+  logError: jest.fn(),
 }));
 
 /**
@@ -61,12 +64,10 @@ describe('serve', () => {
     });
 
     it('server handles "close" event correctly', async () => {
-      jest.spyOn(console, 'log').mockImplementation();
-
       await serve.handler(getMockArgv());
       const finishPromise = new Promise<void>((resolve, _) => {
         mockServer.on('close', () => {
-          expect(global.console.log).toHaveBeenCalledTimes(2);
+          expect(logInfo).toHaveBeenCalledTimes(2);
           resolve();
         });
       });
@@ -84,7 +85,7 @@ describe('serve', () => {
       await serve.handler(getMockArgv());
       const finishPromise = new Promise<void>((resolve, _) => {
         mockServer.on('error', () => {
-          expect(global.console.log).toHaveBeenCalledTimes(1);
+          expect(logInfo).toHaveBeenCalledTimes(1);
           expect(logServerErrorMock).toHaveBeenCalled();
           resolve();
         });
@@ -106,7 +107,6 @@ describe('serve', () => {
           return mockServer as any;
         });
 
-      jest.spyOn(console, 'log').mockImplementation();
       const logRequestMock = jest
         .spyOn(serveUtils, 'logRequest')
         .mockImplementation();
@@ -114,7 +114,7 @@ describe('serve', () => {
       await serve.handler(getMockArgv());
       const finishPromise = new Promise<void>((resolve, _) => {
         mockServer.on('request', (...args) => {
-          expect(global.console.log).toHaveBeenCalledTimes(1);
+          expect(logInfo).toHaveBeenCalledTimes(1);
           expect(logRequestMock).toHaveBeenCalled();
           requestCallback(...args);
           resolve();

--- a/packages/snaps-cli/src/cmds/serve/serveHandler.ts
+++ b/packages/snaps-cli/src/cmds/serve/serveHandler.ts
@@ -1,4 +1,4 @@
-import { validateDirPath } from '@metamask/snaps-utils';
+import { logInfo, validateDirPath } from '@metamask/snaps-utils';
 import http from 'http';
 import serveHandler from 'serve-handler';
 
@@ -18,7 +18,7 @@ export async function serve(argv: YargsArgs): Promise<void> {
 
   await validateDirPath(rootDir as string, true);
 
-  console.log(`\nStarting server...`);
+  logInfo(`\nStarting server...`);
 
   const server = http.createServer((req, res) => {
     serveHandler(req, res, {
@@ -55,7 +55,7 @@ export async function serve(argv: YargsArgs): Promise<void> {
   });
 
   server.on('close', () => {
-    console.log('Server closed');
+    logInfo('Server closed');
     process.exitCode = 1;
   });
 }

--- a/packages/snaps-cli/src/cmds/serve/serveUtils.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serveUtils.test.ts
@@ -1,14 +1,20 @@
-import * as miscUtils from '../../utils/misc';
+import { logError, logInfo } from '@metamask/snaps-utils';
+
 import { logServerListening, logRequest, logServerError } from './serveUtils';
+
+jest.mock('@metamask/snaps-utils', () => ({
+  ...jest.requireActual('@metamask/snaps-utils'),
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+}));
 
 describe('serve utility functions', () => {
   describe('logServerListening', () => {
     const portInput = 8000;
 
     it('logs to console', () => {
-      jest.spyOn(console, 'log').mockImplementation();
       logServerListening(portInput);
-      expect(global.console.log).toHaveBeenCalledTimes(1);
+      expect(logInfo).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -18,9 +24,8 @@ describe('serve utility functions', () => {
     };
 
     it('logs to console', () => {
-      jest.spyOn(console, 'log').mockImplementation();
       logRequest(requestInput);
-      expect(global.console.log).toHaveBeenCalledTimes(1);
+      expect(logInfo).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -30,9 +35,8 @@ describe('serve utility functions', () => {
     it('logs already in use error to console', () => {
       const mockError: Error & { code?: string } = new Error('error message');
       mockError.code = 'EADDRINUSE';
-      jest.spyOn(miscUtils, 'logError').mockImplementation();
       logServerError(mockError, port);
-      expect(miscUtils.logError).toHaveBeenCalledTimes(1);
+      expect(logError).toHaveBeenCalledTimes(1);
     });
 
     it('logs server error to console', () => {
@@ -40,9 +44,8 @@ describe('serve utility functions', () => {
         'error message',
       );
       mockBadError.code = 'fake';
-      jest.spyOn(miscUtils, 'logError').mockImplementation();
       logServerError(mockBadError, port);
-      expect(miscUtils.logError).toHaveBeenCalledTimes(1);
+      expect(logError).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/snaps-cli/src/cmds/serve/serveUtils.ts
+++ b/packages/snaps-cli/src/cmds/serve/serveUtils.ts
@@ -1,4 +1,4 @@
-import { logError } from '../../utils';
+import { logError, logInfo } from '@metamask/snaps-utils';
 
 /**
  * Log a message with the URL and port of the server.
@@ -6,7 +6,7 @@ import { logError } from '../../utils';
  * @param port - The port that the server is running on.
  */
 export function logServerListening(port: number) {
-  console.log(`Server listening on: http://localhost:${port}`);
+  logInfo(`Server listening on: http://localhost:${port}`);
 }
 
 /**
@@ -16,7 +16,7 @@ export function logServerListening(port: number) {
  * @param request.url - The URL of the request.
  */
 export function logRequest(request: { url: string }) {
-  console.log(`Handling incoming request for: ${request.url}`);
+  logInfo(`Handling incoming request for: ${request.url}`);
 }
 
 /**
@@ -29,6 +29,6 @@ export function logServerError(error: Error, port: number) {
   if ((error as any).code === 'EADDRINUSE') {
     logError(`Server error: Port ${port} already in use.`);
   } else {
-    logError(`Server error: ${error.message}`, error);
+    logError(`Server error: ${error.message}`);
   }
 }

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.ts
@@ -1,5 +1,7 @@
 import {
   getOutfilePath,
+  logError,
+  logInfo,
   validateDirPath,
   validateFilePath,
   validateOutfileName,
@@ -7,7 +9,7 @@ import {
 import chokidar from 'chokidar';
 
 import { YargsArgs } from '../../types/yargs';
-import { loadConfig, logError } from '../../utils';
+import { loadConfig } from '../../utils';
 import { bundle } from '../build/bundle';
 import { evalHandler } from '../eval/evalHandler';
 import { manifestHandler } from '../manifest/manifestHandler';
@@ -46,7 +48,7 @@ export async function watch(argv: YargsArgs): Promise<void> {
 
   const buildSnap = async (path?: string, logMessage?: string) => {
     if (logMessage !== undefined) {
-      console.log(logMessage);
+      logInfo(logMessage);
     }
 
     try {
@@ -109,12 +111,12 @@ export async function watch(argv: YargsArgs): Promise<void> {
         logError(`Error while processing "${path}".`, error);
       });
     })
-    .on('unlink', (path) => console.log(`File removed: ${path}`))
+    .on('unlink', (path) => logInfo(`File removed: ${path}`))
     .on('error', (error: Error) => {
       logError(`Watcher error: ${error.message}`, error);
     })
 
     .add(rootDir);
 
-  console.log(`Watching '${rootDir}' for changes...`);
+  logInfo(`Watching '${rootDir}' for changes...`);
 }

--- a/packages/snaps-cli/src/utils/misc.test.ts
+++ b/packages/snaps-cli/src/utils/misc.test.ts
@@ -4,7 +4,6 @@ import pathUtils from 'path';
 import {
   booleanStringToBoolean,
   logError,
-  logWarning,
   sanitizeInputs,
   setSnapGlobals,
   trimPathString,
@@ -108,10 +107,6 @@ describe('misc', () => {
     global.snaps.verboseErrors = bool;
   };
 
-  const setSuppressWarnings = (bool: boolean) => {
-    global.snaps.suppressWarnings = bool;
-  };
-
   const setIsWatching = (bool: boolean) => {
     global.snaps.isWatching = bool;
   };
@@ -199,62 +194,6 @@ describe('misc', () => {
       jest.spyOn(console, 'error').mockImplementation();
       logError(null, new Error('verbose'));
       expect(global.console.error).toHaveBeenCalledWith('Unknown error.');
-    });
-  });
-
-  describe('logWarning', () => {
-    it('logs a warning and error message to console', () => {
-      setSuppressWarnings(false);
-      setVerboseErrors(true);
-
-      jest.spyOn(console, 'warn').mockImplementation();
-      jest.spyOn(console, 'error').mockImplementation();
-
-      logWarning('custom warning message', new Error('verbose'));
-      expect(global.console.warn).toHaveBeenCalledWith(
-        'custom warning message',
-      );
-      expect(global.console.error).toHaveBeenCalledWith(new Error('verbose'));
-    });
-
-    it('if verbose errors is set to false, just logs a warning message to console', () => {
-      setSuppressWarnings(false);
-      setVerboseErrors(false);
-
-      jest.spyOn(console, 'warn').mockImplementation();
-      jest.spyOn(console, 'error').mockImplementation();
-
-      logWarning('custom warning message', new Error('verbose'));
-      expect(global.console.warn).toHaveBeenCalledWith(
-        'custom warning message',
-      );
-      expect(global.console.error).not.toHaveBeenCalled();
-    });
-
-    it('given no error, just logs a warning message to console', () => {
-      setSuppressWarnings(false);
-      setVerboseErrors(false);
-
-      jest.spyOn(console, 'warn').mockImplementation();
-      jest.spyOn(console, 'error').mockImplementation();
-
-      logWarning('custom warning message');
-      expect(global.console.warn).toHaveBeenCalledWith(
-        'custom warning message',
-      );
-      expect(global.console.error).not.toHaveBeenCalled();
-    });
-
-    it('logs no message to console', () => {
-      setSuppressWarnings(true);
-      setVerboseErrors(true);
-
-      jest.spyOn(console, 'warn').mockImplementation();
-      jest.spyOn(console, 'error').mockImplementation();
-
-      logWarning('custom warning message', new Error('verbose'));
-      expect(global.console.warn).not.toHaveBeenCalled();
-      expect(global.console.error).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/snaps-cli/src/utils/misc.test.ts
+++ b/packages/snaps-cli/src/utils/misc.test.ts
@@ -10,11 +10,7 @@ import {
   writeError,
 } from './misc';
 
-jest.mock('fs', () => ({
-  promises: {
-    unlink: jest.fn(),
-  },
-}));
+jest.mock('fs');
 
 describe('misc', () => {
   global.snaps = {

--- a/packages/snaps-cli/src/utils/misc.ts
+++ b/packages/snaps-cli/src/utils/misc.ts
@@ -1,3 +1,4 @@
+import { logError as logErrorUtil } from '@metamask/snaps-utils';
 import { hasProperty } from '@metamask/utils';
 import { promises as filesystem } from 'fs';
 import path from 'path';
@@ -106,30 +107,15 @@ export function sanitizeInputs(argv: Arguments) {
  */
 export function logError(message: string | null, error?: Error): void {
   if (message !== null) {
-    console.error(message);
+    logErrorUtil(message);
   }
 
   if (error && global.snaps.verboseErrors) {
-    console.error(error);
+    logErrorUtil(error);
   }
 
   if (message === null && (!error || (error && !global.snaps.verboseErrors))) {
-    console.error('Unknown error.');
-  }
-}
-
-/**
- * Logs a warning message to console.
- *
- * @param message - The warning message.
- * @param error - The original error.
- */
-export function logWarning(message: string, error?: Error): void {
-  if (message && !global.snaps.suppressWarnings) {
-    console.warn(message);
-    if (error && global.snaps.verboseErrors) {
-      console.error(error);
-    }
+    logErrorUtil('Unknown error.');
   }
 }
 

--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -10,6 +10,7 @@ import {
   CronjobSpecification,
   flatten,
   parseCronExpression,
+  logError,
 } from '@metamask/snaps-utils';
 import { Duration, inMilliseconds } from '@metamask/utils';
 
@@ -123,7 +124,7 @@ export class CronjobController extends BaseController<
     /* eslint-enable @typescript-eslint/unbound-method */
 
     this.dailyCheckIn().catch((error) => {
-      console.error(error);
+      logError(error);
     });
   }
 
@@ -201,7 +202,7 @@ export class CronjobController extends BaseController<
     timer.start(() => {
       this.executeCronjob(job).catch((error) => {
         // TODO: Decide how to handle errors.
-        console.error(error);
+        logError(error);
       });
 
       this.#timers.delete(job.id);
@@ -292,7 +293,7 @@ export class CronjobController extends BaseController<
     this.#dailyTimer.start(() => {
       this.dailyCheckIn().catch((error) => {
         // TODO: Decide how to handle errors.
-        console.error(error);
+        logError(error);
       });
     });
   }

--- a/packages/snaps-controllers/src/logging.ts
+++ b/packages/snaps-controllers/src/logging.ts
@@ -1,0 +1,10 @@
+import { snapsLogger } from '@metamask/snaps-utils';
+import { createModuleLogger } from '@metamask/utils';
+
+/**
+ * A logging function specific to this package. The log messages don't show up
+ * by default, but they can be enabled by setting the environment variable:
+ * - `DEBUG=metamask:snaps:snaps-controllers`, or
+ * - `DEBUG=metamask:snaps:*` to enable all logs from `@metamask/snaps-*`.
+ */
+export const log = createModuleLogger(snapsLogger, 'snaps-controllers');

--- a/packages/snaps-controllers/src/multichain/MultiChainController.ts
+++ b/packages/snaps-controllers/src/multichain/MultiChainController.ts
@@ -29,6 +29,7 @@ import {
   getSnapPermissionName,
   isAccountIdArray,
   Namespaces,
+  logError,
 } from '@metamask/snaps-utils';
 import { hasProperty, assert } from '@metamask/utils';
 import { nanoid } from 'nanoid';
@@ -426,7 +427,7 @@ export class MultiChainController extends BaseController<
       }
     } catch (error) {
       // Ignore errors for now
-      console.error(error);
+      logError(error);
     }
 
     return null;

--- a/packages/snaps-execution-environments/ava.config.js
+++ b/packages/snaps-execution-environments/ava.config.js
@@ -1,7 +1,7 @@
 module.exports = () => {
   return {
     extensions: ['ts'],
-    require: ['ts-node/register'],
+    require: ['ts-node/register', 'tsconfig-paths/register'],
     verbose: true,
     files: ['src/**/*.ava.test.ts'],
     timeout: '30s',

--- a/packages/snaps-execution-environments/nyc.config.js
+++ b/packages/snaps-execution-environments/nyc.config.js
@@ -4,7 +4,7 @@
 module.exports = {
   'check-coverage': true,
   branches: 89.81,
-  lines: 90.38,
+  lines: 90.29,
   functions: 94.31,
-  statements: 90.38,
+  statements: 90.29,
 };

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -87,6 +87,7 @@
     "rimraf": "^3.0.2",
     "shx": "^0.3.4",
     "ts-jest": "^29.0.0",
+    "tsconfig-paths": "^4.1.2",
     "tsconfig-paths-webpack-plugin": "^4.0.0",
     "typescript": "~4.8.4",
     "webpack": "^5.68.0",

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.ts
@@ -4,6 +4,7 @@ import { HandlerType } from '@metamask/snaps-utils';
 import { Json, JsonRpcRequest, JsonRpcResponse } from '@metamask/utils';
 import { Duplex, DuplexOptions, EventEmitter, Readable } from 'stream';
 
+import * as logging from '../logging';
 import { BaseSnapExecutor } from './BaseSnapExecutor';
 
 const FAKE_ORIGIN = 'origin:foo';
@@ -1259,7 +1260,7 @@ describe('BaseSnapExecutor', () => {
   it('does not return control to a snap after idle teardown', async () => {
     jest.useRealTimers();
     const consoleLogSpy = jest.spyOn(console, 'log');
-    const consoleWarnSpy = jest.spyOn(console, 'warn');
+    const logSpy = jest.spyOn(logging, 'log');
     const TIMER_ENDOWMENTS = [
       'setTimeout',
       'clearTimeout',
@@ -1356,7 +1357,7 @@ describe('BaseSnapExecutor', () => {
     });
 
     expect(consoleLogSpy).not.toHaveBeenCalledWith('Jailbreak');
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
+    expect(logSpy).toHaveBeenCalledWith(
       'Late promise received after Snap finished execution. Promise will be dropped.',
     );
   });
@@ -1364,7 +1365,7 @@ describe('BaseSnapExecutor', () => {
   it('does not return control to a snap after idle teardown when request fails', async () => {
     jest.useRealTimers();
     const consoleLogSpy = jest.spyOn(console, 'log');
-    const consoleWarnSpy = jest.spyOn(console, 'warn');
+    const logSpy = jest.spyOn(logging, 'log');
     const TIMER_ENDOWMENTS = [
       'setTimeout',
       'clearTimeout',
@@ -1465,7 +1466,7 @@ describe('BaseSnapExecutor', () => {
     });
 
     expect(consoleLogSpy).not.toHaveBeenCalledWith('Jailbreak');
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
+    expect(logSpy).toHaveBeenCalledWith(
       'Late promise received after Snap finished execution. Promise will be dropped.',
     );
   });

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -8,6 +8,7 @@ import {
   HandlerType,
   SnapExportsParameters,
   SNAP_EXPORT_NAMES,
+  logError,
 } from '@metamask/snaps-utils';
 import {
   isObject,
@@ -25,6 +26,7 @@ import { createIdRemapMiddleware } from 'json-rpc-engine';
 import { Duplex } from 'stream';
 import { validate } from 'superstruct';
 
+import { log } from '../logging';
 import EEOpenRPCDocument from '../openrpc.json';
 import {
   CommandMethodsMapping,
@@ -113,7 +115,7 @@ export class BaseSnapExecutor {
     this.commandStream.on('data', (data) => {
       this.onCommandRequest(data).catch((error) => {
         // TODO: Decide how to handle errors.
-        console.error(error);
+        logError(error);
       });
     });
     this.rpcStream = rpcStream;
@@ -272,7 +274,7 @@ export class BaseSnapExecutor {
     sourceCode: string,
     _endowments?: string[],
   ): Promise<void> {
-    console.log(`starting snap '${snapName}' in worker`);
+    log(`Starting snap '${snapName}' in worker.`);
     if (this.snapPromiseErrorHandler) {
       removeEventListener('unhandledrejection', this.snapPromiseErrorHandler);
     }

--- a/packages/snaps-execution-environments/src/common/lockdown/lockdown-more.ts
+++ b/packages/snaps-execution-environments/src/common/lockdown/lockdown-more.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference path="../../../../../node_modules/ses/index.d.ts" />
 
+import { logError } from '@metamask/snaps-utils';
+
 /**
  * The SES `lockdown` function only hardens the properties enumerated by the
  * universalPropertyNames constant specified in 'ses/src/whitelist'. This
@@ -72,7 +74,7 @@ export function executeLockdownMore() {
       }
     });
   } catch (error) {
-    console.error('Protecting intrinsics failed:', error);
+    logError('Protecting intrinsics failed:', error);
     throw error;
   }
 }

--- a/packages/snaps-execution-environments/src/common/lockdown/lockdown.ts
+++ b/packages/snaps-execution-environments/src/common/lockdown/lockdown.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference path="../../../../../node_modules/ses/index.d.ts" />
 
+import { logError } from '@metamask/snaps-utils';
+
 /**
  * Execute SES lockdown in the current context, i.e., the current iframe.
  *
@@ -17,7 +19,7 @@ export function executeLockdown() {
     });
   } catch (error) {
     // If the `lockdown` call throws an exception, it should not be able to continue
-    console.error('Lockdown failed:', error);
+    logError('Lockdown failed:', error);
     throw error;
   }
 }

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -1,3 +1,5 @@
+import { log } from '../logging';
+
 /**
  * Takes an error that was thrown, determines if it is
  * an error object. If it is then it will return that. Otherwise,
@@ -39,7 +41,7 @@ export async function withTeardown<T>(
         if (teardownRef.lastTeardown === myTeardown) {
           resolve(value);
         } else {
-          console.warn(
+          log(
             'Late promise received after Snap finished execution. Promise will be dropped.',
           );
         }
@@ -48,7 +50,7 @@ export async function withTeardown<T>(
         if (teardownRef.lastTeardown === myTeardown) {
           reject(reason);
         } else {
-          console.warn(
+          log(
             'Late promise received after Snap finished execution. Promise will be dropped.',
           );
         }

--- a/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/iframe/IFrameSnapExecutor.ts
@@ -1,9 +1,10 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
-import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
+import { logError, SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
 import pump from 'pump';
 
 import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
+import { log } from '../logging';
 
 export class IFrameSnapExecutor extends BaseSnapExecutor {
   /**
@@ -14,7 +15,7 @@ export class IFrameSnapExecutor extends BaseSnapExecutor {
    * message streams.
    */
   static initialize() {
-    console.log('Worker: Connecting to parent.');
+    log('Worker: Connecting to parent.');
 
     const parentStream = new WindowPostMessageStream({
       name: 'child',
@@ -26,7 +27,7 @@ export class IFrameSnapExecutor extends BaseSnapExecutor {
     const mux = new ObjectMultiplex();
     pump(parentStream, mux, parentStream, (error) => {
       if (error) {
-        console.error(`Parent stream failure, closing worker.`, error);
+        logError(`Parent stream failure, closing worker.`, error);
       }
       self.close();
     });

--- a/packages/snaps-execution-environments/src/logging.ts
+++ b/packages/snaps-execution-environments/src/logging.ts
@@ -1,0 +1,13 @@
+import { snapsLogger } from '@metamask/snaps-utils';
+import { createModuleLogger } from '@metamask/utils';
+
+/**
+ * A logging function specific to this package. The log messages don't show up
+ * by default, but they can be enabled by setting the environment variable:
+ * - `DEBUG=metamask:snaps:snaps-execution-environments`, or
+ * - `DEBUG=metamask:snaps:*` to enable all logs from `@metamask/snaps-*`.
+ */
+export const log = createModuleLogger(
+  snapsLogger,
+  'snaps-execution-environments',
+);

--- a/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/node-process/ChildProcessSnapExecutor.ts
@@ -1,19 +1,20 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { ProcessMessageStream } from '@metamask/post-message-stream';
-import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
+import { logError, SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
 import pump from 'pump';
 
 import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
+import { log } from '../logging';
 
 export class ChildProcessSnapExecutor extends BaseSnapExecutor {
   static initialize() {
-    console.log('Worker: Connecting to parent.');
+    log('Worker: Connecting to parent.');
 
     const parentStream = new ProcessMessageStream();
     const mux = new ObjectMultiplex();
     pump(parentStream, mux as any, parentStream, (error) => {
       if (error) {
-        console.error(`Parent stream failure, closing worker.`, error);
+        logError(`Parent stream failure, closing worker.`, error);
       }
       self.close();
     });

--- a/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/node-thread/ThreadSnapExecutor.ts
@@ -1,19 +1,20 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { ThreadMessageStream } from '@metamask/post-message-stream';
-import { SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
+import { logError, SNAP_STREAM_NAMES } from '@metamask/snaps-utils';
 import pump from 'pump';
 
 import { BaseSnapExecutor } from '../common/BaseSnapExecutor';
+import { log } from '../logging';
 
 export class ThreadSnapExecutor extends BaseSnapExecutor {
   static initialize() {
-    console.log('Worker: Connecting to parent.');
+    log('Worker: Connecting to parent.');
 
     const parentStream = new ThreadMessageStream();
     const mux = new ObjectMultiplex();
     pump(parentStream, mux as any, parentStream, (error) => {
       if (error) {
-        console.error(`Parent stream failure, closing worker.`, error);
+        logError(`Parent stream failure, closing worker.`, error);
       }
       self.close();
     });

--- a/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/offscreen/OffscreenSnapExecutor.ts
@@ -2,7 +2,7 @@ import {
   BasePostMessageStream,
   WindowPostMessageStream,
 } from '@metamask/post-message-stream';
-import { createWindow } from '@metamask/snaps-utils';
+import { createWindow, logError } from '@metamask/snaps-utils';
 import { JsonRpcRequest, assert } from '@metamask/utils';
 
 type ExecutorJob = {
@@ -68,7 +68,7 @@ export class OffscreenSnapExecutor {
           this.#onData(data);
         })
         .catch((error) => {
-          console.error('[Worker] Error initializing job:', error);
+          logError('[Worker] Error initializing job:', error);
         });
 
       return;

--- a/packages/snaps-execution-environments/update-coverage-thresholds.js
+++ b/packages/snaps-execution-environments/update-coverage-thresholds.js
@@ -1,8 +1,11 @@
-// This script is a custom replacement for jest-it-up
+/* eslint-disable no-console */
+
+// This script is a custom replacement for jest-it-up.
 // Since two test runners are used in the snaps-execution-environments package,
 // it is required that coverage process runs independently based on the results
 // from both test runners.
 // This script will update changes to coverage thresholds when they're improved.
+
 'use strict';
 
 const fs = require('fs');

--- a/packages/snaps-rollup-plugin/src/__fixtures__/source-map.ts
+++ b/packages/snaps-rollup-plugin/src/__fixtures__/source-map.ts
@@ -2,4 +2,5 @@
 
 // eslint-disable-next-line import/unambiguous
 const foo = 'bar';
+// eslint-disable-next-line no-console
 console.log(foo);

--- a/packages/snaps-utils/src/eval-worker.ts
+++ b/packages/snaps-utils/src/eval-worker.ts
@@ -55,6 +55,7 @@ const invalidExports = Object.keys(snapModule.exports).filter(
 );
 
 if (invalidExports.length > 0) {
+  // eslint-disable-next-line no-console
   console.warn(`Invalid snap exports detected:\n${invalidExports.join('\n')}`);
 }
 

--- a/packages/snaps-utils/src/index.browser.ts
+++ b/packages/snaps-utils/src/index.browser.ts
@@ -8,6 +8,7 @@ export * from './flatMap';
 export * from './handlers';
 export * from './iframe';
 export * from './json-rpc';
+export * from './logging';
 export * from './manifest/index.browser';
 export * from './namespace';
 export * from './notification';

--- a/packages/snaps-utils/src/index.ts
+++ b/packages/snaps-utils/src/index.ts
@@ -10,6 +10,7 @@ export * from './fs';
 export * from './handlers';
 export * from './iframe';
 export * from './json-rpc';
+export * from './logging';
 export * from './manifest';
 export * from './mock';
 export * from './namespace';

--- a/packages/snaps-utils/src/logging.test.ts
+++ b/packages/snaps-utils/src/logging.test.ts
@@ -1,0 +1,29 @@
+import { logError, logInfo, logWarning } from './logging';
+
+describe('logInfo', () => {
+  it('logs the message', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation();
+
+    logInfo('foo', 'bar', 'baz');
+    expect(spy).toHaveBeenCalledWith('foo', 'bar', 'baz');
+  });
+});
+
+describe('logError', () => {
+  it('logs the error', () => {
+    const error = new Error('foo');
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    logError(error, 'bar', 'baz');
+    expect(spy).toHaveBeenCalledWith(error, 'bar', 'baz');
+  });
+});
+
+describe('logWarning', () => {
+  it('logs the warning', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+    logWarning('foo', 'bar', 'baz');
+    expect(spy).toHaveBeenCalledWith('foo', 'bar', 'baz');
+  });
+});

--- a/packages/snaps-utils/src/logging.ts
+++ b/packages/snaps-utils/src/logging.ts
@@ -1,0 +1,59 @@
+import { createProjectLogger } from '@metamask/utils';
+
+// The global logger used across the monorepo. Other projects should use this
+// to create a module logger.
+export const snapsLogger = createProjectLogger('snaps');
+
+/**
+ * Log a message. Currently, this is just a wrapper around `console.log`, but
+ * the implementation may change in the future. These logs will be included in
+ * production builds, so they should be used sparingly, and not contain any
+ * sensitive information.
+ *
+ * This function makes it easy to swap out the logging implementation in all
+ * files at once.
+ *
+ * @param message - The message to log.
+ * @param optionalParams - Additional parameters to pass to the logging.
+ */
+export function logInfo(message: string, ...optionalParams: unknown[]): void {
+  // eslint-disable-next-line no-console
+  console.log(message, ...optionalParams);
+}
+
+/**
+ * Log an error. Currently, this is just a wrapper around `console.error`, but
+ * the implementation may change in the future. These logs will be included in
+ * production builds, so they should be used sparingly, and not contain any
+ * sensitive information.
+ *
+ * This function makes it easy to swap out the logging implementation in all
+ * files at once.
+ *
+ * @param error - The error to log.
+ * @param optionalParams - Additional parameters to pass to the logging.
+ */
+export function logError(error: unknown, ...optionalParams: unknown[]): void {
+  // eslint-disable-next-line no-console
+  console.error(error, ...optionalParams);
+}
+
+/**
+ * Log a warning. Currently, this is just a wrapper around `console.warn`, but
+ * the implementation may change in the future. These logs will be included in
+ * production builds, so they should be used sparingly, and not contain any
+ * sensitive information.
+ *
+ * This function makes it easy to swap out the logging implementation in all
+ * files at once.
+ *
+ * @param message - The message to log.
+ * @param optionalParams - Additional parameters to pass to the logging.
+ */
+export function logWarning(
+  message: string,
+  ...optionalParams: unknown[]
+): void {
+  // eslint-disable-next-line no-console
+  console.warn(message, ...optionalParams);
+}

--- a/packages/snaps-utils/src/logging.ts
+++ b/packages/snaps-utils/src/logging.ts
@@ -27,6 +27,10 @@ export function logInfo(message: string, ...optionalParams: unknown[]): void {
  * production builds, so they should be used sparingly, and not contain any
  * sensitive information.
  *
+ * These logs should always be visible, without requiring the user to enable
+ * verbose logging (like setting a `DEBUG` environment variable), as they are
+ * important for debugging snaps.
+ *
  * This function makes it easy to swap out the logging implementation in all
  * files at once.
  *
@@ -43,6 +47,10 @@ export function logError(error: unknown, ...optionalParams: unknown[]): void {
  * the implementation may change in the future. These logs will be included in
  * production builds, so they should be used sparingly, and not contain any
  * sensitive information.
+ *
+ * These logs should always be visible, without requiring the user to enable
+ * verbose logging (like setting a `DEBUG` environment variable), as they are
+ * important for debugging snaps.
  *
  * This function makes it easy to swap out the logging implementation in all
  * files at once.

--- a/packages/snaps-utils/src/test-utils/server.ts
+++ b/packages/snaps-utils/src/test-utils/server.ts
@@ -2,6 +2,8 @@ import http from 'http';
 import path from 'path';
 import serveHandler from 'serve-handler';
 
+import { logError } from '../logging';
+
 /**
  * Starts a local server that serves the iframe execution environment.
  *
@@ -41,17 +43,18 @@ export async function startServer(
     });
 
     server.listen({ port }, () => {
+      // eslint-disable-next-line no-console
       console.log(`Server listening on: http://localhost:${port}`);
       resolve(server);
     });
 
     server.on('error', (error) => {
-      console.error('Server error', error);
+      logError('Server error', error);
       reject(error);
     });
 
     server.on('close', () => {
-      console.log('Server closed');
+      logError('Server closed');
       reject(new Error('Server closed'));
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,7 @@ __metadata:
     stream-browserify: ^3.0.0
     superstruct: ^1.0.3
     ts-jest: ^29.0.0
+    tsconfig-paths: ^4.1.2
     tsconfig-paths-webpack-plugin: ^4.0.0
     typescript: ~4.8.4
     webpack: ^5.68.0
@@ -15665,7 +15666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^4.0.0":
+"tsconfig-paths@npm:^4.0.0, tsconfig-paths@npm:^4.1.2":
   version: 4.1.2
   resolution: "tsconfig-paths@npm:4.1.2"
   dependencies:


### PR DESCRIPTION
This PR standardises logging across the repository, by replacing all calls to `console.log`, `console.warn`, `console.error` with:

1. `logInfo`, `logWarning` or `logError` for public logging, i.e., the CLI logging information to the console. Right now these are just wrappers around their respective `console` function, but in the future we can easily swap out the implementation just by changing these functions.
2. A new `log` function based on the `@metamask/utils` logging utils, for debug logging. These messages don't show up in the console by default, so they won't show up in production builds either.

    In order to see these log messages you have to set the `DEBUG` environment variable to either:
    - `DEBUG="metamask:snaps:*"` to see all Snaps-related debug messages, or
    - `DEBUG="metamask:snaps:snaps-controllers"` (currently only `snaps-controllers` and `snaps-execution-environments` use this function), to only show debug messages for that particular package.

I've also added the `no-console` rule to our ESLint configuration, to make sure we only use one of the functions mentioned above.

Closes #1149.