### PR TITLE
Add harden events utilities

### DIFF
--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -38,7 +38,7 @@
     "@metamask/base-controller": "^2.0.0",
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/permission-controller": "^3.0.0",
-    "@metamask/post-message-stream": "^6.1.0",
+    "@metamask/post-message-stream": "^6.1.1",
     "@metamask/rpc-methods": "^0.31.0",
     "@metamask/snaps-execution-environments": "^0.31.0",
     "@metamask/snaps-registry": "^1.1.1",

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 77.41,
-  "functions": 91.26,
-  "lines": 85.29,
-  "statements": 85.37
+  "branches": 78.62,
+  "functions": 91.4,
+  "lines": 87.95,
+  "statements": 88.02
 }

--- a/packages/snaps-execution-environments/jest.config.js
+++ b/packages/snaps-execution-environments/jest.config.js
@@ -5,7 +5,12 @@ const baseConfig = require('../../jest.config.base');
 delete baseConfig.coverageThreshold;
 
 module.exports = deepmerge(baseConfig, {
-  coveragePathIgnorePatterns: ['./src/index.ts', './src/common/test-utils'],
+  coveragePathIgnorePatterns: [
+    './src/index.ts',
+    './src/iframe/index.ts',
+    './src/offscreen/index.ts',
+    './src/common/test-utils',
+  ],
   coverageDirectory: './coverage/jest',
   testTimeout: 10000,
   testEnvironment: '<rootDir>/jest.environment.js',

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@metamask/object-multiplex": "^1.2.0",
-    "@metamask/post-message-stream": "^6.1.0",
+    "@metamask/post-message-stream": "^6.1.1",
     "@metamask/providers": "^10.2.0",
     "@metamask/rpc-methods": "^0.31.0",
     "@metamask/snaps-utils": "^0.31.0",

--- a/packages/snaps-execution-environments/src/common/lockdown/lockdown-events.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/lockdown/lockdown-events.test.browser.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line import/unambiguous
+import { expect } from '@wdio/globals';
+
+import { executeLockdownEvents } from './lockdown-events';
+
+describe('lockdown events security', () => {
+  it('should lockdown events and made event properties inaccessible', async () => {
+    executeLockdownEvents();
+
+    const eventTarget = new EventTarget();
+
+    const promise = new Promise((resolve) => {
+      eventTarget.addEventListener('just-test-event', (eventObject) => {
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        resolve(eventObject.composedPath);
+      });
+    });
+
+    const testEvent = new Event('just-test-event');
+    eventTarget.dispatchEvent(testEvent);
+
+    const result = await promise;
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/snaps-execution-environments/src/common/lockdown/lockdown-events.ts
+++ b/packages/snaps-execution-environments/src/common/lockdown/lockdown-events.ts
@@ -1,0 +1,57 @@
+// When creating a sandbox, limitation of the events from leaking
+// sensitive objects is required. This is done by overriding own properties
+// of prototypes of all existing events.
+import { hasProperty } from '@metamask/utils';
+
+/**
+ * Targeted Event objects and properties.
+ * Note: This is a map of the prototypes that inherit from Events with
+ * properties that are identified to leak sensitive objects.
+ * Not all browsers support all event types, so checking its existence is required.
+ */
+const targetEvents = new Map();
+if (hasProperty(globalThis, 'UIEvent')) {
+  targetEvents.set(UIEvent.prototype, ['view']);
+}
+if (hasProperty(globalThis, 'MutationEvent')) {
+  targetEvents.set(MutationEvent.prototype, ['relatedNode']);
+}
+if (hasProperty(globalThis, 'MessageEvent')) {
+  targetEvents.set(MessageEvent.prototype, ['source']);
+}
+if (hasProperty(globalThis, 'FocusEvent')) {
+  targetEvents.set(FocusEvent.prototype, ['relatedTarget']);
+}
+if (hasProperty(globalThis, 'MouseEvent')) {
+  targetEvents.set(MouseEvent.prototype, [
+    'relatedTarget',
+    'fromElement',
+    'toElement',
+  ]);
+}
+if (hasProperty(globalThis, 'TouchEvent')) {
+  targetEvents.set(TouchEvent.prototype, ['targetTouches', 'touches']);
+}
+if (hasProperty(globalThis, 'Event')) {
+  targetEvents.set(Event.prototype, [
+    'target',
+    'currentTarget',
+    'srcElement',
+    'composedPath',
+  ]);
+}
+
+/**
+ * Attenuate Event objects by replacing its own properties.
+ */
+export function executeLockdownEvents() {
+  targetEvents.forEach((properties, prototype) => {
+    for (const property of properties) {
+      Object.defineProperty(prototype, property, {
+        value: undefined,
+        configurable: false,
+        writable: false,
+      });
+    }
+  });
+}

--- a/packages/snaps-execution-environments/src/iframe/index.ts
+++ b/packages/snaps-execution-environments/src/iframe/index.ts
@@ -1,8 +1,10 @@
 import { executeLockdown } from '../common/lockdown/lockdown';
+import { executeLockdownEvents } from '../common/lockdown/lockdown-events';
 import { executeLockdownMore } from '../common/lockdown/lockdown-more';
 import { IFrameSnapExecutor } from './IFrameSnapExecutor';
 
 executeLockdown();
 executeLockdownMore();
+executeLockdownEvents();
 
 IFrameSnapExecutor.initialize();

--- a/packages/snaps-execution-environments/src/offscreen/index.ts
+++ b/packages/snaps-execution-environments/src/offscreen/index.ts
@@ -1,11 +1,13 @@
 import { BrowserRuntimePostMessageStream } from '@metamask/post-message-stream';
 
 import { executeLockdown } from '../common/lockdown/lockdown';
+import { executeLockdownEvents } from '../common/lockdown/lockdown-events';
 import { executeLockdownMore } from '../common/lockdown/lockdown-more';
 import { OffscreenSnapExecutor } from './OffscreenSnapExecutor';
 
 executeLockdown();
 executeLockdownMore();
+executeLockdownEvents();
 
 // The stream from the offscreen document to the execution service.
 const parentStream = new BrowserRuntimePostMessageStream({

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -82,7 +82,7 @@
     "@metamask/eslint-config-nodejs": "^11.0.1",
     "@metamask/eslint-config-typescript": "^11.0.0",
     "@metamask/key-tree": "^7.0.0",
-    "@metamask/post-message-stream": "^6.1.0",
+    "@metamask/post-message-stream": "^6.1.1",
     "@types/jest": "^27.5.1",
     "@types/mocha": "^10.0.1",
     "@types/semver": "^7.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,7 +2937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/post-message-stream@npm:^6.1.0":
+"@metamask/post-message-stream@npm:^6.1.1":
   version: 6.1.1
   resolution: "@metamask/post-message-stream@npm:6.1.1"
   dependencies:
@@ -3145,7 +3145,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/object-multiplex": ^1.1.0
     "@metamask/permission-controller": ^3.0.0
-    "@metamask/post-message-stream": ^6.1.0
+    "@metamask/post-message-stream": ^6.1.1
     "@metamask/rpc-methods": ^0.31.0
     "@metamask/snaps-execution-environments": ^0.31.0
     "@metamask/snaps-registry": ^1.1.1
@@ -3228,7 +3228,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/object-multiplex": ^1.2.0
-    "@metamask/post-message-stream": ^6.1.0
+    "@metamask/post-message-stream": ^6.1.1
     "@metamask/providers": ^10.2.0
     "@metamask/rpc-methods": ^0.31.0
     "@metamask/snaps-utils": ^0.31.0
@@ -3420,7 +3420,7 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/key-tree": ^7.0.0
     "@metamask/permission-controller": ^3.0.0
-    "@metamask/post-message-stream": ^6.1.0
+    "@metamask/post-message-stream": ^6.1.1
     "@metamask/providers": ^10.2.1
     "@metamask/snaps-registry": ^1.1.1
     "@metamask/snaps-ui": ^0.31.0


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/snaps-monorepo/issues/1132

This PR will add utility functions with procedures for hardening Event related objects.

New lockdown procedure file is added exclusively for events `lockdown-events.ts` exporting function `executeLockdownEvents` that is called in `packages/snaps-execution-environments/src/iframe/index.ts` before other lockdown functions to ensure that this one will be executed before SES disallows further changes.


Currently blocked by (depends on): https://github.com/MetaMask/post-message-stream/pull/79
