### PR TITLE
[WIP] Combine snap installation in one popup

### DIFF
--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -104,6 +104,10 @@ const specificationBuilder: PermissionSpecificationBuilder<
         });
       }
     },
+    sideEffect: {
+      onPermitted: permittedHandler,
+      onFailure: async () => Promise.resolve(),
+    },
   };
 };
 
@@ -190,4 +194,20 @@ export function getInvokeSnapImplementation({
       handler: HandlerType.OnRpcRequest,
     })) as Json;
   };
+}
+
+/**
+ * This is a test.
+ *
+ * @param options0 - Test.
+ * @param options0.requestData - Test.
+ * @param options0.callAction - Test.
+ */
+async function permittedHandler({ requestData, callAction }: any) {
+  console.log(requestData);
+  await callAction(
+    'SnapController:install',
+    requestData.metadata.origin,
+    requestData.permissions[WALLET_SNAP_PERMISSION_KEY].caveats[0].value,
+  );
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1,4 +1,7 @@
-import { AddApprovalRequest } from '@metamask/approval-controller';
+import {
+  AddApprovalRequest,
+  UpdateRequestState,
+} from '@metamask/approval-controller';
 import {
   BaseControllerV2 as BaseController,
   RestrictedControllerMessenger,
@@ -244,6 +247,11 @@ type RollbackSnapshot = {
   newVersion: string;
 };
 
+type PendingApproval = {
+  id: string;
+  promise: Promise<unknown>;
+};
+
 // Controller Messenger Actions
 
 /**
@@ -470,7 +478,8 @@ export type AllowedActions =
   | ExecuteSnapAction
   | TerminateAllSnapsAction
   | TerminateSnapAction
-  | UpdateCaveat;
+  | UpdateCaveat
+  | UpdateRequestState;
 
 export type AllowedEvents = ExecutionServiceEvents;
 
@@ -1600,17 +1609,6 @@ export class SnapController extends BaseController<
           );
         }
 
-        // const permissions = this.messagingSystem.call(
-        //   'PermissionController:getPermissions',
-        //   origin,
-        // ) as SubjectPermissions<PermissionConstraint>;
-
-        // if (!isSnapPermitted(permissions, snapId)) {
-        //   throw ethErrors.provider.unauthorized(
-        //     `Not authorized to install snap "${snapId}". Request the permission for the snap before attempting to install it.`,
-        //   );
-        // }
-
         const isUpdate = pendingUpdates.includes(snapId);
 
         if (isUpdate && this.#isValidUpdate(snapId, version)) {
@@ -1662,27 +1660,11 @@ export class SnapController extends BaseController<
   ): Promise<ProcessSnapResult> {
     validateSnapId(snapId);
 
-    const confirmationId = nanoid();
-
-    const confirmation = this.messagingSystem.call(
-      'ApprovalController:addRequest',
-      {
-        origin,
-        id: confirmationId,
-        type: SNAP_APPROVAL_INSTALL,
-        requestData: {
-          // Mirror previous installation metadata
-          metadata: { id: confirmationId, origin: snapId, dappOrigin: origin },
-          snapId,
-        },
-        requestState: {
-          loading: true,
-          error: false,
-          Permissions: null,
-        },
-      },
-      true,
-    );
+    const pendingApproval = this.#createApproval({
+      origin,
+      snapId,
+      type: SNAP_APPROVAL_INSTALL,
+    });
 
     const location = this.#detectSnapLocation(snapId, {
       versionRange,
@@ -1728,7 +1710,7 @@ export class SnapController extends BaseController<
         location,
       });
 
-      await this.authorize(snapId, confirmation, confirmationId);
+      await this.authorize(snapId, pendingApproval);
       await this.#startSnap({
         snapId,
         sourceCode,
@@ -1743,6 +1725,46 @@ export class SnapController extends BaseController<
 
       throw error;
     }
+  }
+
+  #createApproval({
+    origin,
+    snapId,
+    type,
+  }: {
+    origin: string;
+    snapId: ValidatedSnapId;
+    type: string;
+  }): PendingApproval {
+    const id = nanoid();
+    const promise = this.messagingSystem.call(
+      'ApprovalController:addRequest',
+      {
+        origin,
+        id,
+        type,
+        requestData: {
+          // Mirror previous installation metadata
+          metadata: { id, origin: snapId, dappOrigin: origin },
+          snapId,
+        },
+        requestState: {
+          loading: true,
+          error: false,
+          permissions: null,
+        },
+      },
+      true,
+    );
+
+    return { id, promise };
+  }
+
+  #updateApproval(id: string, requestState: Record<string, Json>) {
+    this.messagingSystem.call('ApprovalController:updateRequestState', {
+      id,
+      requestState,
+    });
   }
 
   /**
@@ -1776,6 +1798,13 @@ export class SnapController extends BaseController<
         `Received invalid snap version range: "${newVersionRange}".`,
       );
     }
+
+    const pendingApproval = this.#createApproval({
+      origin,
+      snapId,
+      type: SNAP_APPROVAL_UPDATE,
+    });
+
     const newSnap = await this.#fetchSnap(snapId, location);
     const newVersion = newSnap.manifest.result.version;
     if (!gtVersion(newVersion, snap.version)) {
@@ -1794,30 +1823,23 @@ export class SnapController extends BaseController<
       newSnap.manifest.result.initialPermissions,
     );
 
+    this.#validateSnapPermissions(processedPermissions);
+
     const { newPermissions, unusedPermissions, approvedPermissions } =
       this.#calculatePermissionsChange(snapId, processedPermissions);
 
-    const id = nanoid();
+    this.#updateApproval(pendingApproval.id, {
+      permissions: newPermissions,
+      newVersion: newSnap.manifest.result.version,
+      newPermissions,
+      approvedPermissions,
+      unusedPermissions,
+      loading: false,
+      error: false,
+    });
+
     const { permissions: approvedNewPermissions, ...requestData } =
-      (await this.messagingSystem.call(
-        'ApprovalController:addRequest',
-        {
-          origin,
-          id,
-          type: SNAP_APPROVAL_UPDATE,
-          requestData: {
-            // First two keys mirror installation params
-            metadata: { id, origin: snapId, dappOrigin: origin },
-            permissions: newPermissions,
-            snapId,
-            newVersion: newSnap.manifest.result.version,
-            newPermissions,
-            approvedPermissions,
-            unusedPermissions,
-          },
-        },
-        true,
-      )) as PermissionsRequest;
+      (await pendingApproval.promise) as PermissionsRequest;
 
     if (this.isRunning(snapId)) {
       await this.stopSnap(snapId, SnapStatusEvents.Stop);
@@ -2211,22 +2233,40 @@ export class SnapController extends BaseController<
     );
   }
 
+  #validateSnapPermissions(
+    processedPermissions: Record<string, Pick<PermissionConstraint, 'caveats'>>,
+  ) {
+    const excludedPermissionErrors = Object.keys(processedPermissions).reduce<
+      string[]
+    >((errors, permission) => {
+      if (hasProperty(this.#excludedPermissions, permission)) {
+        errors.push(this.#excludedPermissions[permission]);
+      }
+
+      return errors;
+    }, []);
+
+    assert(
+      excludedPermissionErrors.length === 0,
+      `One or more permissions are not allowed:\n${excludedPermissionErrors.join(
+        '\n',
+      )}`,
+    );
+  }
+
   /**
    * Initiates a request for the given snap's initial permissions.
    * Must be called in order. See processRequestedSnap.
    *
    * This function is not hash private yet because of tests.
    *
-   * @param origin - The origin of the install request.
    * @param snapId - The id of the Snap.
-   * @param permissionRequest
-   * @param confirmationId
+   * @param pendingApproval - Pending approval to update.
    * @returns The snap's approvedPermissions.
    */
   private async authorize(
     snapId: SnapId,
-    permissionRequest: any,
-    confirmationId: string,
+    pendingApproval: PendingApproval,
   ): Promise<void> {
     log(`Authorizing snap: ${snapId}`);
     const snapsState = this.state.snaps;
@@ -2237,35 +2277,16 @@ export class SnapController extends BaseController<
       const processedPermissions =
         this.#processSnapPermissions(initialPermissions);
 
-      const excludedPermissionErrors = Object.keys(processedPermissions).reduce<
-        string[]
-      >((errors, permission) => {
-        if (hasProperty(this.#excludedPermissions, permission)) {
-          errors.push(this.#excludedPermissions[permission]);
-        }
+      this.#validateSnapPermissions(processedPermissions);
 
-        return errors;
-      }, []);
-
-      assert(
-        excludedPermissionErrors.length === 0,
-        `One or more permissions are not allowed:\n${excludedPermissionErrors.join(
-          '\n',
-        )}`,
-      );
-
-      // @ts-expect-error Not updated
-      await this.messagingSystem.call('ApprovalController:updateRequestState', {
-        id: confirmationId,
-        requestState: {
-          loading: false,
-          error: false,
-          permissions: processedPermissions,
-        },
+      this.#updateApproval(pendingApproval.id, {
+        loading: false,
+        error: false,
+        permissions: processedPermissions,
       });
 
       const { permissions: approvedPermissions, ...requestData } =
-        await permissionRequest;
+        (await pendingApproval.promise) as PermissionsRequest;
 
       if (isNonEmptyArray(Object.keys(approvedPermissions))) {
         this.messagingSystem.call('PermissionController:grantPermissions', {

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1601,16 +1601,16 @@ export class SnapController extends BaseController<
           );
         }
 
-        const permissions = this.messagingSystem.call(
-          'PermissionController:getPermissions',
-          origin,
-        ) as SubjectPermissions<PermissionConstraint>;
+        // const permissions = this.messagingSystem.call(
+        //   'PermissionController:getPermissions',
+        //   origin,
+        // ) as SubjectPermissions<PermissionConstraint>;
 
-        if (!isSnapPermitted(permissions, snapId)) {
-          throw ethErrors.provider.unauthorized(
-            `Not authorized to install snap "${snapId}". Request the permission for the snap before attempting to install it.`,
-          );
-        }
+        // if (!isSnapPermitted(permissions, snapId)) {
+        //   throw ethErrors.provider.unauthorized(
+        //     `Not authorized to install snap "${snapId}". Request the permission for the snap before attempting to install it.`,
+        //   );
+        // }
 
         const isUpdate = pendingUpdates.includes(snapId);
 


### PR DESCRIPTION
This allows MetaMask extension to display the snap installation flow in one popup and makes `wallet_requestPermissions` install the snaps