### PR TITLE
BREAKING: Require snaps to request at least one handler permission

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 88.77,
-  "functions": 95.05,
-  "lines": 96.49,
-  "statements": 96.39
+  "functions": 95.07,
+  "lines": 96.5,
+  "statements": 96.4
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -2552,7 +2552,7 @@ describe('SnapController', () => {
           [MOCK_SNAP_ID]: {},
         }),
       ).rejects.toThrow(
-        'A snap must request at least one of the following permissions: endowment:rpc, endowment:keyring, endowment:transaction-insight, endowment:cronjob',
+        'A snap must request at least one of the following permissions: endowment:rpc, endowment:keyring, endowment:transaction-insight, endowment:cronjob.',
       );
 
       controller.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -686,6 +686,7 @@ describe('SnapController', () => {
   it('supports non-snap permissions', async () => {
     const messenger = getSnapControllerMessenger();
     const initialPermissions: SnapPermissions = {
+      [handlerEndowments.onRpcRequest]: { snaps: false, dapps: true },
       // @ts-expect-error Current type only expects snap permissions
       // eslint-disable-next-line @typescript-eslint/naming-convention
       eth_accounts: {
@@ -2492,6 +2493,7 @@ describe('SnapController', () => {
 
     it('throws an error if a forbidden permission is requested', async () => {
       const initialPermissions = {
+        [handlerEndowments.onRpcRequest]: { snaps: false, dapps: true },
         // eslint-disable-next-line @typescript-eslint/naming-convention
         'endowment:long-running': {},
       };
@@ -2519,6 +2521,39 @@ describe('SnapController', () => {
           [MOCK_SNAP_ID]: {},
         }),
       ).rejects.toThrow('One or more permissions are not allowed:\nfoobar');
+
+      controller.destroy();
+    });
+
+    it('throws an error if no handler permissions are requested', async () => {
+      const initialPermissions = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        snap_dialog: {},
+      };
+
+      const { manifest } = getSnapFiles({
+        manifest: getSnapManifest({
+          initialPermissions,
+        }),
+      });
+
+      const messenger = getSnapControllerMessenger();
+      const controller = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          detectSnapLocation: loopbackDetect({
+            manifest: manifest.result,
+          }),
+        }),
+      );
+
+      await expect(
+        controller.installSnaps(MOCK_ORIGIN, {
+          [MOCK_SNAP_ID]: {},
+        }),
+      ).rejects.toThrow(
+        'A snap must request at least one of the following permissions: endowment:rpc, endowment:keyring, endowment:transaction-insight, endowment:cronjob',
+      );
 
       controller.destroy();
     });
@@ -2561,6 +2596,8 @@ describe('SnapController', () => {
 
     it('maps permission caveats to the proper format', async () => {
       const initialPermissions = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'endowment:rpc': { snaps: false, dapps: true },
         // eslint-disable-next-line @typescript-eslint/naming-convention
         snap_getBip32Entropy: [
           { path: ['m', "44'", "60'"], curve: 'secp256k1' as const },
@@ -2612,6 +2649,17 @@ describe('SnapController', () => {
           requestState: {
             loading: false,
             permissions: {
+              [handlerEndowments.onRpcRequest]: {
+                caveats: [
+                  {
+                    type: SnapCaveatType.RpcOrigin,
+                    value: {
+                      dapps: true,
+                      snaps: false,
+                    },
+                  },
+                ],
+              },
               // eslint-disable-next-line @typescript-eslint/naming-convention
               snap_getBip32Entropy: {
                 caveats: [
@@ -2631,6 +2679,17 @@ describe('SnapController', () => {
         'PermissionController:grantPermissions',
         {
           approvedPermissions: {
+            [handlerEndowments.onRpcRequest]: {
+              caveats: [
+                {
+                  type: SnapCaveatType.RpcOrigin,
+                  value: {
+                    dapps: true,
+                    snaps: false,
+                  },
+                },
+              ],
+            },
             // eslint-disable-next-line @typescript-eslint/naming-convention
             snap_getBip32Entropy: {
               caveats: [
@@ -2748,6 +2807,7 @@ describe('SnapController', () => {
 
     it('maps permission caveats to the proper format when updating snaps', async () => {
       const initialPermissions = {
+        [handlerEndowments.onRpcRequest]: { snaps: false, dapps: true },
         // eslint-disable-next-line @typescript-eslint/naming-convention
         snap_getBip32Entropy: [
           { path: ['m', "44'", "60'"], curve: 'secp256k1' as const },
@@ -2792,6 +2852,17 @@ describe('SnapController', () => {
         'PermissionController:grantPermissions',
         {
           approvedPermissions: {
+            [handlerEndowments.onRpcRequest]: {
+              caveats: [
+                {
+                  type: SnapCaveatType.RpcOrigin,
+                  value: {
+                    dapps: true,
+                    snaps: false,
+                  },
+                },
+              ],
+            },
             // eslint-disable-next-line @typescript-eslint/naming-convention
             snap_getBip32Entropy: {
               caveats: [
@@ -3859,6 +3930,7 @@ describe('SnapController', () => {
 
       /* eslint-disable @typescript-eslint/naming-convention */
       const initialPermissions = {
+        [handlerEndowments.onRpcRequest]: { snaps: false, dapps: true },
         snap_confirm: {},
         snap_manageState: {},
       };
@@ -3880,6 +3952,21 @@ describe('SnapController', () => {
           date: 1,
           invoker: MOCK_SNAP_ID,
         },
+        [handlerEndowments.onRpcRequest]: {
+          caveats: [
+            {
+              type: SnapCaveatType.RpcOrigin,
+              value: {
+                dapps: true,
+                snaps: false,
+              },
+            },
+          ],
+          parentCapability: handlerEndowments.onRpcRequest,
+          id: '3',
+          date: 1,
+          invoker: MOCK_SNAP_ID,
+        },
       };
 
       const { manifest } = getSnapFiles({
@@ -3892,6 +3979,7 @@ describe('SnapController', () => {
         manifest: getSnapManifest({
           version: '1.1.0' as SemVerRange,
           initialPermissions: {
+            [handlerEndowments.onRpcRequest]: { snaps: false, dapps: true },
             snap_confirm: {},
             'endowment:network-access': {},
           },
@@ -3990,6 +4078,8 @@ describe('SnapController', () => {
             newVersion: '1.1.0',
             newPermissions: { 'endowment:network-access': {} },
             approvedPermissions: {
+              [handlerEndowments.onRpcRequest]:
+                approvedPermissions[handlerEndowments.onRpcRequest],
               snap_confirm: approvedPermissions.snap_confirm,
             },
             unusedPermissions: {
@@ -4079,6 +4169,7 @@ describe('SnapController', () => {
 
       /* eslint-disable @typescript-eslint/naming-convention */
       const initialPermissions = {
+        [handlerEndowments.onRpcRequest]: { snaps: false, dapps: true },
         snap_confirm: {},
         snap_manageState: {},
       };
@@ -4096,6 +4187,21 @@ describe('SnapController', () => {
           caveats: null,
           parentCapability: 'snap_manageState',
           id: '2',
+          date: 1,
+          invoker: MOCK_SNAP_ID,
+        },
+        [handlerEndowments.onRpcRequest]: {
+          caveats: [
+            {
+              type: SnapCaveatType.RpcOrigin,
+              value: {
+                dapps: true,
+                snaps: false,
+              },
+            },
+          ],
+          parentCapability: handlerEndowments.onRpcRequest,
+          id: '3',
           date: 1,
           invoker: MOCK_SNAP_ID,
         },
@@ -4118,6 +4224,10 @@ describe('SnapController', () => {
                 manifest: getSnapManifest({
                   version: '1.1.0' as SemVerRange,
                   initialPermissions: {
+                    [handlerEndowments.onRpcRequest]: {
+                      snaps: false,
+                      dapps: true,
+                    },
                     snap_confirm: {},
                     'endowment:network-access': {},
                   },

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2300,7 +2300,7 @@ export class SnapController extends BaseController<
       permissionKeys.some((key) => handlerPermissions.includes(key)),
       `A snap must request at least one of the following permissions: ${handlerPermissions.join(
         ', ',
-      )} `,
+      )}.`,
     );
 
     const excludedPermissionErrors = permissionKeys.reduce<string[]>(

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -2292,15 +2292,27 @@ export class SnapController extends BaseController<
   #validateSnapPermissions(
     processedPermissions: Record<string, Pick<PermissionConstraint, 'caveats'>>,
   ) {
-    const excludedPermissionErrors = Object.keys(processedPermissions).reduce<
-      string[]
-    >((errors, permission) => {
-      if (hasProperty(this.#excludedPermissions, permission)) {
-        errors.push(this.#excludedPermissions[permission]);
-      }
+    const permissionKeys = Object.keys(processedPermissions);
 
-      return errors;
-    }, []);
+    const handlerPermissions = Object.values(handlerEndowments);
+
+    assert(
+      permissionKeys.some((key) => handlerPermissions.includes(key)),
+      `A snap must request at least one of the following permissions: ${handlerPermissions.join(
+        ', ',
+      )} `,
+    );
+
+    const excludedPermissionErrors = permissionKeys.reduce<string[]>(
+      (errors, permission) => {
+        if (hasProperty(this.#excludedPermissions, permission)) {
+          errors.push(this.#excludedPermissions[permission]);
+        }
+
+        return errors;
+      },
+      [],
+    );
 
     assert(
       excludedPermissionErrors.length === 0,

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -105,6 +105,8 @@ export const PermissionsStruct = type({
     object({ jobs: CronjobSpecificationArrayStruct }),
   ),
   'endowment:rpc': optional(RpcOriginsStruct),
+  snap_dialog: optional(object({})),
+  // TODO: Remove
   snap_confirm: optional(object({})),
   snap_manageState: optional(object({})),
   snap_notify: optional(object({})),


### PR DESCRIPTION
Require snaps to request at least one handler permission. 

Fixes #899 