### PR TITLE
Add method to get metadata from the Snaps registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
       "prettier --write"
     ]
   },
-  "resolutions": {
-    "@metamask/snaps-registry": "portal:/Users/morten/Development/MetaMask/snaps-registry"
-  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
       "prettier --write"
     ]
   },
+  "resolutions": {
+    "@metamask/snaps-registry": "portal:/Users/morten/Development/MetaMask/snaps-registry"
+  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -38,7 +38,7 @@
     "@metamask/post-message-stream": "^6.1.0",
     "@metamask/rpc-methods": "^0.28.0",
     "@metamask/snaps-execution-environments": "^0.28.0",
-    "@metamask/snaps-registry": "^1.0.0",
+    "@metamask/snaps-registry": "^1.1.0",
     "@metamask/snaps-utils": "^0.28.0",
     "@metamask/subject-metadata-controller": "^1.0.1",
     "@metamask/utils": "^3.4.1",

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -3822,6 +3822,38 @@ describe('SnapController', () => {
     });
   });
 
+  describe('getRegistryMetadata', () => {
+    it('returns the metadata for a verified snap', async () => {
+      const registry = new MockSnapsRegistry();
+      registry.getMetadata.mockReturnValue({
+        name: 'Mock Snap',
+      });
+
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          registry,
+        }),
+      );
+
+      expect(
+        await snapController.getRegistryMetadata(MOCK_SNAP_ID),
+      ).toStrictEqual({
+        name: 'Mock Snap',
+      });
+    });
+
+    it('returns null for a non-verified snap', async () => {
+      const registry = new MockSnapsRegistry();
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          registry,
+        }),
+      );
+
+      expect(await snapController.getRegistryMetadata(MOCK_SNAP_ID)).toBeNull();
+    });
+  });
+
   describe('SnapController actions', () => {
     describe('SnapController:get', () => {
       it('gets a snap', () => {
@@ -4204,6 +4236,33 @@ describe('SnapController', () => {
 
         messenger.call('SnapController:removeSnapError', 'foo');
         expect(snapController.state.snapErrors.foo).toBeUndefined();
+      });
+    });
+
+    describe('SnapController:getRegistryMetadata', () => {
+      it('calls SnapController.getRegistryMetadata()', async () => {
+        const messenger = getSnapControllerMessenger();
+        const registry = new MockSnapsRegistry();
+
+        registry.getMetadata.mockReturnValue({
+          name: 'Mock Snap',
+        });
+
+        getSnapController(
+          getSnapControllerOptions({
+            messenger,
+            registry,
+          }),
+        );
+
+        expect(
+          await messenger.call(
+            'SnapController:getRegistryMetadata',
+            MOCK_SNAP_ID,
+          ),
+        ).toStrictEqual({
+          name: 'Mock Snap',
+        });
       });
     });
   });

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -101,6 +101,7 @@ import {
   JsonSnapsRegistry,
   SnapsRegistry,
   SnapsRegistryInfo,
+  SnapsRegistryMetadata,
   SnapsRegistryRequest,
   SnapsRegistryStatus,
 } from './registry';
@@ -344,6 +345,11 @@ export type RemoveSnapError = {
   handler: SnapController['removeSnapError'];
 };
 
+export type GetRegistryMetadata = {
+  type: `${typeof controllerName}:getRegistryMetadata`;
+  handler: SnapController['getRegistryMetadata'];
+};
+
 export type SnapControllerActions =
   | ClearSnapState
   | GetSnap
@@ -360,7 +366,8 @@ export type SnapControllerActions =
   | RemoveSnapError
   | GetAllSnaps
   | IncrementActiveReferences
-  | DecrementActiveReferences;
+  | DecrementActiveReferences
+  | GetRegistryMetadata;
 
 // Controller Messenger Events
 
@@ -919,6 +926,11 @@ export class SnapController extends BaseController<
     this.messagingSystem.registerActionHandler(
       `${controllerName}:decrementActiveReferences`,
       (...args) => this.decrementActiveReferences(...args),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:getRegistryMetadata`,
+      async (...args) => this.getRegistryMetadata(...args),
     );
   }
 
@@ -1814,6 +1826,19 @@ export class SnapController extends BaseController<
     );
 
     return truncatedSnap;
+  }
+
+  /**
+   * Get metadata for the given snap ID.
+   *
+   * @param snapId - The ID of the snap to get metadata for.
+   * @returns The metadata for the given snap ID, or `null` if the snap is not
+   * verified.
+   */
+  async getRegistryMetadata(
+    snapId: SnapId,
+  ): Promise<SnapsRegistryMetadata | null> {
+    return await this.#registry.getMetadata(snapId);
   }
 
   /**

--- a/packages/snaps-controllers/src/snaps/registry/json.test.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.test.ts
@@ -13,6 +13,9 @@ const MOCK_DATABASE: SnapsRegistryDatabase = {
   verifiedSnaps: {
     [MOCK_SNAP_ID]: {
       id: MOCK_SNAP_ID,
+      metadata: {
+        name: 'Mock Snap',
+      },
       versions: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         ['1.0.0' as SemVerVersion]: {
@@ -36,6 +39,7 @@ const MOCK_DATABASE: SnapsRegistryDatabase = {
 
 describe('JsonSnapsRegistry', () => {
   fetchMock.enableMocks();
+
   it('can get entries from the registry', async () => {
     fetchMock.mockResponse(JSON.stringify(MOCK_DATABASE));
     const registry = new JsonSnapsRegistry();
@@ -176,5 +180,27 @@ describe('JsonSnapsRegistry', () => {
         },
       }),
     ).rejects.toThrow('Snaps registry is unavailable, installation blocked.');
+  });
+
+  describe('getMetadata', () => {
+    it('returns the metadata for a verified snap', async () => {
+      fetchMock.mockResponse(JSON.stringify(MOCK_DATABASE));
+
+      const registry = new JsonSnapsRegistry();
+      const result = await registry.getMetadata(MOCK_SNAP_ID);
+
+      expect(result).toStrictEqual({
+        name: 'Mock Snap',
+      });
+    });
+
+    it('returns null for a non-verified snap', async () => {
+      fetchMock.mockResponse(JSON.stringify(MOCK_DATABASE));
+
+      const registry = new JsonSnapsRegistry();
+      const result = await registry.getMetadata('foo');
+
+      expect(result).toBeNull();
+    });
   });
 });

--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -5,6 +5,7 @@ import { satisfiesVersionRange } from '@metamask/utils';
 import {
   SnapsRegistry,
   SnapsRegistryInfo,
+  SnapsRegistryMetadata,
   SnapsRegistryRequest,
   SnapsRegistryResult,
   SnapsRegistryStatus,
@@ -99,5 +100,19 @@ export class JsonSnapsRegistry implements SnapsRegistry {
       acc[snapId] = result;
       return acc;
     }, Promise.resolve({}));
+  }
+
+  /**
+   * Get metadata for the given snap ID.
+   *
+   * @param snapId - The ID of the snap to get metadata for.
+   * @returns The metadata for the given snap ID, or `null` if the snap is not
+   * verified.
+   */
+  public async getMetadata(
+    snapId: SnapId,
+  ): Promise<SnapsRegistryMetadata | null> {
+    const database = await this.#getDatabase();
+    return database?.verifiedSnaps[snapId]?.metadata ?? null;
   }
 }

--- a/packages/snaps-controllers/src/snaps/registry/registry.ts
+++ b/packages/snaps-controllers/src/snaps/registry/registry.ts
@@ -1,9 +1,11 @@
-import { BlockReason } from '@metamask/snaps-registry';
+import { BlockReason, SnapsRegistryDatabase } from '@metamask/snaps-registry';
 import { SnapId } from '@metamask/snaps-utils';
 import { SemVerVersion } from '@metamask/utils';
 
 export type SnapsRegistryInfo = { version: SemVerVersion; checksum: string };
 export type SnapsRegistryRequest = Record<SnapId, SnapsRegistryInfo>;
+export type SnapsRegistryMetadata =
+  SnapsRegistryDatabase['verifiedSnaps'][SnapId]['metadata'];
 
 // TODO: Decide on names for these
 export enum SnapsRegistryStatus {
@@ -21,4 +23,13 @@ export type SnapsRegistry = {
   get(
     snaps: SnapsRegistryRequest,
   ): Promise<Record<SnapId, SnapsRegistryResult>>;
+
+  /**
+   * Get metadata for the given snap ID.
+   *
+   * @param snapId - The ID of the snap to get metadata for.
+   * @returns The metadata for the given snap ID, or `null` if the snap is not
+   * verified.
+   */
+  getMetadata(snapId: SnapId): Promise<SnapsRegistryMetadata | null>;
 };

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -218,6 +218,7 @@ export const getSnapControllerMessenger = (
       'SnapController:removeSnapError',
       'SnapController:incrementActiveReferences',
       'SnapController:decrementActiveReferences',
+      'SnapController:getRegistryMetadata',
       'SubjectMetadataController:getSubjectMetadata',
     ],
   });

--- a/packages/snaps-controllers/src/test-utils/registry.ts
+++ b/packages/snaps-controllers/src/test-utils/registry.ts
@@ -12,4 +12,6 @@ export class MockSnapsRegistry implements SnapsRegistry {
       ),
     );
   });
+
+  getMetadata = jest.fn().mockResolvedValue(null);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,7 +2861,7 @@ __metadata:
     "@metamask/post-message-stream": ^6.1.0
     "@metamask/rpc-methods": ^0.28.0
     "@metamask/snaps-execution-environments": ^0.28.0
-    "@metamask/snaps-registry": ^1.0.0
+    "@metamask/snaps-registry": ^1.1.0
     "@metamask/snaps-utils": ^0.28.0
     "@metamask/subject-metadata-controller": ^1.0.1
     "@metamask/template-snap": ^0.7.0
@@ -2973,14 +2973,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-registry@portal:/Users/morten/Development/MetaMask/snaps-registry::locator=root%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@metamask/snaps-registry@portal:/Users/morten/Development/MetaMask/snaps-registry::locator=root%40workspace%3A."
+"@metamask/snaps-registry@npm:^1.0.0, @metamask/snaps-registry@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@metamask/snaps-registry@npm:1.1.0"
   dependencies:
     "@metamask/utils": ^3.4.0
     superstruct: ^1.0.3
+  checksum: a67a9e7a30a2f7bc55d130b278573aa2bf043ab5c5935704ab8166898dadf37557284412f9b653f9ed52059a557a51b8472aabbe6887a06922d5526ead12199b
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@metamask/snaps-rollup-plugin@^0.28.0, @metamask/snaps-rollup-plugin@workspace:packages/snaps-rollup-plugin":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -2973,15 +2973,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-registry@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/snaps-registry@npm:1.0.0"
+"@metamask/snaps-registry@portal:/Users/morten/Development/MetaMask/snaps-registry::locator=root%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@metamask/snaps-registry@portal:/Users/morten/Development/MetaMask/snaps-registry::locator=root%40workspace%3A."
   dependencies:
     "@metamask/utils": ^3.4.0
     superstruct: ^1.0.3
-  checksum: 6a127d4d2db30e6f3966f4f82f3810a22a79db62c84b5db2b95d189dd36fe59aa5de59f01203095c9f7f07a44c1bf049c0fc046931269327d0693d1274f8f154
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@metamask/snaps-rollup-plugin@^0.28.0, @metamask/snaps-rollup-plugin@workspace:packages/snaps-rollup-plugin":
   version: 0.0.0-use.local


### PR DESCRIPTION
This adds a new function `getRegistryMetadata` to the `SnapController` in order to get metadata for verified snaps.

Prerequisite for MetaMask/MetaMask-planning#298.