### PR TITLE
Improve Rollup test stability

### DIFF
--- a/packages/snaps-rollup-plugin/src/plugin.test.ts
+++ b/packages/snaps-rollup-plugin/src/plugin.test.ts
@@ -8,6 +8,7 @@ import {
   getSnapManifest,
 } from '@metamask/snaps-utils/test-utils';
 import virtual, { RollupVirtualOptions } from '@rollup/plugin-virtual';
+import assert from 'assert';
 import { promises as fs } from 'fs';
 import { OutputOptions, rollup, RollupOutput } from 'rollup';
 
@@ -172,8 +173,12 @@ describe('snaps', () => {
     });
 
     const { map } = output[0];
-    expect(map).toMatchInlineSnapshot(`
-      SourceMap {
+    assert(map);
+
+    const { sources, ...partialMap } = map;
+
+    expect(partialMap).toMatchInlineSnapshot(`
+      {
         "file": "source-map.js",
         "mappings": "AACEA,MAAM,CAACC,OAAO,CAACC,YAAY,GAAG,CAAC;EAAEC;AAAO,CAAE,KAAK;EAC7CC,OAAO,CAACC,GAAG,CAAC,eAAe,CAAC;EAE5B,MAAM;IAAEC,MAAM;IAAEC;EAAI,CAAA,GAAGJ,OAAO;EAC9B,OAAOG,MAAM,GAAGC,EAAE;AACnB,CAAA",
         "names": [
@@ -185,9 +190,6 @@ describe('snaps', () => {
           "log",
           "method",
           "id",
-        ],
-        "sources": [
-          "../../../../../../../source-map.ts",
         ],
         "sourcesContent": [
           "


### PR DESCRIPTION
The `sources` part of a source map can change depending on the environment, causing instability in the test in some cases. Since it's not an important part of the test, it can be removed from the snapshot.