### PR TITLE
Properly secure `snap` and `ethereum` request functions

### DIFF
--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -384,7 +384,8 @@ export class BaseSnapExecutor {
 
     const request = async (args: RequestArguments) => {
       assert(
-        args.method.startsWith('wallet_') || args.method.startsWith('snap_'),
+        String.prototype.startsWith.call(args.method, 'wallet_') ||
+          String.prototype.startsWith.call(args.method, 'snap_'),
         'The global Snap API only allows RPC methods starting with `wallet_*` and `snap_*`.',
       );
       this.notify({ method: 'OutboundRequest' });
@@ -427,7 +428,7 @@ export class BaseSnapExecutor {
 
     const request = async (args: RequestArguments) => {
       assert(
-        !args.method.startsWith('snap_'),
+        !String.prototype.startsWith.call(args.method, 'snap_'),
         ethErrors.rpc.methodNotFound({
           data: {
             method: args.method,

--- a/packages/snaps-execution-environments/src/common/test-utils/endowments.ts
+++ b/packages/snaps-execution-environments/src/common/test-utils/endowments.ts
@@ -52,7 +52,7 @@ export function getMockedStreamProvider() {
 
   const request = async (args: RequestArguments) => {
     assert(
-      !args.method.startsWith('snap_'),
+      !String.prototype.startsWith.call(args.method, 'snap_'),
       ethErrors.rpc.methodNotFound({
         data: {
           method: args.method,


### PR DESCRIPTION
Fixes a problem where it was possible to trick the separation of concern measures in `snap.request` and `ethereum.request`

Fixes #1213
