### PR TITLE
Throw errors on failed `fetch`

### DIFF
--- a/packages/snaps-controllers/src/snaps/location/http.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.test.ts
@@ -32,6 +32,15 @@ describe('HttpLocation', () => {
     expect(bundle.toString()).toStrictEqual(DEFAULT_SNAP_BUNDLE);
   });
 
+  it('throws if fetch fails', async () => {
+    const base = 'http://foo.bar';
+
+    fetchMock.mockResponse(async () => ({ status: 404, body: 'Not found' }));
+    const location = new HttpLocation(new URL(base));
+    await expect(location.manifest()).rejects.toThrow('Failed to fetch');
+    await expect(location.fetch('foo')).rejects.toThrow('Failed to fetch');
+  });
+
   it('returns proper root', () => {
     const base = 'http://foo.bar/foo/';
     expect(new HttpLocation(new URL(base)).root.toString()).toStrictEqual(base);

--- a/packages/snaps-controllers/src/snaps/location/http.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.test.ts
@@ -37,8 +37,12 @@ describe('HttpLocation', () => {
 
     fetchMock.mockResponse(async () => ({ status: 404, body: 'Not found' }));
     const location = new HttpLocation(new URL(base));
-    await expect(location.manifest()).rejects.toThrow('Failed to fetch');
-    await expect(location.fetch('foo')).rejects.toThrow('Failed to fetch');
+    await expect(location.manifest()).rejects.toThrow(
+      'Failed to fetch "http://foo.bar/snap.manifest.json". Status code: 404.',
+    );
+    await expect(location.fetch('foo.js')).rejects.toThrow(
+      'Failed to fetch "http://foo.bar/foo.js". Status code: 404.',
+    );
   });
 
   it('returns proper root', () => {

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -56,9 +56,11 @@ export class HttpLocation implements SnapLocation {
       this.url,
     ).toString();
 
-    const contents = await (
-      await this.fetchFn(canonicalPath, this.fetchOptions)
-    ).text();
+    const response = await this.fetchFn(canonicalPath, this.fetchOptions);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch "${canonicalPath}".`);
+    }
+    const contents = await response.text();
     const manifest = JSON.parse(contents);
     const vfile = new VirtualFile<SnapManifest>({
       value: contents,
@@ -84,6 +86,9 @@ export class HttpLocation implements SnapLocation {
 
     const canonicalPath = this.toCanonical(relativePath).toString();
     const response = await this.fetchFn(canonicalPath, this.fetchOptions);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch "${canonicalPath}".`);
+    }
     const vfile = new VirtualFile({
       value: '',
       path: relativePath,

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -58,7 +58,9 @@ export class HttpLocation implements SnapLocation {
 
     const response = await this.fetchFn(canonicalPath, this.fetchOptions);
     if (!response.ok) {
-      throw new Error(`Failed to fetch "${canonicalPath}". Status code: ${response.status}.`);
+      throw new Error(
+        `Failed to fetch "${canonicalPath}". Status code: ${response.status}.`,
+      );
     }
     const contents = await response.text();
     const manifest = JSON.parse(contents);
@@ -87,7 +89,9 @@ export class HttpLocation implements SnapLocation {
     const canonicalPath = this.toCanonical(relativePath).toString();
     const response = await this.fetchFn(canonicalPath, this.fetchOptions);
     if (!response.ok) {
-      throw new Error(`Failed to fetch "${canonicalPath}". Status code: ${response.status}.`);
+      throw new Error(
+        `Failed to fetch "${canonicalPath}". Status code: ${response.status}.`,
+      );
     }
     const vfile = new VirtualFile({
       value: '',

--- a/packages/snaps-controllers/src/snaps/location/http.ts
+++ b/packages/snaps-controllers/src/snaps/location/http.ts
@@ -58,7 +58,7 @@ export class HttpLocation implements SnapLocation {
 
     const response = await this.fetchFn(canonicalPath, this.fetchOptions);
     if (!response.ok) {
-      throw new Error(`Failed to fetch "${canonicalPath}".`);
+      throw new Error(`Failed to fetch "${canonicalPath}". Status code: ${response.status}.`);
     }
     const contents = await response.text();
     const manifest = JSON.parse(contents);
@@ -87,7 +87,7 @@ export class HttpLocation implements SnapLocation {
     const canonicalPath = this.toCanonical(relativePath).toString();
     const response = await this.fetchFn(canonicalPath, this.fetchOptions);
     if (!response.ok) {
-      throw new Error(`Failed to fetch "${canonicalPath}".`);
+      throw new Error(`Failed to fetch "${canonicalPath}". Status code: ${response.status}.`);
     }
     const vfile = new VirtualFile({
       value: '',

--- a/packages/snaps-controllers/src/snaps/location/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.test.ts
@@ -6,6 +6,8 @@ import path from 'path';
 
 import { NpmLocation } from './npm';
 
+fetchMock.enableMocks();
+
 describe('NpmLocation', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
@@ -98,6 +100,13 @@ describe('NpmLocation', () => {
     expect(svgIcon?.startsWith('<svg') && svgIcon.endsWith('</svg>')).toBe(
       true,
     );
+  });
+
+  it('throws if fetch fails', async () => {
+    fetchMock.mockResponse(async () => ({ status: 404, body: 'Not found' }));
+    const location = new NpmLocation(new URL('npm:@metamask/template-snap'));
+    await expect(location.manifest()).rejects.toThrow('Failed to fetch');
+    await expect(location.fetch('foo')).rejects.toThrow('Failed to fetch');
   });
 
   it("can't use custom registries by default", () => {

--- a/packages/snaps-controllers/src/snaps/location/npm.test.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.test.ts
@@ -105,8 +105,12 @@ describe('NpmLocation', () => {
   it('throws if fetch fails', async () => {
     fetchMock.mockResponse(async () => ({ status: 404, body: 'Not found' }));
     const location = new NpmLocation(new URL('npm:@metamask/template-snap'));
-    await expect(location.manifest()).rejects.toThrow('Failed to fetch');
-    await expect(location.fetch('foo')).rejects.toThrow('Failed to fetch');
+    await expect(location.manifest()).rejects.toThrow(
+      'Failed to fetch NPM registry entry. Status code: 404.',
+    );
+    await expect(location.fetch('foo')).rejects.toThrow(
+      'Failed to fetch NPM registry entry. Status code: 404.',
+    );
   });
 
   it("can't use custom registries by default", () => {

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -226,7 +226,7 @@ async function fetchNpmTarball(
     new URL(packageName, registryUrl).toString(),
   );
   if (!packageResponse.ok) {
-    throw new Error('Failed to fetch NPM registry entry');
+    throw new Error(`Failed to fetch NPM registry entry. Status code: ${packageResponse.status}.`);
   }
   const packageMetadata = await packageResponse.json();
 

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -222,9 +222,13 @@ async function fetchNpmTarball(
   registryUrl: URL | string,
   fetchFunction: typeof fetch,
 ): Promise<[ReadableStream, SemVerVersion]> {
-  const packageMetadata = await (
-    await fetchFunction(new URL(packageName, registryUrl).toString())
-  ).json();
+  const packageResponse = await fetchFunction(
+    new URL(packageName, registryUrl).toString(),
+  );
+  if (!packageResponse.ok) {
+    throw new Error('Failed to fetch NPM registry entry');
+  }
+  const packageMetadata = await packageResponse.json();
 
   if (!isObject(packageMetadata)) {
     throw new Error(

--- a/packages/snaps-controllers/src/snaps/location/npm.ts
+++ b/packages/snaps-controllers/src/snaps/location/npm.ts
@@ -226,7 +226,9 @@ async function fetchNpmTarball(
     new URL(packageName, registryUrl).toString(),
   );
   if (!packageResponse.ok) {
-    throw new Error(`Failed to fetch NPM registry entry. Status code: ${packageResponse.status}.`);
+    throw new Error(
+      `Failed to fetch NPM registry entry. Status code: ${packageResponse.status}.`,
+    );
   }
   const packageMetadata = await packageResponse.json();
 


### PR DESCRIPTION
Throw errors if `fetch` fails when trying to fetch snaps, for example if a snap URL results in 404. Previously these functions would return garbage data by trying to parse 404 responses.

Fixes #1226 