### PR TITLE
Establish pre-fetch NPM tarball size limit

### DIFF
--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -200,6 +200,9 @@ export class NpmLocation implements SnapLocation {
   }
 }
 
+// Safety limit for tarballs, 250 MB in bytes
+const TARBALL_SIZE_SAFETY_LIMIT = 262144000;
+
 /**
  * Fetches the tarball (`.tgz` file) of the specified package and version from
  * the public npm registry. Throws an error if fetching fails.
@@ -267,6 +270,13 @@ async function fetchNpmTarball(
   if (!tarballResponse.ok || !tarballResponse.body) {
     throw new Error(`Failed to fetch tarball for package "${packageName}".`);
   }
+  const tarballSizeString = tarballResponse.headers.get('content-length');
+  assert(tarballSizeString, 'Snap tarball has invalid content-length');
+  const tarballSize = parseInt(tarballSizeString, 10);
+  assert(
+    tarballSize <= TARBALL_SIZE_SAFETY_LIMIT / 2,
+    'Snap tarball exceeds size limit',
+  );
   return [tarballResponse.body, targetVersion];
 }
 
@@ -292,9 +302,6 @@ function getNodeStream(stream: ReadableStream): Readable {
 
   return new ReadableWebToNodeStream(stream);
 }
-
-// Safety limit for tarballs, 250 MB in bytes
-const TARBALL_SIZE_SAFETY_LIMIT = 262144000;
 
 /**
  * Creates a `tar-stream` that will get the necessary files from an npm Snap


### PR DESCRIPTION
Establishes a pre-fetch NPM tarball size limit to prevent denial of service.