### PR TITLE
Improve validation and sanitizing of snap IDs

### DIFF
--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -14,7 +14,7 @@ import {
   HandlerType,
   SnapRpcHookArgs,
   SnapCaveatType,
-  validateSnapId,
+  assertIsValidSnapId,
 } from '@metamask/snaps-utils';
 import {
   isJsonRpcRequest,
@@ -71,7 +71,7 @@ export function validateCaveat(caveat: Caveat<string, any>) {
   }
   const snapIds = Object.keys(caveat.value);
   for (const snapId of snapIds) {
-    validateSnapId(snapId);
+    assertIsValidSnapId(snapId);
   }
 }
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2377,19 +2377,31 @@ describe('SnapController', () => {
         controller.installSnaps(MOCK_ORIGIN, {
           [snapId]: {},
         }),
-      ).rejects.toThrow('Invalid snap ID:');
+      ).rejects.toThrow(
+        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "foo"`,
+      );
     });
 
     it('returns an error if an origin does not have the permission to install a snap', async () => {
-      const controller = getSnapController();
+      const rootMessenger = getControllerMessenger();
+
+      rootMessenger.registerActionHandler(
+        'PermissionController:getPermissions',
+        () => ({}),
+      );
+
+      const controller = getSnapController(
+        getSnapControllerOptions({
+          messenger: getSnapControllerMessenger(rootMessenger),
+        }),
+      );
 
       await expect(
         controller.installSnaps(MOCK_ORIGIN, {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          'npm:bar': {},
+          [MOCK_SNAP_ID]: {},
         }),
       ).rejects.toThrow(
-        `Not authorized to install snap "npm:bar". Request the permission for the snap before attempting to install it.`,
+        `Not authorized to install snap "${MOCK_SNAP_ID}". Request the permission for the snap before attempting to install it.`,
       );
     });
 
@@ -2759,7 +2771,7 @@ describe('SnapController', () => {
           MOCK_LOCAL_SNAP_ID,
           detectSnapLocation(),
         ),
-      ).rejects.toThrow(`Snap "${MOCK_LOCAL_SNAP_ID}" not found`);
+      ).rejects.toThrow(`Snap "${MOCK_LOCAL_SNAP_ID}" not found.`);
     });
 
     it('throws an error if the specified SemVer range is invalid', async () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2378,7 +2378,7 @@ describe('SnapController', () => {
           [snapId]: {},
         }),
       ).rejects.toThrow(
-        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "foo"`,
+        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "foo".`,
       );
     });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2377,7 +2377,7 @@ describe('SnapController', () => {
         controller.installSnaps(MOCK_ORIGIN, {
           [snapId]: {},
         }),
-      ).rejects.toThrow('Invalid snap id. Unknown prefix. Received: "foo".');
+      ).rejects.toThrow('Invalid snap ID:');
     });
 
     it('returns an error if an origin does not have the permission to install a snap', async () => {
@@ -2385,10 +2385,11 @@ describe('SnapController', () => {
 
       await expect(
         controller.installSnaps(MOCK_ORIGIN, {
-          bar: {},
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'npm:bar': {},
         }),
       ).rejects.toThrow(
-        `Not authorized to install snap "bar". Request the permission for the snap before attempting to install it.`,
+        `Not authorized to install snap "npm:bar". Request the permission for the snap before attempting to install it.`,
       );
     });
 
@@ -2750,15 +2751,15 @@ describe('SnapController', () => {
   });
 
   describe('updateSnap', () => {
-    it('throws an error on invalid snap id', async () => {
+    it('throws an error for non installed snap', async () => {
       const detectSnapLocation = loopbackDetect();
       await expect(async () =>
         getSnapController().updateSnap(
           MOCK_ORIGIN,
-          'local:foo',
+          MOCK_LOCAL_SNAP_ID,
           detectSnapLocation(),
         ),
-      ).rejects.toThrow('Snap "local:foo" not found');
+      ).rejects.toThrow(`Snap "${MOCK_LOCAL_SNAP_ID}" not found`);
     });
 
     it('throws an error if the specified SemVer range is invalid', async () => {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -578,7 +578,6 @@ type AddSnapArgs = {
 // When we set a snap, we need all required properties to be present and
 // validated.
 type SetSnapArgs = Omit<AddSnapArgs, 'location'> & {
-  id: ValidatedSnapId;
   manifest: VirtualFile<SnapManifest>;
   files: VirtualFile[];
   /**

--- a/packages/snaps-utils/jest.config.js
+++ b/packages/snaps-utils/jest.config.js
@@ -19,9 +19,9 @@ const coveragePathIgnorePatterns = [
 module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
-      branches: 91.43,
+      branches: 91.41,
       functions: 100,
-      lines: 98.93,
+      lines: 98.94,
       statements: 98.97,
     },
   },

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -40,9 +40,18 @@ describe('createSnapId', () => {
     );
   });
 
-  it('strips whitespace', () => {
-    expect(createSnapId(' local:http://localhost:8000 ')).toBe(
-      'local:http://localhost:8000',
+  it('disallows whitespace', () => {
+    expect(() => createSnapId(' local:http://localhost:8000')).toThrow(
+      'Invalid snap ID.',
+    );
+    expect(() => createSnapId('local:http://localhost:8000 ')).toThrow(
+      'Invalid snap ID.',
+    );
+    expect(() => createSnapId('local:http://localhost:8000\n')).toThrow(
+      'Invalid snap ID.',
+    );
+    expect(() => createSnapId('local:http://localhost:8000\r')).toThrow(
+      'Invalid snap ID.',
     );
   });
 

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -20,12 +20,17 @@ describe('assertIsValidSnapId', () => {
   it.each([undefined, {}, null, true, 2])(
     'throws for non-strings (#%#)',
     (value) => {
-      expect(() => assertIsValidSnapId(value)).toThrow('Invalid snap ID:');
+      expect(() => assertIsValidSnapId(value)).toThrow(
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: ${value}`,
+      );
     },
   );
 
   it('throws for invalid snap id', () => {
-    expect(() => assertIsValidSnapId('foo:bar')).toThrow('Invalid snap ID:');
+    expect(() => assertIsValidSnapId('foo:bar')).toThrow(
+      `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "foo:bar"`,
+    );
   });
 
   it('supports valid NPM IDs', () => {
@@ -40,25 +45,25 @@ describe('assertIsValidSnapId', () => {
     ).not.toThrow();
   });
 
-  it('disallows whitespace', () => {
-    expect(() => assertIsValidSnapId(' local:http://localhost:8000')).toThrow(
-      'Invalid snap ID:',
-    );
-    expect(() => assertIsValidSnapId('local:http://localhost:8000 ')).toThrow(
-      'Invalid snap ID:',
-    );
-    expect(() => assertIsValidSnapId('local:http://localhost:8000\n')).toThrow(
-      'Invalid snap ID:',
-    );
-    expect(() => assertIsValidSnapId('local:http://localhost:8000\r')).toThrow(
-      'Invalid snap ID:',
+  it.each([
+    ' local:http://localhost:8000',
+    'local:http://localhost:8000 ',
+    'local:http://localhost:8000\n',
+    'local:http://localhost:8000\r',
+  ])('disallows whitespace #%#', (value) => {
+    expect(() => assertIsValidSnapId(value)).toThrow(
+      /Invalid snap ID: Expected the value to satisfy a union of `intersection | string`, but received: .\+/u,
     );
   });
 
-  it('disallows non-ASCII symbols', () => {
-    expect(() => assertIsValidSnapId('local:😎')).toThrow('Invalid snap ID:');
-    expect(() => assertIsValidSnapId('local:␡')).toThrow('Invalid snap ID:');
-  });
+  it.each(['local:😎', 'local:␡'])(
+    'disallows non-ASCII symbols #%#',
+    (value) => {
+      expect(() => assertIsValidSnapId(value)).toThrow(
+        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "${value}"`,
+      );
+    },
+  );
 });
 
 describe('isCaipChainId', () => {

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -11,53 +11,53 @@ import {
   isCaipChainId,
   LocalSnapIdStruct,
   NpmSnapIdStruct,
-  createSnapId,
+  assertIsValidSnapId,
   verifyRequestedSnapPermissions,
 } from './snaps';
 import { uri, WALLET_SNAP_PERMISSION_KEY } from './types';
 
-describe('createSnapId', () => {
+describe('assertIsValidSnapId', () => {
   it.each([undefined, {}, null, true, 2])(
     'throws for non-strings (#%#)',
     (value) => {
-      expect(() => createSnapId(value)).toThrow('Invalid snap ID.');
+      expect(() => assertIsValidSnapId(value)).toThrow('Invalid snap ID:');
     },
   );
 
   it('throws for invalid snap id', () => {
-    expect(() => createSnapId('foo:bar')).toThrow('Invalid snap ID.');
+    expect(() => assertIsValidSnapId('foo:bar')).toThrow('Invalid snap ID:');
   });
 
   it('supports valid NPM IDs', () => {
-    expect(createSnapId('npm:@metamask/test-snap-bip44')).toBe(
-      'npm:@metamask/test-snap-bip44',
-    );
+    expect(() =>
+      assertIsValidSnapId('npm:@metamask/test-snap-bip44'),
+    ).not.toThrow();
   });
 
   it('supports valid local IDs', () => {
-    expect(createSnapId('local:http://localhost:8000')).toBe(
-      'local:http://localhost:8000',
-    );
+    expect(() =>
+      assertIsValidSnapId('local:http://localhost:8000'),
+    ).not.toThrow();
   });
 
   it('disallows whitespace', () => {
-    expect(() => createSnapId(' local:http://localhost:8000')).toThrow(
-      'Invalid snap ID.',
+    expect(() => assertIsValidSnapId(' local:http://localhost:8000')).toThrow(
+      'Invalid snap ID:',
     );
-    expect(() => createSnapId('local:http://localhost:8000 ')).toThrow(
-      'Invalid snap ID.',
+    expect(() => assertIsValidSnapId('local:http://localhost:8000 ')).toThrow(
+      'Invalid snap ID:',
     );
-    expect(() => createSnapId('local:http://localhost:8000\n')).toThrow(
-      'Invalid snap ID.',
+    expect(() => assertIsValidSnapId('local:http://localhost:8000\n')).toThrow(
+      'Invalid snap ID:',
     );
-    expect(() => createSnapId('local:http://localhost:8000\r')).toThrow(
-      'Invalid snap ID.',
+    expect(() => assertIsValidSnapId('local:http://localhost:8000\r')).toThrow(
+      'Invalid snap ID:',
     );
   });
 
   it('disallows non-ASCII symbols', () => {
-    expect(() => createSnapId('local:😎')).toThrow('Invalid snap ID.');
-    expect(() => createSnapId('local:␡')).toThrow('Invalid snap ID.');
+    expect(() => assertIsValidSnapId('local:😎')).toThrow('Invalid snap ID:');
+    expect(() => assertIsValidSnapId('local:␡')).toThrow('Invalid snap ID:');
   });
 });
 

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -22,14 +22,14 @@ describe('assertIsValidSnapId', () => {
     (value) => {
       expect(() => assertIsValidSnapId(value)).toThrow(
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: ${value}`,
+        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: ${value}.`,
       );
     },
   );
 
   it('throws for invalid snap id', () => {
     expect(() => assertIsValidSnapId('foo:bar')).toThrow(
-      `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "foo:bar"`,
+      `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "foo:bar".`,
     );
   });
 
@@ -52,7 +52,7 @@ describe('assertIsValidSnapId', () => {
     'local:http://localhost:8000\r',
   ])('disallows whitespace #%#', (value) => {
     expect(() => assertIsValidSnapId(value)).toThrow(
-      /Invalid snap ID: Expected the value to satisfy a union of `intersection | string`, but received: .\+/u,
+      /Invalid snap ID: Expected the value to satisfy a union of `intersection \| string`, but received: .+\./u,
     );
   });
 
@@ -60,7 +60,7 @@ describe('assertIsValidSnapId', () => {
     'disallows non-ASCII symbols #%#',
     (value) => {
       expect(() => assertIsValidSnapId(value)).toThrow(
-        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "${value}"`,
+        `Invalid snap ID: Expected the value to satisfy a union of \`intersection | string\`, but received: "${value}".`,
       );
     },
   );

--- a/packages/snaps-utils/src/snaps.test.ts
+++ b/packages/snaps-utils/src/snaps.test.ts
@@ -11,33 +11,45 @@ import {
   isCaipChainId,
   LocalSnapIdStruct,
   NpmSnapIdStruct,
-  validateSnapId,
+  createSnapId,
   verifyRequestedSnapPermissions,
 } from './snaps';
-import { SnapIdPrefixes, uri, WALLET_SNAP_PERMISSION_KEY } from './types';
+import { uri, WALLET_SNAP_PERMISSION_KEY } from './types';
 
-describe('validateSnapId', () => {
+describe('createSnapId', () => {
   it.each([undefined, {}, null, true, 2])(
     'throws for non-strings (#%#)',
     (value) => {
-      expect(() => validateSnapId(value)).toThrow(
-        'Invalid snap id. Not a string.',
-      );
+      expect(() => createSnapId(value)).toThrow('Invalid snap ID.');
     },
   );
 
   it('throws for invalid snap id', () => {
-    expect(() => validateSnapId('foo:bar')).toThrow(
-      'Invalid snap id. Unknown prefix.',
+    expect(() => createSnapId('foo:bar')).toThrow('Invalid snap ID.');
+  });
+
+  it('supports valid NPM IDs', () => {
+    expect(createSnapId('npm:@metamask/test-snap-bip44')).toBe(
+      'npm:@metamask/test-snap-bip44',
     );
   });
 
-  it.each(Object.values(SnapIdPrefixes))(
-    'returns with "%s" prefix',
-    (prefix) => {
-      expect(() => validateSnapId(`${prefix}bar`)).not.toThrow();
-    },
-  );
+  it('supports valid local IDs', () => {
+    expect(createSnapId('local:http://localhost:8000')).toBe(
+      'local:http://localhost:8000',
+    );
+  });
+
+  it('strips whitespace', () => {
+    expect(createSnapId(' local:http://localhost:8000 ')).toBe(
+      'local:http://localhost:8000',
+    );
+  });
+
+  it('disallows non-ASCII symbols', () => {
+    expect(() => createSnapId('local:😎')).toThrow('Invalid snap ID.');
+    expect(() => createSnapId('local:␡')).toThrow('Invalid snap ID.');
+  });
 });
 
 describe('isCaipChainId', () => {

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -253,7 +253,7 @@ export const LocalSnapIdStruct = refine(
   'local Snap Id',
   (value) => {
     if (!value.startsWith(SnapIdPrefixes.local)) {
-      return `Expected local Snap ID, got "${value}".`;
+      return `Expected local snap ID, got "${value}".`;
     }
 
     const [error] = validate(

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -4,12 +4,18 @@ import {
   PermissionConstraint,
 } from '@metamask/permission-controller';
 import { BlockReason } from '@metamask/snaps-registry';
-import { assert, Json, SemVerVersion, isObject, Opaque } from '@metamask/utils';
+import {
+  assert,
+  Json,
+  SemVerVersion,
+  isObject,
+  Opaque,
+  assertStruct,
+} from '@metamask/utils';
 import { base64 } from '@scure/base';
 import { SerializedEthereumRpcError } from 'eth-rpc-errors/dist/classes';
 import stableStringify from 'fast-json-stable-stringify';
 import {
-  create,
   empty,
   enums,
   intersection,
@@ -309,19 +315,17 @@ export function getSnapPrefix(snapId: string): SnapIdPrefixes {
   }
   throw new Error(`Invalid or no prefix found for "${snapId}"`);
 }
+
 /**
- * Validates and coerces an input to be a valid Snap ID.
+ * Assert that the given value is a valid snap ID.
  *
- * @param snapId - The snap ID.
- * @returns The potentially coerced snap ID.
- * @throws If the snap ID is invalid and cannot be coerced to valid
+ * @param value - The value to check.
+ * @throws If the value is not a valid snap ID.
  */
-export function createSnapId(snapId: unknown): ValidatedSnapId {
-  try {
-    return create(snapId, SnapIdStruct) as ValidatedSnapId;
-  } catch (error) {
-    throw new Error(`Invalid snap ID. Validation error: ${error.message}`);
-  }
+export function assertIsValidSnapId(
+  value: unknown,
+): asserts value is ValidatedSnapId {
+  assertStruct(value, SnapIdStruct, 'Invalid snap ID');
 }
 
 /**

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -9,7 +9,6 @@ import { base64 } from '@scure/base';
 import { SerializedEthereumRpcError } from 'eth-rpc-errors/dist/classes';
 import stableStringify from 'fast-json-stable-stringify';
 import {
-  coerce,
   create,
   empty,
   enums,
@@ -232,23 +231,10 @@ export function validateSnapShasum(
   }
 }
 
-/**
- * Sanitizes a potential snap id string.
- *
- * @param snapId - A potential snap id.
- * @returns A sanitized potential snap id.
- */
-function sanitizeSnapId(snapId: string) {
-  return snapId.replace(/\s/gu, '');
-}
-
 export const LOCALHOST_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'] as const;
 
-const ASCIIString = pattern(string(), /^[\x21-\x7E]*$/u);
-
-export const BaseSnapIdStruct = coerce(ASCIIString, string(), (value) =>
-  sanitizeSnapId(value),
-);
+// Require snap ids to only consist of printable ASCII characters
+export const BaseSnapIdStruct = pattern(string(), /^[\x21-\x7E]*$/u);
 
 const LocalSnapIdSubUrlStruct = uri({
   protocol: enums(['http:', 'https:']),

--- a/packages/snaps-utils/src/test-utils/snap.ts
+++ b/packages/snaps-utils/src/test-utils/snap.ts
@@ -1,6 +1,12 @@
 import { SemVerVersion } from '@metamask/utils';
 
-import { PersistedSnap, Snap, SnapStatus, TruncatedSnap } from '../snaps';
+import {
+  PersistedSnap,
+  Snap,
+  SnapStatus,
+  TruncatedSnap,
+  ValidatedSnapId,
+} from '../snaps';
 import { MakeSemVer } from './common';
 import {
   DEFAULT_SNAP_BUNDLE,
@@ -8,8 +14,9 @@ import {
   getSnapManifest,
 } from './manifest';
 
-export const MOCK_SNAP_ID = 'npm:@metamask/example-snap';
-export const MOCK_LOCAL_SNAP_ID = 'local:http://localhost:8080';
+export const MOCK_SNAP_ID = 'npm:@metamask/example-snap' as ValidatedSnapId;
+export const MOCK_LOCAL_SNAP_ID =
+  'local:http://localhost:8080' as ValidatedSnapId;
 export const MOCK_ORIGIN = 'example.com';
 
 type GetPersistedSnapObjectOptions = Partial<MakeSemVer<PersistedSnap>>;


### PR DESCRIPTION
Replaces existing validation of snap IDs with Superstruct-based validation that leverages existing structs. Also adds a base struct to the existing snap ID structs that enforces strictly printable ASCII characters to be part of the ID string. This enforces no whitespaces or otherwise invisible characters.

Fixes https://github.com/MetaMask/MetaMask-planning/issues/351