### PR TITLE
Fix invoke snap error message

### DIFF
--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -181,7 +181,7 @@ export function getInvokeSnapImplementation({
 
     if (!getSnap(snapId)) {
       throw ethErrors.rpc.invalidRequest({
-        message: `The snap "${snapId}" is not installed. This is a bug, please report it.`,
+        message: `The snap "${snapId}" is not installed. Please install it first, before invoking the snap.`,
       });
     }
 


### PR DESCRIPTION
When invoking a snap when it's not installed, this error message shows up:

> The snap "foo-snap" is not installed. This is a bug, please report it.

This is not a bug however. It means that the snap needs to be installed. I've changed the copy to reflect that.

Closes #1166.