### PR TITLE
Upload coverage results in a single job

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -137,12 +137,17 @@ jobs:
           key: test-build-${{ runner.os }}-${{ matrix.node-version }}-${{ github.sha }}
       - run: yarn --immutable --immutable-cache
       - run: yarn workspace ${{ matrix.package-name }} run test:ci
+      - name: Get coverage folder
+        id: get-coverage-folder
+        run: |
+          echo "coverage-folder=$(yarn workspaces list --json | grep ${{ matrix.package-name }} | jq -r '.location')/coverage" >> "$GITHUB_OUTPUT"
+        shell: bash
       - name: Upload coverage artifact
         if: ${{ matrix.node-version == '16.x' }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: packages/${{ matrix.package-name }}/coverage/**/coverage-final.json
+          path: ${{ steps.get-coverage-folder.outputs.coverage-folder }}/**/coverage-final.json
           if-no-files-found: error
           retention-days: 1
       - name: Require clean working directory

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -140,6 +140,7 @@ jobs:
       - name: Get coverage folder
         id: get-coverage-folder
         run: |
+          echo "stub" >> stub
           echo "coverage-folder=$(yarn workspaces list --json | grep ${{ matrix.package-name }} | jq -r '.location')/coverage" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Upload coverage artifact
@@ -147,7 +148,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: ${{ steps.get-coverage-folder.outputs.coverage-folder }}/**/coverage-final.json
+          path: |
+            stub
+            ${{ steps.get-coverage-folder.outputs.coverage-folder }}/**/coverage-final.json
           if-no-files-found: warn
           retention-days: 1
       - name: Require clean working directory
@@ -163,7 +166,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v3
       - name: Download coverage artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -166,12 +166,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
+      - uses: actions/checkout@v3
       - name: Download coverage artifact
         uses: actions/download-artifact@v3
         with:
           name: coverage
       - name: Upload coverage results
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        with:
+          files: packages/**/coverage-final.json
 
   platform-compatibility-test:
     name: Test platform compatibility

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -137,8 +137,14 @@ jobs:
           key: test-build-${{ runner.os }}-${{ matrix.node-version }}-${{ github.sha }}
       - run: yarn --immutable --immutable-cache
       - run: yarn workspace ${{ matrix.package-name }} run test:ci
-      - name: Upload coverage results
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+      - name: Upload coverage artifact
+        if: ${{ matrix.node-version == '16.x' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: packages/${{ matrix.package-name }}/coverage/**/coverage-final.json
+          if-no-files-found: error
+          retention-days: 1
       - name: Require clean working directory
         shell: bash
         run: |
@@ -146,6 +152,21 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
+
+  upload-coverage:
+    name: Upload coverage to Codecov
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+      - name: Display structure of downloaded files
+        run: ls -R
+  #      - name: Upload coverage results
+  #        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
 
   platform-compatibility-test:
     name: Test platform compatibility

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           name: coverage
           path: ${{ steps.get-coverage-folder.outputs.coverage-folder }}/**/coverage-final.json
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 1
       - name: Require clean working directory
         shell: bash

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -170,10 +170,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage
-      - name: Display structure of downloaded files
-        run: ls -R
-  #      - name: Upload coverage results
-  #        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+      - name: Upload coverage results
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
 
   platform-compatibility-test:
     name: Test platform compatibility


### PR DESCRIPTION
Rather than uploading coverage after each test run, we now only upload it after all tests have completed. Hopefully this helps with Codecov's processing time.

Depends on #1254.