### PR TITLE
Snaps globalThis now has proper self-referential properties

### DIFF
--- a/packages/snaps-execution-environments/nyc.config.js
+++ b/packages/snaps-execution-environments/nyc.config.js
@@ -3,8 +3,8 @@
  */
 module.exports = {
   'check-coverage': true,
-  branches: 89.81,
-  lines: 90.32,
-  functions: 94.31,
-  statements: 90.32,
+  branches: 89.28,
+  lines: 90.55,
+  functions: 94.56,
+  statements: 90.55,
 };

--- a/packages/snaps-execution-environments/nyc.config.js
+++ b/packages/snaps-execution-environments/nyc.config.js
@@ -3,8 +3,8 @@
  */
 module.exports = {
   'check-coverage': true,
-  branches: 89.28,
-  lines: 90.52,
-  functions: 94.56,
-  statements: 90.52,
+  branches: 89.81,
+  lines: 90.32,
+  functions: 94.31,
+  statements: 90.32,
 };

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -327,9 +327,15 @@ export class BaseSnapExecutor {
         ...endowments,
         module: snapModule,
         exports: snapModule.exports,
-        window: { ...endowments },
-        self: { ...endowments },
       });
+      // All of those are JavaScript runtime specific and self referential,
+      // but we add them for compatibility sake with external libraries.
+      //
+      // We can't do that in the injected globals object above
+      // because SES creates it's own globalThis
+      compartment.globalThis.self = compartment.globalThis;
+      compartment.globalThis.global = compartment.globalThis;
+      compartment.globalThis.window = compartment.globalThis;
 
       await this.executeInSnapContext(snapName, () => {
         compartment.evaluate(sourceCode);

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -332,7 +332,7 @@ export class BaseSnapExecutor {
       // but we add them for compatibility sake with external libraries.
       //
       // We can't do that in the injected globals object above
-      // because SES creates it's own globalThis
+      // because SES creates its own globalThis
       compartment.globalThis.self = compartment.globalThis;
       compartment.globalThis.global = compartment.globalThis;
       compartment.globalThis.window = compartment.globalThis;


### PR DESCRIPTION
Different JavaScript runtimes have different global objects, browsers have `self`, `window` and `globalThis`, while Node has `globalThis` and `global`.

All of them are self-referential. `self.self === self` and so on.

This fixes how we injected those globals to all point to the same object and add self-referential properties.

Fixes issue 3 from #1160 