### PR TITLE
Accept string operation for `snap_manageState`

### DIFF
--- a/packages/rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/rpc-methods/src/restricted/manageState.test.ts
@@ -238,6 +238,39 @@ describe('snap_manageState', () => {
       );
     });
 
+    it('accepts a string as operation', async () => {
+      const mockSnapState = {
+        some: {
+          data: 'for a snap state',
+        },
+      };
+
+      const clearSnapState = jest.fn().mockResolvedValueOnce(true);
+      const getSnapState = jest.fn().mockResolvedValueOnce(true);
+      const updateSnapState = jest.fn().mockResolvedValueOnce(true);
+
+      const manageStateImplementation = getManageStateImplementation({
+        clearSnapState,
+        getSnapState,
+        updateSnapState,
+        getMnemonic: jest
+          .fn()
+          .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
+        getUnlockPromise: jest.fn(),
+      });
+
+      expect(
+        await manageStateImplementation({
+          context: { origin: MOCK_SNAP_ID },
+          method: 'snap_manageState',
+          params: {
+            operation: 'update',
+            newState: mockSnapState,
+          },
+        }),
+      ).not.toThrow();
+    });
+
     it('throws an error if the state is corrupt', async () => {
       const clearSnapState = jest.fn().mockResolvedValueOnce(true);
       const getSnapState = jest.fn().mockResolvedValueOnce('foo');

--- a/packages/rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/rpc-methods/src/restricted/manageState.test.ts
@@ -259,8 +259,8 @@ describe('snap_manageState', () => {
         getUnlockPromise: jest.fn(),
       });
 
-      expect(
-        await manageStateImplementation({
+      expect(async () =>
+        manageStateImplementation({
           context: { origin: MOCK_SNAP_ID },
           method: 'snap_manageState',
           params: {

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -16,7 +16,7 @@ import {
 } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
-import { deriveEntropy } from '../utils';
+import { deriveEntropy, EnumToUnion } from '../utils';
 
 // The salt used for SIP-6-based entropy derivation.
 export const STATE_ENCRYPTION_SALT = 'snap_manageState encryption';
@@ -113,7 +113,7 @@ export enum ManageStateOperation {
 }
 
 export type ManageStateArgs = {
-  operation: ManageStateOperation;
+  operation: EnumToUnion<ManageStateOperation>;
   newState?: Record<string, Json>;
 };
 


### PR DESCRIPTION
Closes #1207.

To make the JSON-RPC methods easier to work with, we allow both enums and plain string values where applicable. Unfortunately, `snap_manageState` was not changed to allow this before, so I have fixed it.