### PR TITLE
Ensure that same method hooks are used in type and builder

### DIFF
--- a/packages/rpc-methods/jest.config.js
+++ b/packages/rpc-methods/jest.config.js
@@ -11,7 +11,7 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 84.95,
-      functions: 93.5,
+      functions: 94.73,
       lines: 94.37,
       statements: 94.4,
     },

--- a/packages/rpc-methods/src/permitted/getSnaps.ts
+++ b/packages/rpc-methods/src/permitted/getSnaps.ts
@@ -5,6 +5,12 @@ import {
   JsonRpcEngineEndCallback,
 } from '@metamask/types';
 
+import { MethodHooksObject } from '../utils';
+
+const hookNames: MethodHooksObject<GetSnapsHooks> = {
+  getSnaps: true,
+};
+
 /**
  * `wallet_getSnaps` gets the requester's permitted and installed Snaps.
  */
@@ -15,9 +21,7 @@ export const getSnapsHandler: PermittedHandlerExport<
 > = {
   methodNames: ['wallet_getSnaps'],
   implementation: getSnapsImplementation,
-  hookNames: {
-    getSnaps: true,
-  },
+  hookNames,
 };
 
 export type GetSnapsHooks = {

--- a/packages/rpc-methods/src/permitted/requestSnaps.ts
+++ b/packages/rpc-methods/src/permitted/requestSnaps.ts
@@ -18,11 +18,18 @@ import { hasProperty, isObject, Json } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
 import { WALLET_SNAP_PERMISSION_KEY } from '../restricted/invokeSnap';
+import { MethodHooksObject } from '../utils';
 import {
   handleInstallSnaps,
   InstallSnapsHook,
   InstallSnapsResult,
 } from './common/snapInstallation';
+
+const hookNames: MethodHooksObject<RequestSnapsHooks> = {
+  installSnaps: true,
+  requestPermissions: true,
+  getPermissions: true,
+};
 
 /**
  * `wallet_requestSnaps` installs the requested Snaps and requests permission to use them if necessary.
@@ -34,11 +41,7 @@ export const requestSnapsHandler: PermittedHandlerExport<
 > = {
   methodNames: ['wallet_requestSnaps'],
   implementation: requestSnapsImplementation,
-  hookNames: {
-    installSnaps: true,
-    requestPermissions: true,
-    getPermissions: true,
-  },
+  hookNames,
 };
 
 export type RequestSnapsHooks = {

--- a/packages/rpc-methods/src/restricted/dialog.ts
+++ b/packages/rpc-methods/src/restricted/dialog.ts
@@ -21,7 +21,7 @@ import {
   union,
 } from 'superstruct';
 
-import { EnumToUnion, enumValue } from '../utils';
+import { EnumToUnion, enumValue, MethodHooksObject } from '../utils';
 
 const methodName = 'snap_dialog';
 
@@ -94,12 +94,14 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<DialogMethodHooks> = {
+  showDialog: true,
+};
+
 export const dialogBuilder = Object.freeze({
   targetKey: methodName,
   specificationBuilder,
-  methodHooks: {
-    showDialog: true,
-  },
+  methodHooks,
 } as const);
 
 // Note: We use `type` here instead of `object` because `type` does not validate

--- a/packages/rpc-methods/src/restricted/getBip32Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip32Entropy.ts
@@ -23,7 +23,7 @@ import { Json, NonEmptyArray, assertStruct, assert } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 import { array, size, type } from 'superstruct';
 
-import { isEqual } from '../utils';
+import { isEqual, MethodHooksObject } from '../utils';
 
 const targetKey = 'snap_getBip32Entropy';
 
@@ -121,13 +121,15 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<GetBip32EntropyMethodHooks> = {
+  getMnemonic: true,
+  getUnlockPromise: true,
+};
+
 export const getBip32EntropyBuilder = Object.freeze({
   targetKey,
   specificationBuilder,
-  methodHooks: {
-    getMnemonic: true,
-    getUnlockPromise: true,
-  },
+  methodHooks,
 } as const);
 
 /**

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -1,6 +1,5 @@
 import { BIP32Node, SLIP10Node } from '@metamask/key-tree';
 import {
-  Caveat,
   PermissionSpecificationBuilder,
   PermissionType,
   PermissionValidatorConstraint,
@@ -8,15 +7,13 @@ import {
   ValidPermissionSpecification,
 } from '@metamask/permission-controller';
 import {
-  Bip32Entropy,
   bip32entropy,
   Bip32PathStruct,
   SnapCaveatType,
-  SnapGetBip32EntropyPermissionsStruct,
 } from '@metamask/snaps-utils';
 import { NonEmptyArray, assertStruct } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
-import { boolean, enums, object, optional, type } from 'superstruct';
+import { boolean, enums, object, optional } from 'superstruct';
 
 import { MethodHooksObject } from '../utils';
 
@@ -61,24 +58,6 @@ export const Bip32PublicKeyArgsStruct = bip32entropy(
     compressed: optional(boolean()),
   }),
 );
-
-/**
- * Validate the path values associated with a caveat. This validates that the
- * value is a non-empty array with valid derivation paths and curves.
- *
- * @param caveat - The caveat to validate.
- * @throws If the value is invalid.
- */
-export function validateCaveatPaths(
-  caveat: Caveat<string, any>,
-): asserts caveat is Caveat<string, Bip32Entropy[]> {
-  assertStruct(
-    caveat,
-    type({ value: SnapGetBip32EntropyPermissionsStruct }),
-    'Invalid BIP-32 public key caveat',
-    ethErrors.rpc.internal,
-  );
-}
 
 /**
  * The specification builder for the `snap_getBip32PublicKey` permission.

--- a/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
+++ b/packages/rpc-methods/src/restricted/getBip32PublicKey.ts
@@ -18,6 +18,8 @@ import { NonEmptyArray, assertStruct } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 import { boolean, enums, object, optional, type } from 'superstruct';
 
+import { MethodHooksObject } from '../utils';
+
 const targetKey = 'snap_getBip32PublicKey';
 
 export type GetBip32PublicKeyMethodHooks = {
@@ -110,13 +112,15 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<GetBip32PublicKeyMethodHooks> = {
+  getMnemonic: true,
+  getUnlockPromise: true,
+};
+
 export const getBip32PublicKeyBuilder = Object.freeze({
   targetKey,
   specificationBuilder,
-  methodHooks: {
-    getMnemonic: true,
-    getUnlockPromise: true,
-  },
+  methodHooks,
 } as const);
 
 /**

--- a/packages/rpc-methods/src/restricted/getBip44Entropy.ts
+++ b/packages/rpc-methods/src/restricted/getBip44Entropy.ts
@@ -18,6 +18,8 @@ import {
 } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
+import { MethodHooksObject } from '../utils';
+
 const targetKey = 'snap_getBip44Entropy';
 
 export type GetBip44EntropyMethodHooks = {
@@ -132,13 +134,15 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<GetBip44EntropyMethodHooks> = {
+  getMnemonic: true,
+  getUnlockPromise: true,
+};
+
 export const getBip44EntropyBuilder = Object.freeze({
   targetKey,
   specificationBuilder,
-  methodHooks: {
-    getMnemonic: true,
-    getUnlockPromise: true,
-  },
+  methodHooks,
 } as const);
 
 /**

--- a/packages/rpc-methods/src/restricted/getEntropy.ts
+++ b/packages/rpc-methods/src/restricted/getEntropy.ts
@@ -9,7 +9,7 @@ import { assertStruct, Hex, NonEmptyArray } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 import { Infer, literal, object, optional, string } from 'superstruct';
 
-import { deriveEntropy } from '../utils';
+import { deriveEntropy, MethodHooksObject } from '../utils';
 
 const targetKey = 'snap_getEntropy';
 
@@ -54,13 +54,15 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<GetEntropyHooks> = {
+  getMnemonic: true,
+  getUnlockPromise: true,
+};
+
 export const getEntropyBuilder = Object.freeze({
   targetKey,
   specificationBuilder,
-  methodHooks: {
-    getMnemonic: true,
-    getUnlockPromise: true,
-  },
+  methodHooks,
 } as const);
 
 export type GetEntropyHooks = {

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -26,6 +26,8 @@ import {
 import { ethErrors } from 'eth-rpc-errors';
 import { nanoid } from 'nanoid';
 
+import { MethodHooksObject } from '../utils';
+
 export const WALLET_SNAP_PERMISSION_KEY = 'wallet_snap';
 
 export type InvokeSnapMethodHooks = {
@@ -107,13 +109,15 @@ const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<InvokeSnapMethodHooks> = {
+  getSnap: true,
+  handleSnapRpcRequest: true,
+};
+
 export const invokeSnapBuilder = Object.freeze({
   targetKey: WALLET_SNAP_PERMISSION_KEY,
   specificationBuilder,
-  methodHooks: {
-    getSnap: true,
-    handleSnapRpcRequest: true,
-  },
+  methodHooks,
 } as const);
 
 export const InvokeSnapCaveatSpecifications: Record<

--- a/packages/rpc-methods/src/restricted/manageState.ts
+++ b/packages/rpc-methods/src/restricted/manageState.ts
@@ -16,7 +16,7 @@ import {
 } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
-import { deriveEntropy, EnumToUnion } from '../utils';
+import { deriveEntropy, EnumToUnion, MethodHooksObject } from '../utils';
 
 // The salt used for SIP-6-based entropy derivation.
 export const STATE_ENCRYPTION_SALT = 'snap_manageState encryption';
@@ -94,16 +94,18 @@ export const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<ManageStateMethodHooks> = {
+  getMnemonic: true,
+  getUnlockPromise: true,
+  clearSnapState: true,
+  getSnapState: true,
+  updateSnapState: true,
+};
+
 export const manageStateBuilder = Object.freeze({
   targetKey: methodName,
   specificationBuilder,
-  methodHooks: {
-    getMnemonic: true,
-    getUnlockPromise: true,
-    clearSnapState: true,
-    getSnapState: true,
-    updateSnapState: true,
-  },
+  methodHooks,
 } as const);
 
 export enum ManageStateOperation {

--- a/packages/rpc-methods/src/restricted/notify.ts
+++ b/packages/rpc-methods/src/restricted/notify.ts
@@ -7,7 +7,7 @@ import {
 import { NonEmptyArray, isObject } from '@metamask/utils';
 import { ethErrors } from 'eth-rpc-errors';
 
-import { EnumToUnion } from '../utils';
+import { EnumToUnion, MethodHooksObject } from '../utils';
 
 const methodName = 'snap_notify';
 
@@ -84,13 +84,15 @@ export const specificationBuilder: PermissionSpecificationBuilder<
   };
 };
 
+const methodHooks: MethodHooksObject<NotifyMethodHooks> = {
+  showNativeNotification: true,
+  showInAppNotification: true,
+};
+
 export const notifyBuilder = Object.freeze({
   targetKey: methodName,
   specificationBuilder,
-  methodHooks: {
-    showNativeNotification: true,
-    showInAppNotification: true,
-  },
+  methodHooks,
 } as const);
 
 /**

--- a/packages/rpc-methods/src/utils.ts
+++ b/packages/rpc-methods/src/utils.ts
@@ -14,6 +14,15 @@ import { literal, Struct } from 'superstruct';
 const HARDENED_VALUE = 0x80000000;
 
 /**
+ * Maps an interface with method hooks to an object, using the keys of the
+ * interface, and `true` as value. This ensures that the `methodHooks` object
+ * has the same values as the interface.
+ */
+export type MethodHooksObject<HooksType extends Record<string, unknown>> = {
+  [Key in keyof HooksType]: true;
+};
+
+/**
  * Returns the subset of the specified `hooks` that are included in the
  * `hookNames` object. This is a Principle of Least Authority (POLA) measure
  * to ensure that each RPC method implementation only has access to the


### PR DESCRIPTION
By using a new type `MethodHooksObject`, we can ensure that the `methodHooks` and `hookNames` specified match the ones specified in the type. For example, using the following type:

```ts
type GetBip32EntropyMethodHooks = {
  getMnemonic: () => Promise<Uint8Array>;
  getUnlockPromise: (shouldShowUnlockRequest: boolean) => Promise<void>;
};
```

This will work:

```ts
const methodHooks: MethodHooksObject<GetBip32EntropyMethodHooks> = {
  getMnemonic: true,
  getUnlockPromise: true,
};
```

This will not:

```ts
// TS2741: Property 'getUnlockPromise' is missing in type '{ getMnemonic: true; }' but required
// in type 'MethodHooksObject<GetBip32EntropyMethodHooks>'.
const methodHooks: MethodHooksObject<GetBip32EntropyMethodHooks> = {
  getMnemonic: true,
};
```

This solves issues where we may forget to update the `methodHooks` object after adding a new hook to the type.

Closes #287.