### PR TITLE
Bump `key-tree` to `7.0.0`

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -10,7 +10,7 @@ module.exports = deepmerge(baseConfig, {
   ],
   coverageThreshold: {
     global: {
-      branches: 84.95,
+      branches: 85.21,
       functions: 93.5,
       lines: 94.37,
       statements: 94.4,

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/browser-passworder": "^4.0.2",
-    "@metamask/key-tree": "^6.2.1",
+    "@metamask/key-tree": "^7.0.0",
     "@metamask/permission-controller": "^3.0.0",
     "@metamask/snaps-ui": "^0.30.0",
     "@metamask/snaps-utils": "^0.30.0",

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -1,4 +1,9 @@
-import { BIP32Node, JsonSLIP10Node, SLIP10Node } from '@metamask/key-tree';
+import {
+  BIP32Node,
+  JsonSLIP10Node,
+  SLIP10Node,
+  SLIP10PathNode,
+} from '@metamask/key-tree';
 import {
   Caveat,
   PermissionConstraint,
@@ -204,13 +209,17 @@ export function getBip32EntropyImplementation({
     const { params } = args;
     assert(params);
 
+    const prefix = params.curve === 'ed25519' ? 'slip10' : 'bip32';
+
     const node = await SLIP10Node.fromDerivationPath({
       curve: params.curve,
       derivationPath: [
         await getMnemonic(),
         ...params.path
           .slice(1)
-          .map<BIP32Node>((index) => `bip32:${index}` as BIP32Node),
+          .map<BIP32Node | SLIP10PathNode>(
+            (index) => `${prefix}:${index}` as BIP32Node | SLIP10PathNode,
+          ),
       ],
     });
 

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -81,7 +81,7 @@
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.1",
     "@metamask/eslint-config-typescript": "^11.0.0",
-    "@metamask/key-tree": "^6.2.1",
+    "@metamask/key-tree": "^7.0.0",
     "@metamask/post-message-stream": "^6.1.0",
     "@types/jest": "^27.5.1",
     "@types/mocha": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,9 +2752,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/key-tree@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "@metamask/key-tree@npm:6.2.1"
+"@metamask/key-tree@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@metamask/key-tree@npm:7.0.0"
   dependencies:
     "@metamask/scure-bip39": ^2.1.0
     "@metamask/utils": ^3.3.0
@@ -2762,7 +2762,7 @@ __metadata:
     "@noble/hashes": ^1.0.0
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
-  checksum: 78931e20a2c933535c17d21e092dbc66e3e96f3c171a6814af51830b7774dd3b4059326180a3b1f52e48a258254a7ea70a31d0c335bf24a8c4250f8d196bc7ba
+  checksum: e3b8371ba41766e1936ff0b0b34c46b7a1297e51fe177246ae6446c4f15a6601a6ed4fc5d01d0594e8b1e9b1682096900f7ab4e7e15df94041ec025116a635b9
   languageName: node
   linkType: hard
 
@@ -2874,7 +2874,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/key-tree": ^6.2.1
+    "@metamask/key-tree": ^7.0.0
     "@metamask/permission-controller": ^3.0.0
     "@metamask/snaps-ui": ^0.30.0
     "@metamask/snaps-utils": ^0.30.0
@@ -3314,7 +3314,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/key-tree": ^6.2.1
+    "@metamask/key-tree": ^7.0.0
     "@metamask/permission-controller": ^3.0.0
     "@metamask/post-message-stream": ^6.1.0
     "@metamask/providers": ^10.2.1


### PR DESCRIPTION
Bumps `key-tree` to `7.0.0` and handles a breaking change.