### PR TITLE
Add E2E tests for Snaps CLI

### DIFF
--- a/.yarn/patches/clet-npm-1.0.1-8523231bdc.patch
+++ b/.yarn/patches/clet-npm-1.0.1-8523231bdc.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/validator.js b/lib/validator.js
+index 94c8f4f5c9657d88aa3097426b197193502972cc..ef56780ab973b9421e2f0b6d742e7e5b0979d79c 100644
+--- a/lib/validator.js
++++ b/lib/validator.js
+@@ -21,7 +21,6 @@ export function expect(fn) {
+ }
+ 
+ const extractPathRegex = /\s+at.*[(\s](.*):\d+:\d+\)?/;
+-const __filename = filename(import.meta);
+ 
+ function mergeError(buildError, runError) {
+   buildError.message = runError.message;

--- a/.yarn/patches/clet-npm-1.0.1-8523231bdc.patch
+++ b/.yarn/patches/clet-npm-1.0.1-8523231bdc.patch
@@ -1,3 +1,30 @@
+diff --git a/lib/index.d.ts b/lib/index.d.ts
+index 721d6e980c9f3a79647a1e9b313571c7b8c91776..c20a6bd0719dce96408f014e266e3cf5b315d859 100644
+--- a/lib/index.d.ts
++++ b/lib/index.d.ts
+@@ -122,12 +122,7 @@ export interface TestRunnerContext {
+   },
+ }
+ 
+-export enum WaitType {
+-  message = 'message',
+-  stdout = 'stdout',
+-  stderr = 'stderr',
+-  close = 'close',
+-}
++export type WaitType = 'message' | 'stdout' | 'stderr' | 'close';
+ 
+ export type TestRunnerMiddleware = (ctx: TestRunnerContext, next: any) => Promise<void>;
+ 
+@@ -172,7 +167,7 @@ export class TestRunner extends EventEmitter {
+   kill(): this;
+ 
+   // Operation
+-  tap(fn: (ctx: TestRunnerContext) => void): this;
++  tap(fn: (ctx: TestRunnerContext) => Promise<void>): this;
+ 
+   log(format: string, ...args?: string[]): this;
+ 
 diff --git a/lib/validator.js b/lib/validator.js
 index 94c8f4f5c9657d88aa3097426b197193502972cc..ef56780ab973b9421e2f0b6d742e7e5b0979d79c 100644
 --- a/lib/validator.js

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/core": "patch:@babel/core@npm%3A7.21.0#./.yarn/patches/@babel-core-npm-7.21.0-fb3817b0e5.patch",
     "@lavamoat/lavapack@^3.3.0": "patch:@lavamoat/lavapack@npm%3A3.3.0#./.yarn/patches/@lavamoat-lavapack-npm-3.3.0-5a61b5374d.patch",
     "@types/mocha@^10.0.1": "patch:@types/mocha@npm:10.0.1#.yarn/patches/@types-mocha-npm-10.0.1-7c94e9e170.patch",
+    "clet@^1.0.1": "patch:clet@npm%3A1.0.1#./.yarn/patches/clet-npm-1.0.1-8523231bdc.patch",
     "jest-fetch-mock@^3.0.3": "patch:jest-fetch-mock@npm:3.0.3#.yarn/patches/jest-fetch-mock-npm-3.0.3-ac072ca8af.patch",
     "lavamoat-browserify@^15.5.0": "patch:lavamoat-browserify@npm%3A15.5.0#./.yarn/patches/lavamoat-browserify-npm-15.5.0-ce0bbe5e4c.patch",
     "luxon@^3.2.1": "patch:luxon@npm%3A3.3.0#./.yarn/patches/luxon-npm-3.3.0-bdbae9bfd5.patch"

--- a/packages/examples/examples/typescript/package.json
+++ b/packages/examples/examples/typescript/package.json
@@ -46,6 +46,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",
+    "ts-node": "^10.9.1",
     "typescript": "~4.8.4"
   },
   "engines": {

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "pQ2ZrngcDGpgOR9jH/3BNQW3pooeNdvBPnCozYWZD+4=",
+    "shasum": "Ln2grJxzdrekca9tQ1NOFr5VUbKZIVWBp0HZUzWUoh0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "Ln2grJxzdrekca9tQ1NOFr5VUbKZIVWBp0HZUzWUoh0=",
+    "shasum": "pQ2ZrngcDGpgOR9jH/3BNQW3pooeNdvBPnCozYWZD+4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -30,3 +30,5 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
       throw new Error('Method not found.');
   }
 };
+
+console.log('This should show up during eval.');

--- a/packages/examples/examples/typescript/src/index.ts
+++ b/packages/examples/examples/typescript/src/index.ts
@@ -30,5 +30,3 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
       throw new Error('Method not found.');
   }
 };
-
-console.log('This should show up during eval.');

--- a/packages/examples/examples/typescript/tsconfig.json
+++ b/packages/examples/examples/typescript/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../../../tsconfig.packages.json",
   "compilerOptions": {
-    "typeRoots": ["../../../../node_modules/@types"]
+    "baseUrl": "./",
+    "typeRoots": ["../../../../node_modules/@types"],
+    "paths": {
+      "@metamask/*": ["../../../*/src"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/snaps-cli/.eslintrc.js
+++ b/packages/snaps-cli/.eslintrc.js
@@ -45,5 +45,12 @@ module.exports = {
         'node/no-callback-literal': 'off',
       },
     },
+
+    {
+      files: ['**/*.e2e.test.ts'],
+      rules: {
+        'jest/expect-expect': 'off',
+      },
+    },
   ],
 };

--- a/packages/snaps-cli/babel.config.js
+++ b/packages/snaps-cli/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -38,5 +38,5 @@ module.exports = deepmerge(baseConfig, {
   transform: {
     '^.+\\.jsx?$': 'babel-jest',
   },
-  testTimeout: 60000,
+  testTimeout: 120000,
 });

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -38,4 +38,5 @@ module.exports = deepmerge(baseConfig, {
   transform: {
     '^.+\\.jsx?$': 'babel-jest',
   },
+  testTimeout: 10000,
 });

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -38,5 +38,5 @@ module.exports = deepmerge(baseConfig, {
   transform: {
     '^.+\\.jsx?$': 'babel-jest',
   },
-  testTimeout: 10000,
+  testTimeout: 30000,
 });

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -38,5 +38,5 @@ module.exports = deepmerge(baseConfig, {
   transform: {
     '^.+\\.jsx?$': 'babel-jest',
   },
-  testTimeout: 30000,
+  testTimeout: 60000,
 });

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -2,6 +2,27 @@ const deepmerge = require('deepmerge');
 
 const baseConfig = require('../../jest.config.base');
 
+// Dependencies that are ESM-only, and need to be transpiled by Babel.
+const ESM_DEPENDENCIES = [
+  'clet',
+  'execa',
+  'strip-final-newline',
+  'npm-run-path',
+  'path-key',
+  'onetime',
+  'mimic-fn',
+  'human-signals',
+  'is-stream',
+  'strip-ansi',
+  'ansi-regex',
+  'p-event',
+  'p-timeout',
+  'dirname-filename-esm',
+  'trash',
+  'is-path-inside',
+  'dot-prop',
+];
+
 module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/types'],
   coverageThreshold: {
@@ -13,4 +34,8 @@ module.exports = deepmerge(baseConfig, {
     },
   },
   setupFiles: ['./test/setup.js'],
+  transformIgnorePatterns: [`node_modules/(?!(${ESM_DEPENDENCIES.join('|')}))`],
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+  },
 });

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -76,6 +76,7 @@
     "@typescript-eslint/parser": "^5.42.1",
     "babel-jest": "^29.5.0",
     "clet": "^1.0.1",
+    "cross-fetch": "^3.1.5",
     "deepmerge": "^4.2.2",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -93,7 +93,7 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.0",
-    "ts-node": "^10.7.0",
+    "ts-node": "^10.9.1",
     "tsc-watch": "^4.5.0",
     "typescript": "~4.8.4"
   },

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -23,7 +23,7 @@
     "build:clean": "yarn clean && yarn build",
     "build:watch": "tsc-watch --onSuccess 'yarn build:chmod'",
     "clean": "rimraf '*.tsbuildinfo' 'dist/*'",
-    "test": "jest && yarn posttest",
+    "test": "jest --runInBand && yarn posttest",
     "posttest": "jest-it-up",
     "test:watch": "yarn test --watch",
     "test:ci": "yarn test",

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -74,6 +74,8 @@
     "@types/yargs": "^15.0.12",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
+    "babel-jest": "^29.5.0",
+    "clet": "^1.0.1",
     "deepmerge": "^4.2.2",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -9,6 +9,7 @@ describe('mm-snap build', () => {
       await run({ command })
         .stdout("Build success: 'src/index.ts' bundled as 'dist/bundle.js'!")
         .stdout("Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .kill()
         .end();
     },
   );
@@ -30,6 +31,7 @@ describe('mm-snap build', () => {
       .stdout(
         "Eval Success: evaluated '../examples/examples/typescript/dist/bundle.js' in SES!",
       )
+      .kill()
       .end();
   });
 
@@ -37,6 +39,7 @@ describe('mm-snap build', () => {
     await run({ command: 'build', options: ['--eval false'] })
       .stdout("Build success: 'src/index.ts' bundled as 'dist/bundle.js'!")
       .notStdout("Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .kill()
       .end();
   });
 
@@ -46,6 +49,7 @@ describe('mm-snap build', () => {
         "Error: Invalid params: 'foo.js' is not a file or does not exist.",
       )
       .code(1)
+      .kill()
       .end();
   });
 });

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -24,10 +24,14 @@ describe('mm-snap build', () => {
     await run({
       command: 'build',
       options: [
-        `--src ${join(SNAP_DIR, 'src/index.ts')}`,
-        `--dist ${join(SNAP_DIR, 'dist')}`,
-        `--manifest false`,
-        `--writeManifest false`,
+        '--src',
+        join(SNAP_DIR, 'src/index.ts'),
+        '--dist',
+        join(SNAP_DIR, 'dist'),
+        '--manifest',
+        'false',
+        '--writeManifest',
+        'false',
       ],
       workingDirectory: '.',
     })
@@ -49,7 +53,7 @@ describe('mm-snap build', () => {
   });
 
   it('does not eval when set to false', async () => {
-    await run({ command: 'build', options: ['--eval false'] })
+    await run({ command: 'build', options: ['--eval', 'false'] })
       .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
           'dist',
@@ -63,7 +67,7 @@ describe('mm-snap build', () => {
   });
 
   it('logs an error when the input file does not exist', async () => {
-    await run({ command: 'build', options: ['--src foo.js'] })
+    await run({ command: 'build', options: ['--src', 'foo.js'] })
       .stderr(
         "Error: Invalid params: 'foo.js' is not a file or does not exist.",
       )

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -7,8 +7,15 @@ describe('mm-snap build', () => {
     'builds a snap using "mm-snap %s"',
     async (command) => {
       await run({ command })
-        .stdout("Build success: 'src/index.ts' bundled as 'dist/bundle.js'!")
-        .stdout("Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .stdout(
+          `Build success: '${join('src', 'index.ts')}' bundled as '${join(
+            'dist',
+            'bundle.js',
+          )}'!`,
+        )
+        .stdout(
+          `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
+        )
         .kill()
         .end();
     },
@@ -26,10 +33,18 @@ describe('mm-snap build', () => {
       workingDirectory: '.',
     })
       .stdout(
-        "Build success: '../examples/examples/typescript/src/index.ts' bundled as '../examples/examples/typescript/dist/bundle.js'!",
+        `Build success: '${join(SNAP_DIR, 'src/index.ts')}' bundled as '${join(
+          SNAP_DIR,
+          'dist',
+          'bundle.js',
+        )}'!`,
       )
       .stdout(
-        "Eval Success: evaluated '../examples/examples/typescript/dist/bundle.js' in SES!",
+        `Eval Success: evaluated '${join(
+          SNAP_DIR,
+          'dist',
+          'bundle.js',
+        )}' in SES!`,
       )
       .kill()
       .end();
@@ -37,8 +52,15 @@ describe('mm-snap build', () => {
 
   it('does not eval when set to false', async () => {
     await run({ command: 'build', options: ['--eval false'] })
-      .stdout("Build success: 'src/index.ts' bundled as 'dist/bundle.js'!")
-      .notStdout("Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .stdout(
+        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
+          'dist',
+          'bundle.js',
+        )}'!`,
+      )
+      .notStdout(
+        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
+      )
       .kill()
       .end();
   });

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 
-import { SNAP_DIR, run } from '../../test-utils';
+import { run, SNAP_DIR } from '../../test-utils';
 
 describe('mm-snap build', () => {
   it.each(['build', 'b'])(

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { run, SNAP_DIR } from '../../test-utils';
 
 describe('mm-snap build', () => {
-  it.each(['build', 'b'])(
+  it.skip.each(['build', 'b'])(
     'builds a snap using "mm-snap %s"',
     async (command) => {
       await run({ command })
@@ -21,7 +21,7 @@ describe('mm-snap build', () => {
     },
   );
 
-  it('supports setting a bundle and output file', async () => {
+  it.skip('supports setting a bundle and output file', async () => {
     await run({
       command: 'build',
       options: [
@@ -50,7 +50,7 @@ describe('mm-snap build', () => {
       .end();
   });
 
-  it('does not eval when set to false', async () => {
+  it.skip('does not eval when set to false', async () => {
     await run({ command: 'build', options: ['--eval false'] })
       .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
@@ -65,7 +65,7 @@ describe('mm-snap build', () => {
       .end();
   });
 
-  it('logs an error when the input file does not exist', async () => {
+  it.skip('logs an error when the input file does not exist', async () => {
     await run({ command: 'build', options: ['--src foo.js'] })
       .stderr(
         "Error: Invalid params: 'foo.js' is not a file or does not exist.",

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -7,15 +7,8 @@ describe('mm-snap build', () => {
     'builds a snap using "mm-snap %s"',
     async (command) => {
       await run({ command })
-        .stdout(
-          `Build success: '${join('src', 'index.ts')}' bundled as '${join(
-            'dist',
-            'bundle.js',
-          )}'!`,
-        )
-        .stdout(
-          `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
-        )
+        .stdout(/Build success: '.*' bundled as '.*'!/u)
+        .stdout(/Eval Success: evaluated '.*' in SES!/u)
         .end();
     },
   );
@@ -35,34 +28,15 @@ describe('mm-snap build', () => {
       ],
       workingDirectory: '.',
     })
-      .stdout(
-        `Build success: '${join(SNAP_DIR, 'src/index.ts')}' bundled as '${join(
-          SNAP_DIR,
-          'dist',
-          'bundle.js',
-        )}'!`,
-      )
-      .stdout(
-        `Eval Success: evaluated '${join(
-          SNAP_DIR,
-          'dist',
-          'bundle.js',
-        )}' in SES!`,
-      )
+      .stdout(/Build success: '.*' bundled as '.*'!/u)
+      .stdout(/Eval Success: evaluated '.*' in SES!/u)
       .end();
   });
 
   it('does not eval when set to false', async () => {
     await run({ command: 'build', options: ['--eval', 'false'] })
-      .stdout(
-        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
-          'dist',
-          'bundle.js',
-        )}'!`,
-      )
-      .notStdout(
-        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
-      )
+      .stdout(/Build success: '.*' bundled as '.*'!/u)
+      .notStdout(/Eval Success: evaluated '.*' in SES!/u)
       .end();
   });
 

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { run, SNAP_DIR } from '../../test-utils';
 
 describe('mm-snap build', () => {
-  it.skip.each(['build', 'b'])(
+  it.each(['build', 'b'])(
     'builds a snap using "mm-snap %s"',
     async (command) => {
       await run({ command })
@@ -16,12 +16,11 @@ describe('mm-snap build', () => {
         .stdout(
           `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
         )
-        .kill()
         .end();
     },
   );
 
-  it.skip('supports setting a bundle and output file', async () => {
+  it('supports setting a bundle and output file', async () => {
     await run({
       command: 'build',
       options: [
@@ -46,11 +45,10 @@ describe('mm-snap build', () => {
           'bundle.js',
         )}' in SES!`,
       )
-      .kill()
       .end();
   });
 
-  it.skip('does not eval when set to false', async () => {
+  it('does not eval when set to false', async () => {
     await run({ command: 'build', options: ['--eval false'] })
       .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
@@ -61,17 +59,15 @@ describe('mm-snap build', () => {
       .notStdout(
         `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
       )
-      .kill()
       .end();
   });
 
-  it.skip('logs an error when the input file does not exist', async () => {
+  it('logs an error when the input file does not exist', async () => {
     await run({ command: 'build', options: ['--src foo.js'] })
       .stderr(
         "Error: Invalid params: 'foo.js' is not a file or does not exist.",
       )
       .code(1)
-      .kill()
       .end();
   });
 });

--- a/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/build/build.e2e.test.ts
@@ -1,0 +1,51 @@
+import { join } from 'path';
+
+import { SNAP_DIR, run } from '../../test-utils';
+
+describe('mm-snap build', () => {
+  it.each(['build', 'b'])(
+    'builds a snap using "mm-snap %s"',
+    async (command) => {
+      await run({ command })
+        .stdout("Build success: 'src/index.ts' bundled as 'dist/bundle.js'!")
+        .stdout("Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .end();
+    },
+  );
+
+  it('supports setting a bundle and output file', async () => {
+    await run({
+      command: 'build',
+      options: [
+        `--src ${join(SNAP_DIR, 'src/index.ts')}`,
+        `--dist ${join(SNAP_DIR, 'dist')}`,
+        `--manifest false`,
+        `--writeManifest false`,
+      ],
+      workingDirectory: '.',
+    })
+      .stdout(
+        "Build success: '../examples/examples/typescript/src/index.ts' bundled as '../examples/examples/typescript/dist/bundle.js'!",
+      )
+      .stdout(
+        "Eval Success: evaluated '../examples/examples/typescript/dist/bundle.js' in SES!",
+      )
+      .end();
+  });
+
+  it('does not eval when set to false', async () => {
+    await run({ command: 'build', options: ['--eval false'] })
+      .stdout("Build success: 'src/index.ts' bundled as 'dist/bundle.js'!")
+      .notStdout("Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .end();
+  });
+
+  it('logs an error when the input file does not exist', async () => {
+    await run({ command: 'build', options: ['--src foo.js'] })
+      .stderr(
+        "Error: Invalid params: 'foo.js' is not a file or does not exist.",
+      )
+      .code(1)
+      .end();
+  });
+});

--- a/packages/snaps-cli/src/cmds/eval/__test__/eval-2.js
+++ b/packages/snaps-cli/src/cmds/eval/__test__/eval-2.js
@@ -1,0 +1,3 @@
+// This file is used for the E2E eval test.
+
+throw new Error('Eval failed.');

--- a/packages/snaps-cli/src/cmds/eval/__test__/eval.js
+++ b/packages/snaps-cli/src/cmds/eval/__test__/eval.js
@@ -1,1 +1,127 @@
+/* eslint-disable */
 // This file is used for the E2E eval test.
+
+(function (f) {
+  if (typeof exports === 'object' && typeof module !== 'undefined') {
+    module.exports = f();
+  } else if (typeof define === 'function' && define.amd) {
+    define([], f);
+  } else {
+    let g;
+    if (typeof window !== 'undefined') {
+      g = window;
+    } else if (typeof global !== 'undefined') {
+      g = global;
+    } else if (typeof self !== 'undefined') {
+      g = self;
+    } else {
+      g = this;
+    }
+    g.snap = f();
+  }
+})(function () {
+  let define, module, exports;
+  return (function () {
+    /**
+     *
+     * @param e
+     * @param n
+     * @param t
+     */
+    function r(e, n, t) {
+      /**
+       *
+       * @param i
+       * @param f
+       */
+      function o(i, f) {
+        if (!n[i]) {
+          if (!e[i]) {
+            const c = typeof require === 'function' && require;
+            if (!f && c) {
+              return c(i, !0);
+            }
+            if (u) {
+              return u(i, !0);
+            }
+            const a = new Error(`Cannot find module '${i}'`);
+            throw ((a.code = 'MODULE_NOT_FOUND'), a);
+          }
+          const p = (n[i] = {
+            exports: {},
+          });
+          e[i][0].call(
+            p.exports,
+            function (r) {
+              const n = e[i][1][r];
+              return o(n || r);
+            },
+            p,
+            p.exports,
+            r,
+            e,
+            n,
+            t,
+          );
+        }
+        return n[i].exports;
+      }
+      for (
+        var u = typeof require === 'function' && require, i = 0;
+        i < t.length;
+        i++
+      ) {
+        o(t[i]);
+      }
+      return o;
+    }
+    return r;
+  })()(
+    {
+      1: [
+        function (require, module, exports) {
+          'use strict';
+
+          Object.defineProperty(exports, '__esModule', {
+            value: true,
+          });
+          exports.onRpcRequest = void 0;
+          const _message = require('./message');
+          const onRpcRequest = async ({ origin, request }) => {
+            switch (request.method) {
+              case 'hello':
+                return await snap.request({
+                  method: 'snap_notify',
+                  params: {
+                    type: 'inapp',
+                    message: (0, _message.getMessage)(origin),
+                  },
+                });
+              default:
+                throw new Error('Method not found.');
+            }
+          };
+          exports.onRpcRequest = onRpcRequest;
+        },
+        {
+          './message': 2,
+        },
+      ],
+      2: [
+        function (require, module, exports) {
+          'use strict';
+
+          Object.defineProperty(exports, '__esModule', {
+            value: true,
+          });
+          exports.getMessage = void 0;
+          const getMessage = (originString) => `Hello, ${originString}!`;
+          exports.getMessage = getMessage;
+        },
+        {},
+      ],
+    },
+    {},
+    [1],
+  )(1);
+});

--- a/packages/snaps-cli/src/cmds/eval/__test__/eval.js
+++ b/packages/snaps-cli/src/cmds/eval/__test__/eval.js
@@ -1,0 +1,1 @@
+// This file is used for the E2E eval test.

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -11,6 +11,7 @@ describe('mm-snap eval', () => {
         workingDirectory: __dirname,
       })
         .stdout("Eval Success: evaluated '__test__/eval.js' in SES!")
+        .kill()
         .end();
     },
   );
@@ -23,6 +24,7 @@ describe('mm-snap eval', () => {
     })
       .stderr('Eval failed.')
       .code(1)
+      .kill()
       .end();
   });
 });

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -2,7 +2,7 @@ import { run } from '@metamask/snaps-cli/test-utils';
 import { join } from 'path';
 
 describe('mm-snap eval', () => {
-  it.skip.each(['eval', 'e'])(
+  it.each(['eval', 'e'])(
     'evaluates a snap using "mm-snap %s"',
     async (command) => {
       await run({
@@ -10,34 +10,26 @@ describe('mm-snap eval', () => {
         options: [`--bundle ${join('__test__', 'eval.js')}`],
         workingDirectory: __dirname,
       })
+        .wait(
+          'stdout',
+          `Eval Success: evaluated '${join('__test__', 'eval.js')}' in SES!`,
+        )
         .stdout(
           `Eval Success: evaluated '${join('__test__', 'eval.js')}' in SES!`,
         )
-        .kill()
         .end();
     },
   );
 
   it('shows a message if the evaluation failed', async () => {
-    const runner = run({
+    await run({
       command: 'eval',
       options: [`--bundle ${join('__test__', 'eval-2.js')}`],
       workingDirectory: __dirname,
     })
+      .wait('stderr', 'Eval failed.')
       .stderr('Eval failed.')
       .code(1)
-      .kill();
-
-    await runner.end();
-
-    console.log('Runner connected:', runner.proc.connected);
-    console.log('Runner killed:', runner.proc.killed);
-
-    if (!runner.proc.killed) {
-      console.log('Killing runner...');
-      runner.proc.kill();
-    }
-
-    runner.proc.unref();
+      .end();
   });
 });

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -2,7 +2,7 @@ import { run } from '@metamask/snaps-cli/test-utils';
 import { join } from 'path';
 
 describe('mm-snap eval', () => {
-  it.each(['eval', 'e'])(
+  it.skip.each(['eval', 'e'])(
     'evaluates a snap using "mm-snap %s"',
     async (command) => {
       await run({
@@ -19,14 +19,25 @@ describe('mm-snap eval', () => {
   );
 
   it('shows a message if the evaluation failed', async () => {
-    await run({
+    const runner = run({
       command: 'eval',
       options: [`--bundle ${join('__test__', 'eval-2.js')}`],
       workingDirectory: __dirname,
     })
       .stderr('Eval failed.')
       .code(1)
-      .kill()
-      .end();
+      .kill();
+
+    await runner.end();
+
+    console.log('Runner connected:', runner.proc.connected);
+    console.log('Runner killed:', runner.proc.killed);
+
+    if (!runner.proc.killed) {
+      console.log('Killing runner...');
+      runner.proc.kill();
+    }
+
+    runner.proc.unref();
   });
 });

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -10,7 +10,9 @@ describe('mm-snap eval', () => {
         options: [`--bundle ${join('__test__', 'eval.js')}`],
         workingDirectory: __dirname,
       })
-        .stdout("Eval Success: evaluated '__test__/eval.js' in SES!")
+        .stdout(
+          `Eval Success: evaluated '${join('__test__', 'eval.js')}' in SES!`,
+        )
         .kill()
         .end();
     },

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -1,0 +1,28 @@
+import { run } from '@metamask/snaps-cli/test-utils';
+import { join } from 'path';
+
+describe('mm-snap eval', () => {
+  it.each(['eval', 'e'])(
+    'evaluates a snap using "mm-snap %s"',
+    async (command) => {
+      await run({
+        command,
+        options: [`--bundle ${join('__test__', 'eval.js')}`],
+        workingDirectory: __dirname,
+      })
+        .stdout("Eval Success: evaluated '__test__/eval.js' in SES!")
+        .end();
+    },
+  );
+
+  it('shows a message if the evaluation failed', async () => {
+    await run({
+      command: 'eval',
+      options: [`--bundle ${join('__test__', 'eval-2.js')}`],
+      workingDirectory: __dirname,
+    })
+      .stderr('Eval failed.')
+      .code(1)
+      .end();
+  });
+});

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -10,9 +10,7 @@ describe('mm-snap eval', () => {
         options: ['--bundle', join('__test__', 'eval.js')],
         workingDirectory: __dirname,
       })
-        .stdout(
-          `Eval Success: evaluated '${join('__test__', 'eval.js')}' in SES!`,
-        )
+        .stdout(/Eval Success: evaluated '.*' in SES!/u)
         .end();
     },
   );

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -7,7 +7,7 @@ describe('mm-snap eval', () => {
     async (command) => {
       await run({
         command,
-        options: [`--bundle ${join('__test__', 'eval.js')}`],
+        options: ['--bundle', join('__test__', 'eval.js')],
         workingDirectory: __dirname,
       })
         .stdout(
@@ -20,7 +20,7 @@ describe('mm-snap eval', () => {
   it('shows a message if the evaluation failed', async () => {
     await run({
       command: 'eval',
-      options: [`--bundle ${join('__test__', 'eval-2.js')}`],
+      options: ['--bundle', join('__test__', 'eval-2.js')],
       workingDirectory: __dirname,
     })
       .stderr('Eval failed.')

--- a/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/eval/eval.e2e.test.ts
@@ -10,10 +10,6 @@ describe('mm-snap eval', () => {
         options: [`--bundle ${join('__test__', 'eval.js')}`],
         workingDirectory: __dirname,
       })
-        .wait(
-          'stdout',
-          `Eval Success: evaluated '${join('__test__', 'eval.js')}' in SES!`,
-        )
         .stdout(
           `Eval Success: evaluated '${join('__test__', 'eval.js')}' in SES!`,
         )
@@ -27,7 +23,6 @@ describe('mm-snap eval', () => {
       options: [`--bundle ${join('__test__', 'eval-2.js')}`],
       workingDirectory: __dirname,
     })
-      .wait('stderr', 'Eval failed.')
       .stderr('Eval failed.')
       .code(1)
       .end();

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
-import { resolve } from 'path';
+import { join, resolve } from 'path';
 
 import { run } from '../../test-utils';
 
@@ -29,7 +29,10 @@ describe('mm-snap init', () => {
           'stdout',
           "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
         )
-        .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .wait(
+          'stdout',
+          `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
+        )
         .wait('stdout', 'Snap project successfully initiated!')
         .kill()
         .end();

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -5,7 +5,6 @@ import { join, resolve } from 'path';
 import { run } from '../../test-utils';
 
 jest.unmock('fs');
-jest.setTimeout(60000);
 
 const TMP_DIR = resolve(tmpdir(), 'metamask-snaps-test');
 

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 import { run } from '../../test-utils';
 
 jest.unmock('fs');
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 const TMP_DIR = resolve(tmpdir(), 'metamask-snaps-test');
 
@@ -13,8 +13,6 @@ describe('mm-snap init', () => {
   it.each(['init', 'i'])(
     'initializes a new snap using "mm-snap %s"',
     async (command) => {
-      expect.assertions(1);
-
       const initPath = resolve(TMP_DIR, command);
       await fs.rm(initPath, { force: true, recursive: true });
       await fs.mkdir(TMP_DIR, { recursive: true });
@@ -33,10 +31,6 @@ describe('mm-snap init', () => {
         )
         .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
         .wait('stdout', 'Snap project successfully initiated!')
-        .tap(async () => {
-          const file = await fs.readFile(resolve(initPath, 'package.json'));
-          expect(file).toBeDefined();
-        })
         .kill()
         .end();
     },

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -1,0 +1,46 @@
+import { LogLevel } from 'clet';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { resolve } from 'path';
+
+import { run } from '../../test-utils';
+
+jest.unmock('fs');
+jest.setTimeout(30000);
+
+const TMP_DIR = resolve(tmpdir(), 'metamask-snaps-test');
+
+describe('mm-snap init', () => {
+  it.each(['init', 'i'])(
+    'initializes a new snap using "mm-snap %s"',
+    async (command) => {
+      expect.assertions(1);
+
+      const initPath = resolve(TMP_DIR, command);
+      await fs.rm(initPath, { force: true, recursive: true });
+      await fs.mkdir(TMP_DIR, { recursive: true });
+
+      await run({
+        command,
+        options: [initPath],
+      })
+        .debug(LogLevel.INFO)
+        .wait('stdout', `Preparing ${initPath}...`)
+        .wait('stdout', 'Cloning template...')
+        .wait('stdout', 'Installing dependencies...')
+        .wait('stdout', 'Initializing git repository...')
+        .wait(
+          'stdout',
+          "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+        )
+        .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .wait('stdout', 'Snap project successfully initiated!')
+        .tap(async () => {
+          const file = await fs.readFile(resolve(initPath, 'package.json'));
+          expect(file).toBeDefined();
+        })
+        .kill()
+        .end();
+    },
+  );
+});

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -1,4 +1,3 @@
-import { LogLevel } from 'clet';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { resolve } from 'path';
@@ -24,7 +23,6 @@ describe('mm-snap init', () => {
         command,
         options: [initPath],
       })
-        .debug(LogLevel.INFO)
         .wait('stdout', `Preparing ${initPath}...`)
         .wait('stdout', 'Cloning template...')
         .wait('stdout', 'Installing dependencies...')

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 
 import { run } from '../../test-utils';
 
@@ -9,7 +9,7 @@ jest.unmock('fs');
 const TMP_DIR = resolve(tmpdir(), 'metamask-snaps-test');
 
 describe('mm-snap init', () => {
-  it.skip.each(['init', 'i'])(
+  it.each(['init', 'i'])(
     'initializes a new snap using "mm-snap %s"',
     async (command) => {
       const initPath = resolve(TMP_DIR, command);
@@ -20,18 +20,12 @@ describe('mm-snap init', () => {
         command,
         options: [initPath],
       })
-        .wait('stdout', `Preparing ${initPath}...`)
-        .wait('stdout', 'Cloning template...')
-        .wait('stdout', 'Installing dependencies...')
-        .wait('stdout', 'Initializing git repository...')
-        .wait(
-          'stdout',
-          "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
-        )
-        .wait(
-          'stdout',
-          `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
-        )
+        .stdout(/Preparing .*\.\.\./u)
+        .stdout('Cloning template...')
+        .stdout('Installing dependencies...')
+        .stdout('Initializing git repository...')
+        .stdout(/Build success: '.*' bundled as '.*'!/u)
+        .stdout(/Eval Success: evaluated '.*' in SES!/u)
         .wait('stdout', 'Snap project successfully initiated!')
         .kill()
         .end();

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -9,7 +9,11 @@ jest.unmock('fs');
 const TMP_DIR = resolve(tmpdir(), 'metamask-snaps-test');
 
 describe('mm-snap init', () => {
-  it.each(['init', 'i'])(
+  // TODO: Enable this test. Currently installing dependencies takes too long,
+  // and we don't want to increase the timeout even more. We should consider
+  // making a minimal template for testing purposes, and adding a way to specify
+  // the template to use.
+  it.skip.each(['init', 'i'])(
     'initializes a new snap using "mm-snap %s"',
     async (command) => {
       const initPath = resolve(TMP_DIR, command);

--- a/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/init/init.e2e.test.ts
@@ -9,7 +9,7 @@ jest.unmock('fs');
 const TMP_DIR = resolve(tmpdir(), 'metamask-snaps-test');
 
 describe('mm-snap init', () => {
-  it.each(['init', 'i'])(
+  it.skip.each(['init', 'i'])(
     'initializes a new snap using "mm-snap %s"',
     async (command) => {
       const initPath = resolve(TMP_DIR, command);

--- a/packages/snaps-cli/src/cmds/init/initHandler.ts
+++ b/packages/snaps-cli/src/cmds/init/initHandler.ts
@@ -58,7 +58,7 @@ export async function initHandler(argv: YargsArgs) {
   }
 
   const directoryToUse = directory
-    ? pathUtils.join(process.cwd(), directory)
+    ? pathUtils.resolve(process.cwd(), directory)
     : process.cwd();
 
   logInfo(`Preparing ${directoryToUse}...`);

--- a/packages/snaps-cli/src/cmds/init/initUtils.test.ts
+++ b/packages/snaps-cli/src/cmds/init/initUtils.test.ts
@@ -197,7 +197,7 @@ describe('initUtils', () => {
       expect(execSyncMock).toHaveBeenCalledTimes(1);
       expect(execSyncMock).toHaveBeenCalledWith('yarn install', {
         stdio: [0, 1, 2],
-        cwd: pathUtils.resolve(__dirname, 'foo'),
+        cwd: 'foo',
       });
     });
 

--- a/packages/snaps-cli/src/cmds/init/initUtils.ts
+++ b/packages/snaps-cli/src/cmds/init/initUtils.ts
@@ -110,7 +110,7 @@ export function yarnInstall(directory: string) {
   try {
     execSync('yarn install', {
       stdio: [0, 1, 2],
-      cwd: pathUtils.resolve(__dirname, directory),
+      cwd: directory,
     });
   } catch (error) {
     throw new Error('Init Error: Failed to install dependencies.');

--- a/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
@@ -66,6 +66,7 @@ describe('mm-snap manifest', () => {
         'Manifest Error: "snap.manifest.json" "repository" field does not match the "package.json" "repository" field.',
       )
       .code(1)
+      .kill()
       .end();
 
     await run({
@@ -73,6 +74,7 @@ describe('mm-snap manifest', () => {
       options: ['--fix true'],
     })
       .code(0)
+      .kill()
       .end();
 
     const manifest = await fs.readFile(MANIFEST_PATH, 'utf-8').then(JSON.parse);

--- a/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
@@ -1,7 +1,7 @@
 import { run } from '../../test-utils';
 
 describe('mm-snap manifest', () => {
-  it.each(['manifest', 'm'])(
+  it.skip.each(['manifest', 'm'])(
     'validates the manifest using "mm-snap %s"',
     async (command) => {
       await run({

--- a/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
@@ -1,0 +1,72 @@
+import { LogLevel } from 'clet';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+import { run, SNAP_DIR } from '../../test-utils';
+
+jest.unmock('fs');
+
+describe('mm-snap watch', () => {
+  it.each(['manifest', 'm'])(
+    'validates the manifest using "mm-snap %s"',
+    async (command) => {
+      await run({
+        command,
+        options: ['--serve false'],
+      })
+        .wait('stdout', "Watching 'src/' for changes...")
+        .wait(
+          'stdout',
+          "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+        )
+        .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .kill()
+        .end();
+    },
+  );
+
+  it('logs manifest errors', async () => {
+    // Write something to the bundle, so that the shasum doesn't match.
+    await fs.writeFile(join(SNAP_DIR, 'dist/bundle.js'), '// Hello, world!');
+
+    await run({
+      command: 'manifest',
+      options: ['--fix false'],
+    })
+      .debug(LogLevel.INFO)
+      .stderr('Manifest Error: The manifest is invalid.')
+      .stderr(
+        'Manifest Error: "snap.manifest.json" "shasum" field does not match computed shasum.',
+      )
+      .code(1)
+      .end();
+  });
+
+  it('fixes manifest errors', async () => {
+    // Write something to the bundle, so that the shasum doesn't match.
+    await fs.mkdir(join(SNAP_DIR, 'dist'), { recursive: true });
+    await fs.writeFile(join(SNAP_DIR, 'dist/bundle.js'), '// Hello, world!');
+
+    // Since this is an end-to-end test, and we're working with a "real" snap,
+    // we have to make a copy of the original snap file, so we can modify it and
+    // reset it after the test.
+    const filePath = join(SNAP_DIR, 'snap.manifest.json');
+    const originalFile = await fs.readFile(filePath, 'utf-8');
+
+    await run({
+      command: 'manifest',
+      options: ['--fix true'],
+    })
+      .debug(LogLevel.INFO)
+      .code(0)
+      .end();
+
+    const manifest = await fs.readFile(filePath, 'utf-8').then(JSON.parse);
+
+    expect(manifest.source.shasum).toBe(
+      'SKqZnDaIdSkxTrAKJrEw6W1OnVzNdpsM9aleK9DTuTk=',
+    );
+
+    await fs.writeFile(filePath, originalFile, 'utf-8');
+  });
+});

--- a/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
@@ -1,7 +1,7 @@
 import { run } from '../../test-utils';
 
 describe('mm-snap manifest', () => {
-  it.skip.each(['manifest', 'm'])(
+  it.each(['manifest', 'm'])(
     'validates the manifest using "mm-snap %s"',
     async (command) => {
       await run({

--- a/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/manifest/manifest.e2e.test.ts
@@ -1,83 +1,14 @@
-import { promises as fs } from 'fs';
-import { join } from 'path';
-
-import { run, SNAP_DIR } from '../../test-utils';
-
-jest.unmock('fs');
-
-const MANIFEST_PATH = join(SNAP_DIR, 'snap.manifest.json');
-const PACKAGE_JSON_PATH = join(SNAP_DIR, 'package.json');
+import { run } from '../../test-utils';
 
 describe('mm-snap manifest', () => {
-  let originalManifest: string;
-  let originalPackageJsonFile: string;
-
-  beforeEach(async () => {
-    originalManifest = await fs.readFile(MANIFEST_PATH, 'utf-8');
-    originalPackageJsonFile = await fs.readFile(PACKAGE_JSON_PATH, 'utf-8');
-  });
-
-  afterEach(async () => {
-    await fs.writeFile(MANIFEST_PATH, originalManifest, 'utf-8');
-    await fs.writeFile(PACKAGE_JSON_PATH, originalPackageJsonFile, 'utf-8');
-  });
-
   it.each(['manifest', 'm'])(
     'validates the manifest using "mm-snap %s"',
     async (command) => {
       await run({
         command,
       })
-        .wait('stdout', "Watching 'src/' for changes...")
-        .wait(
-          'stdout',
-          "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
-        )
-        .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
-        .kill()
+        .code(0)
         .end();
     },
   );
-
-  it('logs and fixes manifest errors', async () => {
-    // Write something to the package.json, so that the manifest doesn't match.
-    const packageJson = JSON.parse(originalPackageJsonFile);
-    await fs.writeFile(
-      PACKAGE_JSON_PATH,
-      JSON.stringify(
-        {
-          ...packageJson,
-          repository: {
-            ...packageJson.repository,
-            url: 'https://example.com',
-          },
-        },
-        null,
-        2,
-      ),
-    );
-
-    await run({
-      command: 'manifest',
-      options: ['--fix false'],
-    })
-      .stderr('Manifest Error: The manifest is invalid.')
-      .stderr(
-        'Manifest Error: "snap.manifest.json" "repository" field does not match the "package.json" "repository" field.',
-      )
-      .code(1)
-      .kill()
-      .end();
-
-    await run({
-      command: 'manifest',
-      options: ['--fix true'],
-    })
-      .code(0)
-      .kill()
-      .end();
-
-    const manifest = await fs.readFile(MANIFEST_PATH, 'utf-8').then(JSON.parse);
-    expect(manifest.repository.url).toBe('https://example.com');
-  });
 });

--- a/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
@@ -1,4 +1,4 @@
-import { kill, run } from '@metamask/snaps-cli/test-utils';
+import { run } from '@metamask/snaps-cli/test-utils';
 import fetch from 'cross-fetch';
 
 describe('mm-snap serve', () => {
@@ -16,9 +16,9 @@ describe('mm-snap serve', () => {
     async ({ command, port }) => {
       expect.assertions(1);
 
-      const runner = run({
+      await run({
         command,
-        options: [`--port ${port}`],
+        options: ['--port', port],
       })
         .stdout('Starting server...')
         .stdout(`Server listening on: http://localhost:${port}`)
@@ -26,10 +26,9 @@ describe('mm-snap serve', () => {
           const response = await fetch(`http://localhost:${port}`);
           expect(response.ok).toBe(true);
         })
-        .kill();
-
-      await runner.end();
-      kill(runner);
+        .stdout('Handling incoming request for: /')
+        .kill()
+        .end();
     },
   );
 });

--- a/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
@@ -1,0 +1,39 @@
+import { run } from '@metamask/snaps-cli/test-utils';
+import { WaitType } from 'clet';
+import fetch from 'cross-fetch';
+
+describe('mm-snap serve', () => {
+  it.each([
+    {
+      command: 'serve',
+      port: '8086',
+    },
+    {
+      command: 's',
+      port: '8087',
+    },
+  ])(
+    'serves a snap over HTTP on port $port using "mm-snap $command"',
+    async ({ command, port }) => {
+      expect.assertions(1);
+
+      await run({
+        command,
+        options: [`--port ${port}`],
+      })
+        .wait('stdout' as WaitType, 'Starting server...')
+        .wait(
+          'stdout' as WaitType,
+          `Server listening on: http://localhost:${port}`,
+        )
+        // The types are inaccurate: `tap` supports `async` functions.
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        .tap(async () => {
+          const response = await fetch(`http://localhost:${port}`);
+          expect(response.ok).toBe(true);
+        })
+        .kill()
+        .end();
+    },
+  );
+});

--- a/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
@@ -1,5 +1,4 @@
 import { run } from '@metamask/snaps-cli/test-utils';
-import { WaitType } from 'clet';
 import fetch from 'cross-fetch';
 
 describe('mm-snap serve', () => {
@@ -21,13 +20,8 @@ describe('mm-snap serve', () => {
         command,
         options: [`--port ${port}`],
       })
-        .wait('stdout' as WaitType, 'Starting server...')
-        .wait(
-          'stdout' as WaitType,
-          `Server listening on: http://localhost:${port}`,
-        )
-        // The types are inaccurate: `tap` supports `async` functions.
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        .wait('stdout', 'Starting server...')
+        .wait('stdout', `Server listening on: http://localhost:${port}`)
         .tap(async () => {
           const response = await fetch(`http://localhost:${port}`);
           expect(response.ok).toBe(true);

--- a/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
@@ -1,4 +1,4 @@
-import { run } from '@metamask/snaps-cli/test-utils';
+import { kill, run } from '@metamask/snaps-cli/test-utils';
 import fetch from 'cross-fetch';
 
 describe('mm-snap serve', () => {
@@ -16,7 +16,7 @@ describe('mm-snap serve', () => {
     async ({ command, port }) => {
       expect.assertions(1);
 
-      await run({
+      const runner = run({
         command,
         options: [`--port ${port}`],
       })
@@ -26,8 +26,10 @@ describe('mm-snap serve', () => {
           const response = await fetch(`http://localhost:${port}`);
           expect(response.ok).toBe(true);
         })
-        .kill()
-        .end();
+        .kill();
+
+      await runner.end();
+      kill(runner);
     },
   );
 });

--- a/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
@@ -2,7 +2,7 @@ import { run } from '@metamask/snaps-cli/test-utils';
 import fetch from 'cross-fetch';
 
 describe('mm-snap serve', () => {
-  it.each([
+  it.skip.each([
     {
       command: 'serve',
       port: '8086',

--- a/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/serve/serve.e2e.test.ts
@@ -2,7 +2,7 @@ import { run } from '@metamask/snaps-cli/test-utils';
 import fetch from 'cross-fetch';
 
 describe('mm-snap serve', () => {
-  it.skip.each([
+  it.each([
     {
       command: 'serve',
       port: '8086',
@@ -20,8 +20,8 @@ describe('mm-snap serve', () => {
         command,
         options: [`--port ${port}`],
       })
-        .wait('stdout', 'Starting server...')
-        .wait('stdout', `Server listening on: http://localhost:${port}`)
+        .stdout('Starting server...')
+        .stdout(`Server listening on: http://localhost:${port}`)
         .tap(async () => {
           const response = await fetch(`http://localhost:${port}`);
           expect(response.ok).toBe(true);

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -13,15 +13,8 @@ describe('mm-snap watch', () => {
         options: ['--serve', 'false'],
       })
         .stdout(/Watching '.*' for changes.../u)
-        .stdout(
-          `Build success: '${join('src', 'index.ts')}' bundled as '${join(
-            'dist',
-            'bundle.js',
-          )}'!`,
-        )
-        .stdout(
-          `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
-        )
+        .stdout(/Build success: '.*' bundled as '.*'!/u)
+        .stdout(/Eval Success: evaluated '.*' in SES!/u)
         .kill()
         .end();
     },
@@ -39,13 +32,8 @@ describe('mm-snap watch', () => {
       options: ['--serve', 'false'],
     })
       .stdout(/Watching '.*' for changes.../u)
-      .stdout(
-        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
-          'dist',
-          'bundle.js',
-        )}'!`,
-      )
-      .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
+      .stdout(/Build success: '.*' bundled as '.*'!/u)
+      .stdout(/Eval Success: evaluated '.*' in SES!/u)
       .tap(async () => {
         await fs.writeFile(
           filePath,
@@ -53,14 +41,9 @@ describe('mm-snap watch', () => {
           'utf-8',
         );
       })
-      .stdout(
-        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
-          'dist',
-          'bundle.js',
-        )}'!`,
-      )
+      .stdout(/Build success: '.*' bundled as '.*'!/u)
       .stdout('This should show up during eval.')
-      .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
+      .stdout(/Eval Success: evaluated '.*' in SES!/u)
       .kill()
       .end();
 
@@ -73,13 +56,8 @@ describe('mm-snap watch', () => {
       options: ['--port', '8088'],
     })
       .stdout(/Watching '.*' for changes.../u)
-      .stdout(
-        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
-          'dist',
-          'bundle.js',
-        )}'!`,
-      )
-      .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
+      .stdout(/Build success: '.*' bundled as '.*'!/u)
+      .stdout(/Eval Success: evaluated '.*' in SES!/u)
       .stdout('Starting server...')
       .stdout(`Server listening on: http://localhost:8088`)
       .tap(async () => {

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { run, SNAP_DIR } from '../../test-utils';
 
 describe('mm-snap watch', () => {
-  it.each(['watch', 'w'])(
+  it.skip.each(['watch', 'w'])(
     'builds and watches for changes using "mm-snap %s"',
     async (command) => {
       await run({
@@ -29,7 +29,7 @@ describe('mm-snap watch', () => {
     },
   );
 
-  it('rebuilds after a change', async () => {
+  it.skip('rebuilds after a change', async () => {
     // Since this is an end-to-end test, and we're working with a "real" snap,
     // we have to make a copy of the original snap file, so we can modify it and
     // reset it after the test.
@@ -77,7 +77,7 @@ describe('mm-snap watch', () => {
     await fs.writeFile(filePath, originalFile, 'utf-8');
   });
 
-  it('serves the snap by default', async () => {
+  it.skip('serves the snap by default', async () => {
     await run({
       command: 'watch',
       options: ['--port 8088'],

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -10,6 +10,7 @@ describe('mm-snap watch', () => {
     async (command) => {
       await run({
         command,
+        options: ['--serve false'],
       })
         .wait('stdout', "Watching 'src/' for changes...")
         .wait(
@@ -31,6 +32,7 @@ describe('mm-snap watch', () => {
 
     await run({
       command: 'watch',
+      options: ['--serve false'],
     })
       .wait('stdout', "Watching 'src/' for changes...")
       .wait(
@@ -60,6 +62,7 @@ describe('mm-snap watch', () => {
   it('serves the snap by default', async () => {
     await run({
       command: 'watch',
+      options: ['--port 8088'],
     })
       .wait('stdout', "Watching 'src/' for changes...")
       .wait(
@@ -68,9 +71,9 @@ describe('mm-snap watch', () => {
       )
       .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
       .wait('stdout', 'Starting server...')
-      .wait('stdout', `Server listening on: http://localhost:8086`)
+      .wait('stdout', `Server listening on: http://localhost:8088`)
       .tap(async () => {
-        const response = await fetch(`http://localhost:8086`);
+        const response = await fetch(`http://localhost:8088`);
         expect(response.ok).toBe(true);
       })
       .kill()

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -1,4 +1,3 @@
-import { LogLevel } from 'clet';
 import fetch from 'cross-fetch';
 import { promises as fs } from 'fs';
 import { join } from 'path';
@@ -11,7 +10,6 @@ describe('mm-snap watch', () => {
     async (command) => {
       await run({
         command,
-        options: ['--serve false'],
       })
         .wait('stdout', "Watching 'src/' for changes...")
         .wait(
@@ -33,7 +31,6 @@ describe('mm-snap watch', () => {
 
     await run({
       command: 'watch',
-      options: ['--serve false'],
     })
       .wait('stdout', "Watching 'src/' for changes...")
       .wait(
@@ -54,7 +51,6 @@ describe('mm-snap watch', () => {
       )
       .wait('stdout', 'This should show up during eval.')
       .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
-      .debug(LogLevel.INFO)
       .kill()
       .end();
 

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -15,9 +15,15 @@ describe('mm-snap watch', () => {
         .wait('stdout', "Watching 'src/' for changes...")
         .wait(
           'stdout',
-          "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+          `Build success: '${join('src', 'index.ts')}' bundled as '${join(
+            'dist',
+            'bundle.js',
+          )}'!`,
         )
-        .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .wait(
+          'stdout',
+          `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
+        )
         .kill()
         .end();
     },
@@ -37,9 +43,15 @@ describe('mm-snap watch', () => {
       .wait('stdout', "Watching 'src/' for changes...")
       .wait(
         'stdout',
-        "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
+          'dist',
+          'bundle.js',
+        )}'!`,
       )
-      .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .wait(
+        'stdout',
+        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
+      )
       .tap(async () => {
         await fs.writeFile(
           filePath,
@@ -49,10 +61,16 @@ describe('mm-snap watch', () => {
       })
       .wait(
         'stdout',
-        "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
+          'dist',
+          'bundle.js',
+        )}'!`,
       )
       .wait('stdout', 'This should show up during eval.')
-      .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .wait(
+        'stdout',
+        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
+      )
       .kill()
       .end();
 
@@ -67,9 +85,15 @@ describe('mm-snap watch', () => {
       .wait('stdout', "Watching 'src/' for changes...")
       .wait(
         'stdout',
-        "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+        `Build success: '${join('src', 'index.ts')}' bundled as '${join(
+          'dist',
+          'bundle.js',
+        )}'!`,
       )
-      .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .wait(
+        'stdout',
+        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
+      )
       .wait('stdout', 'Starting server...')
       .wait('stdout', `Server listening on: http://localhost:8088`)
       .tap(async () => {

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -5,23 +5,21 @@ import { join } from 'path';
 import { run, SNAP_DIR } from '../../test-utils';
 
 describe('mm-snap watch', () => {
-  it.skip.each(['watch', 'w'])(
+  it.each(['watch', 'w'])(
     'builds and watches for changes using "mm-snap %s"',
     async (command) => {
       await run({
         command,
         options: ['--serve false'],
       })
-        .wait('stdout', "Watching 'src/' for changes...")
-        .wait(
-          'stdout',
+        .stdout("Watching 'src/' for changes...")
+        .stdout(
           `Build success: '${join('src', 'index.ts')}' bundled as '${join(
             'dist',
             'bundle.js',
           )}'!`,
         )
-        .wait(
-          'stdout',
+        .stdout(
           `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
         )
         .kill()
@@ -29,7 +27,7 @@ describe('mm-snap watch', () => {
     },
   );
 
-  it.skip('rebuilds after a change', async () => {
+  it('rebuilds after a change', async () => {
     // Since this is an end-to-end test, and we're working with a "real" snap,
     // we have to make a copy of the original snap file, so we can modify it and
     // reset it after the test.
@@ -40,18 +38,14 @@ describe('mm-snap watch', () => {
       command: 'watch',
       options: ['--serve false'],
     })
-      .wait('stdout', "Watching 'src/' for changes...")
-      .wait(
-        'stdout',
+      .stdout("Watching 'src/' for changes...")
+      .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
           'dist',
           'bundle.js',
         )}'!`,
       )
-      .wait(
-        'stdout',
-        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
-      )
+      .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
       .tap(async () => {
         await fs.writeFile(
           filePath,
@@ -59,43 +53,35 @@ describe('mm-snap watch', () => {
           'utf-8',
         );
       })
-      .wait(
-        'stdout',
+      .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
           'dist',
           'bundle.js',
         )}'!`,
       )
-      .wait('stdout', 'This should show up during eval.')
-      .wait(
-        'stdout',
-        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
-      )
+      .stdout('This should show up during eval.')
+      .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
       .kill()
       .end();
 
     await fs.writeFile(filePath, originalFile, 'utf-8');
   });
 
-  it.skip('serves the snap by default', async () => {
+  it('serves the snap by default', async () => {
     await run({
       command: 'watch',
       options: ['--port 8088'],
     })
-      .wait('stdout', "Watching 'src/' for changes...")
-      .wait(
-        'stdout',
+      .stdout("Watching 'src/' for changes...")
+      .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
           'dist',
           'bundle.js',
         )}'!`,
       )
-      .wait(
-        'stdout',
-        `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
-      )
-      .wait('stdout', 'Starting server...')
-      .wait('stdout', `Server listening on: http://localhost:8088`)
+      .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
+      .stdout('Starting server...')
+      .stdout(`Server listening on: http://localhost:8088`)
       .tap(async () => {
         const response = await fetch(`http://localhost:8088`);
         expect(response.ok).toBe(true);

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -2,13 +2,13 @@ import fetch from 'cross-fetch';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
-import { run, SNAP_DIR } from '../../test-utils';
+import { kill, run, SNAP_DIR } from '../../test-utils';
 
 describe('mm-snap watch', () => {
   it.each(['watch', 'w'])(
     'builds and watches for changes using "mm-snap %s"',
     async (command) => {
-      await run({
+      const runner = run({
         command,
         options: ['--serve false'],
       })
@@ -22,8 +22,10 @@ describe('mm-snap watch', () => {
         .stdout(
           `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
         )
-        .kill()
-        .end();
+        .kill();
+
+      await runner.end();
+      kill(runner);
     },
   );
 
@@ -34,7 +36,7 @@ describe('mm-snap watch', () => {
     const filePath = join(SNAP_DIR, 'src/index.ts');
     const originalFile = await fs.readFile(filePath, 'utf-8');
 
-    await run({
+    const runner = run({
       command: 'watch',
       options: ['--serve false'],
     })
@@ -61,14 +63,16 @@ describe('mm-snap watch', () => {
       )
       .stdout('This should show up during eval.')
       .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
-      .kill()
-      .end();
+      .kill();
+
+    await runner.end();
+    kill(runner);
 
     await fs.writeFile(filePath, originalFile, 'utf-8');
   });
 
   it('serves the snap by default', async () => {
-    await run({
+    const runner = run({
       command: 'watch',
       options: ['--port 8088'],
     })
@@ -86,7 +90,9 @@ describe('mm-snap watch', () => {
         const response = await fetch(`http://localhost:8088`);
         expect(response.ok).toBe(true);
       })
-      .kill()
-      .end();
+      .kill();
+
+    await runner.end();
+    kill(runner);
   });
 });

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -2,15 +2,15 @@ import fetch from 'cross-fetch';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
-import { kill, run, SNAP_DIR } from '../../test-utils';
+import { run, SNAP_DIR } from '../../test-utils';
 
 describe('mm-snap watch', () => {
   it.each(['watch', 'w'])(
     'builds and watches for changes using "mm-snap %s"',
     async (command) => {
-      const runner = run({
+      await run({
         command,
-        options: ['--serve false'],
+        options: ['--serve', 'false'],
       })
         .stdout("Watching 'src/' for changes...")
         .stdout(
@@ -22,10 +22,8 @@ describe('mm-snap watch', () => {
         .stdout(
           `Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`,
         )
-        .kill();
-
-      await runner.end();
-      kill(runner);
+        .kill()
+        .end();
     },
   );
 
@@ -36,9 +34,9 @@ describe('mm-snap watch', () => {
     const filePath = join(SNAP_DIR, 'src/index.ts');
     const originalFile = await fs.readFile(filePath, 'utf-8');
 
-    const runner = run({
+    await run({
       command: 'watch',
-      options: ['--serve false'],
+      options: ['--serve', 'false'],
     })
       .stdout("Watching 'src/' for changes...")
       .stdout(
@@ -63,18 +61,16 @@ describe('mm-snap watch', () => {
       )
       .stdout('This should show up during eval.')
       .stdout(`Eval Success: evaluated '${join('dist', 'bundle.js')}' in SES!`)
-      .kill();
-
-    await runner.end();
-    kill(runner);
+      .kill()
+      .end();
 
     await fs.writeFile(filePath, originalFile, 'utf-8');
   });
 
   it('serves the snap by default', async () => {
-    const runner = run({
+    await run({
       command: 'watch',
-      options: ['--port 8088'],
+      options: ['--port', '8088'],
     })
       .stdout("Watching 'src/' for changes...")
       .stdout(
@@ -90,9 +86,8 @@ describe('mm-snap watch', () => {
         const response = await fetch(`http://localhost:8088`);
         expect(response.ok).toBe(true);
       })
-      .kill();
-
-    await runner.end();
-    kill(runner);
+      .stdout('Handling incoming request for: /')
+      .kill()
+      .end();
   });
 });

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -1,0 +1,83 @@
+import { LogLevel } from 'clet';
+import fetch from 'cross-fetch';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+import { run, SNAP_DIR } from '../../test-utils';
+
+describe('mm-snap watch', () => {
+  it.each(['watch', 'w'])(
+    'builds and watches for changes using "mm-snap %s"',
+    async (command) => {
+      await run({
+        command,
+        options: ['--serve false'],
+      })
+        .wait('stdout', "Watching 'src/' for changes...")
+        .wait(
+          'stdout',
+          "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+        )
+        .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+        .kill()
+        .end();
+    },
+  );
+
+  it('rebuilds after a change', async () => {
+    // Since this is an end-to-end test, and we're working with a "real" snap,
+    // we have to make a copy of the original snap file, so we can modify it and
+    // reset it after the test.
+    const filePath = join(SNAP_DIR, 'src/index.ts');
+    const originalFile = await fs.readFile(filePath, 'utf-8');
+
+    await run({
+      command: 'watch',
+      options: ['--serve false'],
+    })
+      .wait('stdout', "Watching 'src/' for changes...")
+      .wait(
+        'stdout',
+        "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+      )
+      .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .tap(async () => {
+        await fs.writeFile(
+          filePath,
+          `${originalFile}\nconsole.log("This should show up during eval.");`,
+          'utf-8',
+        );
+      })
+      .wait(
+        'stdout',
+        "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+      )
+      .wait('stdout', 'This should show up during eval.')
+      .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .debug(LogLevel.INFO)
+      .kill()
+      .end();
+
+    await fs.writeFile(filePath, originalFile, 'utf-8');
+  });
+
+  it('serves the snap by default', async () => {
+    await run({
+      command: 'watch',
+    })
+      .wait('stdout', "Watching 'src/' for changes...")
+      .wait(
+        'stdout',
+        "Build success: 'src/index.ts' bundled as 'dist/bundle.js'!",
+      )
+      .wait('stdout', "Eval Success: evaluated 'dist/bundle.js' in SES!")
+      .wait('stdout', 'Starting server...')
+      .wait('stdout', `Server listening on: http://localhost:8086`)
+      .tap(async () => {
+        const response = await fetch(`http://localhost:8086`);
+        expect(response.ok).toBe(true);
+      })
+      .kill()
+      .end();
+  });
+});

--- a/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watch.e2e.test.ts
@@ -12,7 +12,7 @@ describe('mm-snap watch', () => {
         command,
         options: ['--serve', 'false'],
       })
-        .stdout("Watching 'src/' for changes...")
+        .stdout(/Watching '.*' for changes.../u)
         .stdout(
           `Build success: '${join('src', 'index.ts')}' bundled as '${join(
             'dist',
@@ -38,7 +38,7 @@ describe('mm-snap watch', () => {
       command: 'watch',
       options: ['--serve', 'false'],
     })
-      .stdout("Watching 'src/' for changes...")
+      .stdout(/Watching '.*' for changes.../u)
       .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
           'dist',
@@ -72,7 +72,7 @@ describe('mm-snap watch', () => {
       command: 'watch',
       options: ['--port', '8088'],
     })
-      .stdout("Watching 'src/' for changes...")
+      .stdout(/Watching '.*' for changes.../u)
       .stdout(
         `Build success: '${join('src', 'index.ts')}' bundled as '${join(
           'dist',

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -1,4 +1,4 @@
-import { LogLevel, runner } from 'clet';
+import { LogLevel, runner, TestRunner } from 'clet';
 import { join } from 'path';
 
 export const SNAP_DIR = join('..', 'examples/examples/typescript');
@@ -24,7 +24,7 @@ export function run({
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
   const testRunner = runner()
-    .debug(LogLevel.ERROR)
+    .debug(LogLevel.Verbose)
     .cwd(workingDirectory)
     .spawn(
       'yarn',
@@ -56,4 +56,14 @@ export function run({
   };
 
   return testRunner;
+}
+
+/**
+ * Kill the test runner. This is useful for testing long-running commands.
+ *
+ * @param testRunner - The test runner.
+ */
+export function kill(testRunner: TestRunner) {
+  testRunner.proc.kill();
+  testRunner.proc.unref();
 }

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -23,8 +23,21 @@ export function run({
   options = [],
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
-  return runner()
-    .debug(LogLevel.ERROR)
-    .cwd(workingDirectory)
-    .spawn('yarn', ['mm-snap', command, ...options], {});
+  return (
+    runner()
+      .debug(LogLevel.ERROR)
+      .cwd(workingDirectory)
+      // `yarn ts-node --files src/main.ts [command] [options]`
+      .spawn(
+        'yarn',
+        [
+          'ts-node',
+          '--files',
+          join(__dirname, '../main.ts'),
+          command,
+          ...options,
+        ],
+        {},
+      )
+  );
 }

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -24,7 +24,7 @@ export function run({
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
   const testRunner = runner()
-    .debug(LogLevel.Verbose)
+    .debug(LogLevel.ERROR)
     .cwd(workingDirectory)
     .fork(
       require.resolve('ts-node/dist/bin.js'),

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -24,7 +24,7 @@ export function run({
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
   return runner()
-    .debug(LogLevel.Verbose)
+    .debug(LogLevel.ERROR)
     .cwd(workingDirectory)
     .spawn(
       'yarn',

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -23,7 +23,7 @@ export function run({
   options = [],
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
-  return runner()
+  const testRunner = runner()
     .debug(LogLevel.ERROR)
     .cwd(workingDirectory)
     .spawn(
@@ -39,4 +39,21 @@ export function run({
       ],
       {},
     );
+
+  const originalStdout = testRunner.stdout.bind(testRunner);
+  const originalStderr = testRunner.stderr.bind(testRunner);
+
+  testRunner.stdout = (...args: Parameters<typeof originalStdout>) => {
+    testRunner.wait('stdout', ...args);
+    originalStdout(...args);
+    return testRunner;
+  };
+
+  testRunner.stderr = (...args: Parameters<typeof originalStderr>) => {
+    testRunner.wait('stderr', ...args);
+    originalStderr(...args);
+    return testRunner;
+  };
+
+  return testRunner;
 }

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -24,7 +24,7 @@ export function run({
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
   const testRunner = runner()
-    .debug(LogLevel.Verbose)
+    .debug(LogLevel.ERROR)
     .cwd(workingDirectory)
     .spawn(
       'yarn',

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -23,21 +23,20 @@ export function run({
   options = [],
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
-  return (
-    runner()
-      .debug(LogLevel.ERROR)
-      .cwd(workingDirectory)
-      // `yarn ts-node --files src/main.ts [command] [options]`
-      .spawn(
-        'yarn',
-        [
-          'ts-node',
-          '--files',
-          join(__dirname, '../main.ts'),
-          command,
-          ...options,
-        ],
-        {},
-      )
-  );
+  return runner()
+    .debug(LogLevel.ERROR)
+    .cwd(workingDirectory)
+    .spawn(
+      'yarn',
+      [
+        'ts-node',
+        '--require tsconfig-paths/register',
+        '--files',
+        '--swc',
+        join(__dirname, '../main.ts'),
+        command,
+        ...options,
+      ],
+      {},
+    );
 }

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -1,4 +1,4 @@
-import { LogLevel, runner, TestRunner } from 'clet';
+import { LogLevel, runner } from 'clet';
 import { join } from 'path';
 
 export const SNAP_DIR = join('..', 'examples/examples/typescript');
@@ -24,13 +24,13 @@ export function run({
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
   const testRunner = runner()
-    .debug(LogLevel.ERROR)
+    .debug(LogLevel.Verbose)
     .cwd(workingDirectory)
-    .spawn(
-      'yarn',
+    .fork(
+      require.resolve('ts-node/dist/bin.js'),
       [
-        'ts-node',
-        '--require tsconfig-paths/register',
+        '--require',
+        'tsconfig-paths/register',
         '--files',
         '--swc',
         join(__dirname, '../main.ts'),
@@ -56,14 +56,4 @@ export function run({
   };
 
   return testRunner;
-}
-
-/**
- * Kill the test runner. This is useful for testing long-running commands.
- *
- * @param testRunner - The test runner.
- */
-export function kill(testRunner: TestRunner) {
-  testRunner.proc.kill();
-  testRunner.proc.unref();
 }

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -1,0 +1,30 @@
+import { LogLevel, runner } from 'clet';
+import { join } from 'path';
+
+export const SNAP_DIR = join('..', 'examples/examples/typescript');
+
+type RunOptions = {
+  command: string;
+  options?: string[];
+  workingDirectory?: string;
+};
+
+/**
+ * Get a command runner.
+ *
+ * @param options - The run options.
+ * @param options.command - The `mm-snap` CLI command to run.
+ * @param options.options - The options to pass to `mm-snap`.
+ * @param options.workingDirectory - The working directory to run the command in.
+ * @returns The test runner.
+ */
+export function run({
+  command,
+  options = [],
+  workingDirectory = SNAP_DIR,
+}: RunOptions) {
+  return runner()
+    .debug(LogLevel.ERROR)
+    .cwd(workingDirectory)
+    .spawn('yarn', ['mm-snap', command, ...options], {});
+}

--- a/packages/snaps-cli/src/test-utils/e2e.ts
+++ b/packages/snaps-cli/src/test-utils/e2e.ts
@@ -24,7 +24,7 @@ export function run({
   workingDirectory = SNAP_DIR,
 }: RunOptions) {
   return runner()
-    .debug(LogLevel.ERROR)
+    .debug(LogLevel.Verbose)
     .cwd(workingDirectory)
     .spawn(
       'yarn',

--- a/packages/snaps-cli/src/test-utils/index.ts
+++ b/packages/snaps-cli/src/test-utils/index.ts
@@ -1,1 +1,2 @@
+export * from './e2e';
 export * from './fs';

--- a/packages/snaps-utils/src/eval-worker.js
+++ b/packages/snaps-utils/src/eval-worker.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+
+// This exists just for testing.
+require('./eval-worker.ts');

--- a/packages/snaps-utils/tsconfig.build.json
+++ b/packages/snaps-utils/tsconfig.build.json
@@ -11,6 +11,7 @@
     "./src/**/test-utils",
     "./src/**/__mocks__",
     "./src/**/__snapshots__",
+    "./src/eval-worker.js",
     "wdio.config.ts",
     "scripts"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3252,6 +3252,7 @@ __metadata:
     browserify: ^17.0.0
     chokidar: ^3.5.2
     clet: ^1.0.1
+    cross-fetch: ^3.1.5
     deepmerge: ^4.2.2
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
@@ -8199,7 +8200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:3.1.5, cross-fetch@npm:^3.0.4":
+"cross-fetch@npm:3.1.5, cross-fetch@npm:^3.0.4, cross-fetch@npm:^3.1.5":
   version: 3.1.5
   resolution: "cross-fetch@npm:3.1.5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7588,7 +7588,7 @@ __metadata:
 
 "clet@patch:clet@npm%3A1.0.1#./.yarn/patches/clet-npm-1.0.1-8523231bdc.patch::locator=root%40workspace%3A.":
   version: 1.0.1
-  resolution: "clet@patch:clet@npm%3A1.0.1#./.yarn/patches/clet-npm-1.0.1-8523231bdc.patch::version=1.0.1&hash=3eea2e&locator=root%40workspace%3A."
+  resolution: "clet@patch:clet@npm%3A1.0.1#./.yarn/patches/clet-npm-1.0.1-8523231bdc.patch::version=1.0.1&hash=36f435&locator=root%40workspace%3A."
   dependencies:
     dirname-filename-esm: ^1.1.1
     dot-prop: ^7.2.0
@@ -7599,7 +7599,7 @@ __metadata:
     strip-final-newline: ^3.0.0
     throwback: ^4.1.0
     trash: ^8.1.0
-  checksum: eea36cc7f2db80e67b5820b276ba9c223b07df4afb4c48bf14f121d8dd8251a31418ae70ebb5f792bc420ef853b0a68216a3a32043a9e4a579fd2bfa1eab7274
+  checksum: 622901aa005f88f191cbd5534f31c889c7abd6f46f2df60d11c6ce077a1e4e3af441b8f59cef40b5b1de40b24ec485bbc5699de6a449f2e227465d6223819e2d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,7 +3273,7 @@ __metadata:
     ses: ^0.18.1
     superstruct: ^1.0.3
     ts-jest: ^29.0.0
-    ts-node: ^10.7.0
+    ts-node: ^10.9.1
     tsc-watch: ^4.5.0
     typescript: ~4.8.4
     yargs: ^16.2.0
@@ -19186,6 +19186,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^3.0.2
+    ts-node: ^10.9.1
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,32 +2681,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:^29.0.3":
-  version: 29.0.3
-  resolution: "@jest/transform@npm:29.0.3"
+"@jest/transform@npm:^29.0.3, @jest/transform@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "@jest/transform@npm:29.5.0"
   dependencies:
     "@babel/core": ^7.11.6
-    "@jest/types": ^29.0.3
+    "@jest/types": ^29.5.0
     "@jridgewell/trace-mapping": ^0.3.15
     babel-plugin-istanbul: ^6.1.1
     chalk: ^4.0.0
-    convert-source-map: ^1.4.0
+    convert-source-map: ^2.0.0
     fast-json-stable-stringify: ^2.1.0
     graceful-fs: ^4.2.9
-    jest-haste-map: ^29.0.3
-    jest-regex-util: ^29.0.0
-    jest-util: ^29.0.3
+    jest-haste-map: ^29.5.0
+    jest-regex-util: ^29.4.3
+    jest-util: ^29.5.0
     micromatch: ^4.0.4
     pirates: ^4.0.4
     slash: ^3.0.0
-    write-file-atomic: ^4.0.1
-  checksum: c68ebb673a27640372c912736aa26bda5bc4dfd7a890bb10c467b81e8a66826c8b8b6826ebf25ed3c7a70b7818fcc60e3c0d7341d1595d5ce4978d53d22a7ea1
+    write-file-atomic: ^4.0.2
+  checksum: d55d604085c157cf5112e165ff5ac1fa788873b3b31265fb4734ca59892ee24e44119964cc47eb6d178dd9512bbb6c576d1e20e51a201ff4e24d31e818a1c92d
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^29.0.3, @jest/types@npm:^29.1.0, @jest/types@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "@jest/types@npm:29.4.3"
+"@jest/types@npm:^29.0.3, @jest/types@npm:^29.1.0, @jest/types@npm:^29.4.3, @jest/types@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "@jest/types@npm:29.5.0"
   dependencies:
     "@jest/schemas": ^29.4.3
     "@types/istanbul-lib-coverage": ^2.0.0
@@ -2714,7 +2714,7 @@ __metadata:
     "@types/node": "*"
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
-  checksum: 1756f4149d360f98567f56f434144f7af23ed49a2c42889261a314df6b6654c2de70af618fb2ee0ee39cadaf10835b885845557184509503646c9cb9dcc02bac
+  checksum: 1811f94b19cf8a9460a289c4f056796cfc373480e0492692a6125a553cd1a63824bd846d7bb78820b7b6f758f6dd3c2d4558293bb676d541b2fa59c70fdf9d39
   languageName: node
   linkType: hard
 
@@ -3247,9 +3247,11 @@ __metadata:
     "@types/yargs": ^15.0.12
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
+    babel-jest: ^29.5.0
     babelify: ^10.0.0
     browserify: ^17.0.0
     chokidar: ^3.5.2
+    clet: ^1.0.1
     deepmerge: ^4.2.2
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
@@ -4052,6 +4054,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sindresorhus/chunkify@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@sindresorhus/chunkify@npm:0.2.0"
+  checksum: a17d8a385f1c2381d98eaa69d7fb543b65445a4b990750f1e3e78e3ae5fbcb70ebd2e93da8c11a3ac0cbd7e496e72e594c4519967eb15b1abea5b101acee243e
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/df@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@sindresorhus/df@npm:1.0.1"
+  checksum: 0cb43b4ed9fc41e28124362dd4735c1f067d3c8963ccc3cf1684da050c5263bb5f5193e510ca8869e13b782fe4eb6f7ee23e4372193afea932cd0535f4c9ee2b
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/df@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@sindresorhus/df@npm:3.1.1"
+  dependencies:
+    execa: ^2.0.1
+  checksum: 6378a8c62a9df024571b655a9f83d5e55351769dc581ed58a2a0a7b25683b7e644540edda7095bf38208b84ccf9cbc7c519fa7bef6a1129a2d8f7c6cbc618023
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/is@npm:^4.0.0":
   version: 4.6.0
   resolution: "@sindresorhus/is@npm:4.6.0"
@@ -4090,6 +4115,13 @@ __metadata:
   dependencies:
     apg-js: ^4.1.1
   checksum: 708786ba2f10987c45c1fd8a6243ba6572ee7f320531616d71ff66044828bc24af66f5537ce09c9272bdae93fcc35b566a7804fe7997284f2ee5445a36e6add2
+  languageName: node
+  linkType: hard
+
+"@stroncium/procfs@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@stroncium/procfs@npm:1.2.1"
+  checksum: cb09a4a4780f97a4677964930a70597747eb480578a38b63148084d1ab1d6f71e7bd92c8918e12d0ec992ebc48f7761bce1f5e6ac8b4437add0b86b55fde844b
   languageName: node
   linkType: hard
 
@@ -5580,6 +5612,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aggregate-error@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "aggregate-error@npm:4.0.1"
+  dependencies:
+    clean-stack: ^4.0.0
+    indent-string: ^5.0.0
+  checksum: bb3ffdfd13447800fff237c2cba752c59868ee669104bb995dfbbe0b8320e967d679e683dabb640feb32e4882d60258165cde0baafc4cd467cc7d275a13ad6b5
+  languageName: node
+  linkType: hard
+
 "ajv-formats@npm:^2.1.1":
   version: 2.1.1
   resolution: "ajv-formats@npm:2.1.1"
@@ -6007,10 +6049,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-union@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "array-union@npm:1.0.2"
+  dependencies:
+    array-uniq: ^1.0.1
+  checksum: 82cec6421b6e6766556c484835a6d476a873f1b71cace5ab2b4f1b15b1e3162dc4da0d16f7a2b04d4aec18146c6638fe8f661340b31ba8e469fd811a1b45dc8d
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^2.1.0":
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
+  languageName: node
+  linkType: hard
+
+"array-uniq@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "array-uniq@npm:1.0.3"
+  checksum: 1625f06b093d8bf279b81adfec6e72951c0857d65b5e3f65f053fffe9f9dd61c2fc52cff57e38a4700817e7e3f01a4faa433d505ea9e33cdae4514c334e0bf9e
   languageName: node
   linkType: hard
 
@@ -6239,20 +6297,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:^29.0.3":
-  version: 29.0.3
-  resolution: "babel-jest@npm:29.0.3"
+"babel-jest@npm:^29.0.3, babel-jest@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "babel-jest@npm:29.5.0"
   dependencies:
-    "@jest/transform": ^29.0.3
+    "@jest/transform": ^29.5.0
     "@types/babel__core": ^7.1.14
     babel-plugin-istanbul: ^6.1.1
-    babel-preset-jest: ^29.0.2
+    babel-preset-jest: ^29.5.0
     chalk: ^4.0.0
     graceful-fs: ^4.2.9
     slash: ^3.0.0
   peerDependencies:
     "@babel/core": ^7.8.0
-  checksum: 4670945691c204464f7694017d59148b97cdbd51ff91ef492340ef5d6bbc74c461fa698a5feb04a93515300632ed44a55e85500bb61206d8a7ff60afb5b6da48
+  checksum: eafb6d37deb71f0c80bf3c80215aa46732153e5e8bcd73f6ff47d92e5c0c98c8f7f75995d0efec6289c371edad3693cd8fa2367b0661c4deb71a3a7117267ede
   languageName: node
   linkType: hard
 
@@ -6297,15 +6355,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-jest-hoist@npm:^29.0.2":
-  version: 29.0.2
-  resolution: "babel-plugin-jest-hoist@npm:29.0.2"
+"babel-plugin-jest-hoist@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "babel-plugin-jest-hoist@npm:29.5.0"
   dependencies:
     "@babel/template": ^7.3.3
     "@babel/types": ^7.3.3
     "@types/babel__core": ^7.1.14
     "@types/babel__traverse": ^7.0.6
-  checksum: e02ab2c56b471940bc147d75808f6fb5d18b81382088beb36088d2fee8c5f9699b2a814a98884539191d43871d66770928e09c268c095ec39aad5766c3337f34
+  checksum: 099b5254073b6bc985b6d2d045ad26fb8ed30ff8ae6404c4fe8ee7cd0e98a820f69e3dfb871c7c65aae0f4b65af77046244c07bb92d49ef9005c90eedf681539
   languageName: node
   linkType: hard
 
@@ -6413,15 +6471,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-jest@npm:^29.0.2":
-  version: 29.0.2
-  resolution: "babel-preset-jest@npm:29.0.2"
+"babel-preset-jest@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "babel-preset-jest@npm:29.5.0"
   dependencies:
-    babel-plugin-jest-hoist: ^29.0.2
+    babel-plugin-jest-hoist: ^29.5.0
     babel-preset-current-node-syntax: ^1.0.0
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 485db525f4cd38c02c29edcd7240dd232e8d6dbcaef88bfa4765ad3057ed733512f1b7aad06f4bf9661afefeb0ada2c4e259d130113b0289d7db574f82bbd4f8
+  checksum: 5566ca2762766c9319b4973d018d2fa08c0fcf6415c72cc54f4c8e7199e851ea8f5e6c6730f03ed7ed44fc8beefa959dd15911f2647dee47c615ff4faeddb1ad
   languageName: node
   linkType: hard
 
@@ -7501,6 +7559,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clean-stack@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "clean-stack@npm:4.2.0"
+  dependencies:
+    escape-string-regexp: 5.0.0
+  checksum: 373f656a31face5c615c0839213b9b542a0a48057abfb1df66900eab4dc2a5c6097628e4a0b5aa559cdfc4e66f8a14ea47be9681773165a44470ef5fb8ccc172
+  languageName: node
+  linkType: hard
+
+"clet@npm:1.0.1":
+  version: 1.0.1
+  resolution: "clet@npm:1.0.1"
+  dependencies:
+    dirname-filename-esm: ^1.1.1
+    dot-prop: ^7.2.0
+    execa: ^6.1.0
+    lodash.ismatch: ^4.4.0
+    p-event: ^5.0.1
+    strip-ansi: ^7.0.1
+    strip-final-newline: ^3.0.0
+    throwback: ^4.1.0
+    trash: ^8.1.0
+  checksum: cd4a5dafbe659de702fd2cdcc7503accd32b2035be503874aab8d8132056d0c236ef5da5ffdea3d1c4cc963187cc8f7f0d439fee9e7c84eaeaeb946a6192145f
+  languageName: node
+  linkType: hard
+
+"clet@patch:clet@npm%3A1.0.1#./.yarn/patches/clet-npm-1.0.1-8523231bdc.patch::locator=root%40workspace%3A.":
+  version: 1.0.1
+  resolution: "clet@patch:clet@npm%3A1.0.1#./.yarn/patches/clet-npm-1.0.1-8523231bdc.patch::version=1.0.1&hash=3eea2e&locator=root%40workspace%3A."
+  dependencies:
+    dirname-filename-esm: ^1.1.1
+    dot-prop: ^7.2.0
+    execa: ^6.1.0
+    lodash.ismatch: ^4.4.0
+    p-event: ^5.0.1
+    strip-ansi: ^7.0.1
+    strip-final-newline: ^3.0.0
+    throwback: ^4.1.0
+    trash: ^8.1.0
+  checksum: eea36cc7f2db80e67b5820b276ba9c223b07df4afb4c48bf14f121d8dd8251a31418ae70ebb5f792bc420ef853b0a68216a3a32043a9e4a579fd2bfa1eab7274
+  languageName: node
+  linkType: hard
+
 "cli-cursor@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-cursor@npm:3.1.0"
@@ -7958,10 +8059,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.5.1, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0, convert-source-map@npm:^1.8.0, convert-source-map@npm:^1.9.0":
+"convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.5.1, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0, convert-source-map@npm:^1.8.0, convert-source-map@npm:^1.9.0":
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
   checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 63ae9933be5a2b8d4509daca5124e20c14d023c820258e484e32dc324d34c2754e71297c94a05784064ad27615037ef677e3f0c00469fb55f409d2bb21261035
   languageName: node
   linkType: hard
 
@@ -8110,7 +8218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -8605,12 +8713,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dir-glob@npm:^2.0.0":
+  version: 2.2.2
+  resolution: "dir-glob@npm:2.2.2"
+  dependencies:
+    path-type: ^3.0.0
+  checksum: 3aa48714a9f7845ffc30ab03a5c674fe760477cc55e67b0847333371549227d93953e6627ec160f75140c5bea5c5f88d13c01de79bd1997a588efbcf06980842
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
   dependencies:
     path-type: ^4.0.0
   checksum: fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
+  languageName: node
+  linkType: hard
+
+"dirname-filename-esm@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "dirname-filename-esm@npm:1.1.1"
+  checksum: 189edcefe7c3d2de25a1560c6d8eab1f3a607f3b1dd3f7e1ac3923c9c5662cabd5d8a940bb2484ca2acc595d1530d66a52926596707520d82fdc38b6b7dfe1d2
   languageName: node
   linkType: hard
 
@@ -8693,6 +8817,15 @@ __metadata:
     no-case: ^3.0.4
     tslib: ^2.0.3
   checksum: a65e3519414856df0228b9f645332f974f2bf5433370f544a681122eab59e66038fc3349b4be1cdc47152779dac71a5864f1ccda2f745e767c46e9c6543b1169
+  languageName: node
+  linkType: hard
+
+"dot-prop@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "dot-prop@npm:7.2.0"
+  dependencies:
+    type-fest: ^2.11.2
+  checksum: 08e4ff14f7305ffb5fda7e4c88f3cdbeb3cd97bd27efa4f47503869a2ee7f96938b4c21b0a2abf9c37d891a1bdb3994a09d219b0dcfd6130da4eaeb44c6f067e
   languageName: node
   linkType: hard
 
@@ -9404,6 +9537,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:5.0.0, escape-string-regexp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
@@ -9415,13 +9555,6 @@ __metadata:
   version: 2.0.0
   resolution: "escape-string-regexp@npm:2.0.0"
   checksum: 9f8a2d5743677c16e85c810e3024d54f0c8dea6424fad3c79ef6666e81dd0846f7437f5e729dfcdac8981bc9e5294c39b4580814d114076b8d36318f46ae4395
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "escape-string-regexp@npm:5.0.0"
-  checksum: 20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
   languageName: node
   linkType: hard
 
@@ -10016,6 +10149,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"execa@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "execa@npm:2.1.0"
+  dependencies:
+    cross-spawn: ^7.0.0
+    get-stream: ^5.0.0
+    is-stream: ^2.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^3.0.0
+    onetime: ^5.1.0
+    p-finally: ^2.0.0
+    signal-exit: ^3.0.2
+    strip-final-newline: ^2.0.0
+  checksum: 93af9b816a555d0944e0876f4ccd97e0f4593d2049e713518fd5458a7699836449c516c6bb7e6357e11431ec40cce3150625b86d1b1254180faaa0d744265eca
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -10030,6 +10180,23 @@ __metadata:
     signal-exit: ^3.0.3
     strip-final-newline: ^2.0.0
   checksum: fba9022c8c8c15ed862847e94c252b3d946036d7547af310e344a527e59021fd8b6bb0723883ea87044dc4f0201f949046993124a42ccb0855cae5bf8c786343
+  languageName: node
+  linkType: hard
+
+"execa@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "execa@npm:6.1.0"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.1
+    human-signals: ^3.0.1
+    is-stream: ^3.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^5.1.0
+    onetime: ^6.0.0
+    signal-exit: ^3.0.7
+    strip-final-newline: ^3.0.0
+  checksum: 1a4af799839134f5c72eb63d525b87304c1114a63aa71676c91d57ccef2e26f2f53e14c11384ab11c4ec479be1efa83d11c8190e00040355c2c5c3364327fa8e
   languageName: node
   linkType: hard
 
@@ -10947,7 +11114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.1.0":
+"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -11078,7 +11245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.0, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.1.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -11186,6 +11353,20 @@ __metadata:
     merge2: ^1.4.1
     slash: ^3.0.0
   checksum: b4be8885e0cfa018fc783792942d53926c35c50b3aefd3fdcfb9d22c627639dc26bd2327a40a0b74b074100ce95bb7187bfeae2f236856aa3de183af7a02aea6
+  languageName: node
+  linkType: hard
+
+"globby@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "globby@npm:7.1.1"
+  dependencies:
+    array-union: ^1.0.1
+    dir-glob: ^2.0.0
+    glob: ^7.1.2
+    ignore: ^3.3.5
+    pify: ^3.0.0
+    slash: ^1.0.0
+  checksum: f0eba08a08ae7c98149a4411661c0bf08c4717d81e6f355cf624fb01880b249737eb8e951bf86124cb3af8ea1c793c0a9d363ed5cdec99bb2c6b68f8a323025f
   languageName: node
   linkType: hard
 
@@ -11681,6 +11862,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "human-signals@npm:3.0.1"
+  checksum: f252a7769c8094a5c9dc6772816bdb417b188820b04c8b42d0fc468e03a0ba905b1dd07afabe9385cc83504af1ccc2b985cd1e4aeeeb8e0029896c5af2e6f354
+  languageName: node
+  linkType: hard
+
 "human-signals@npm:^4.3.0":
   version: 4.3.0
   resolution: "human-signals@npm:4.3.0"
@@ -11728,6 +11916,13 @@ __metadata:
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^3.3.5":
+  version: 3.3.10
+  resolution: "ignore@npm:3.3.10"
+  checksum: 23e8cc776e367b56615ab21b78decf973a35dfca5522b39d9b47643d8168473b0d1f18dd1321a1bab466a12ea11a2411903f3b21644f4d5461ee0711ec8678bd
   languageName: node
   linkType: hard
 
@@ -11792,6 +11987,13 @@ __metadata:
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
   checksum: 824cfb9929d031dabf059bebfe08cf3137365e112019086ed3dcff6a0a7b698cb80cf67ccccde0e25b9e2d7527aa6cc1fed1ac490c752162496caba3e6699612
+  languageName: node
+  linkType: hard
+
+"indent-string@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "indent-string@npm:5.0.0"
+  checksum: e466c27b6373440e6d84fbc19e750219ce25865cb82d578e41a6053d727e5520dc5725217d6eb1cc76005a1bb1696a0f106d84ce7ebda3033b963a38583fb3b3
   languageName: node
   linkType: hard
 
@@ -12328,6 +12530,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-path-inside@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-path-inside@npm:4.0.0"
+  checksum: 8810fa11c58e6360b82c3e0d6cd7d9c7d0392d3ac9eb10f980b81f9839f40ac6d1d6d6f05d069db0d227759801228f0b072e1b6c343e4469b065ab5fe0b68fe5
+  languageName: node
+  linkType: hard
+
 "is-plain-obj@npm:2.1.0, is-plain-obj@npm:^2.1.0":
   version: 2.1.0
   resolution: "is-plain-obj@npm:2.1.0"
@@ -12848,26 +13057,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^29.0.3":
-  version: 29.0.3
-  resolution: "jest-haste-map@npm:29.0.3"
+"jest-haste-map@npm:^29.0.3, jest-haste-map@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "jest-haste-map@npm:29.5.0"
   dependencies:
-    "@jest/types": ^29.0.3
+    "@jest/types": ^29.5.0
     "@types/graceful-fs": ^4.1.3
     "@types/node": "*"
     anymatch: ^3.0.3
     fb-watchman: ^2.0.0
     fsevents: ^2.3.2
     graceful-fs: ^4.2.9
-    jest-regex-util: ^29.0.0
-    jest-util: ^29.0.3
-    jest-worker: ^29.0.3
+    jest-regex-util: ^29.4.3
+    jest-util: ^29.5.0
+    jest-worker: ^29.5.0
     micromatch: ^4.0.4
     walker: ^1.0.8
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: fb766e0d8174e7e3a43a63b28e23bd35db61a5939d6c5c1335d7f3d642d1c608e16fef8a105289b78795e308ab3176a62bc45acfa3fa14087e7635cb008795c3
+  checksum: 3828ff7783f168e34be2c63887f82a01634261f605dcae062d83f979a61c37739e21b9607ecb962256aea3fbe5a530a1acee062d0026fcb47c607c12796cf3b7
   languageName: node
   linkType: hard
 
@@ -12958,10 +13167,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:^29.0.0":
-  version: 29.0.0
-  resolution: "jest-regex-util@npm:29.0.0"
-  checksum: dce16394c357213008e6f84f2288f77c64bba59b7cb48ea614e85c5aae036a7e46dbfd1f45aa08180b7e7c576102bf4f8f0ff8bc60fb9721fb80874adc3ae0ea
+"jest-regex-util@npm:^29.0.0, jest-regex-util@npm:^29.4.3":
+  version: 29.4.3
+  resolution: "jest-regex-util@npm:29.4.3"
+  checksum: 96fc7fc28cd4dd73a63c13a526202c4bd8b351d4e5b68b1a2a2c88da3308c2a16e26feaa593083eb0bac38cca1aa9dd05025412e7de013ba963fb8e66af22b8a
   languageName: node
   linkType: hard
 
@@ -13083,17 +13292,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.0.0, jest-util@npm:^29.0.3, jest-util@npm:^29.1.0, jest-util@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "jest-util@npm:29.4.3"
+"jest-util@npm:^29.0.0, jest-util@npm:^29.0.3, jest-util@npm:^29.1.0, jest-util@npm:^29.4.3, jest-util@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "jest-util@npm:29.5.0"
   dependencies:
-    "@jest/types": ^29.4.3
+    "@jest/types": ^29.5.0
     "@types/node": "*"
     chalk: ^4.0.0
     ci-info: ^3.2.0
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
-  checksum: 606b3e6077895baf8fb4ad4d08c134f37a6b81d5ba77ae654c942b1ae4b7294ab3b5a0eb93db34f129407b367970cf3b76bf5c80897b30f215f2bc8bf20a5f3f
+  checksum: fd9212950d34d2ecad8c990dda0d8ea59a8a554b0c188b53ea5d6c4a0829a64f2e1d49e6e85e812014933d17426d7136da4785f9cf76fff1799de51b88bc85d3
   languageName: node
   linkType: hard
 
@@ -13138,14 +13347,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^29.0.3":
-  version: 29.0.3
-  resolution: "jest-worker@npm:29.0.3"
+"jest-worker@npm:^29.0.3, jest-worker@npm:^29.5.0":
+  version: 29.5.0
+  resolution: "jest-worker@npm:29.5.0"
   dependencies:
     "@types/node": "*"
+    jest-util: ^29.5.0
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
-  checksum: cdae4a58f6ab1ec3c384b42f1106004d434e65febcb34ba14a1e7d8538f7a5a5c2ebb0cf29cecfe8c71882c526ee02c4aa338a9ce0abcf11fcec9b8fa662189b
+  checksum: 1151a1ae3602b1ea7c42a8f1efe2b5a7bf927039deaa0827bf978880169899b705744e288f80a63603fb3fc2985e0071234986af7dc2c21c7a64333d8777c7c9
   languageName: node
   linkType: hard
 
@@ -13853,6 +14063,13 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.flattendeep@npm:4.4.0"
   checksum: 8521c919acac3d4bcf0aaf040c1ca9cb35d6c617e2d72e9b4d51c9a58b4366622cd6077441a18be626c3f7b28227502b3bf042903d447b056ee7e0b11d45c722
+  languageName: node
+  linkType: hard
+
+"lodash.ismatch@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.ismatch@npm:4.4.0"
+  checksum: a393917578842705c7fc1a30fb80613d1ac42d20b67eb26a2a6004d6d61ee90b419f9eb320508ddcd608e328d91eeaa2651411727eaa9a12534ed6ccb02fc705
   languageName: node
   linkType: hard
 
@@ -14637,6 +14854,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mount-point@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mount-point@npm:3.0.0"
+  dependencies:
+    "@sindresorhus/df": ^1.0.1
+    pify: ^2.3.0
+    pinkie-promise: ^2.0.1
+  checksum: edb588e613020271add5a368404af569d8f5cfc48121be3ebb142ffc939f97de0c407fdd03ae972a7eff0cb880584a71e767993f719a6998cd90f1272def4c25
+  languageName: node
+  linkType: hard
+
+"move-file@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "move-file@npm:3.0.0"
+  dependencies:
+    path-exists: ^5.0.0
+  checksum: 18b0a542b4ae7615748435ac9433166a935f7dad94a9e116a36a24941916b1421b8685ebf0b98ed9bba551aa09a1aa2959da6519cf4830b079d603f6a390c831
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.0.0":
   version: 2.0.0
   resolution: "ms@npm:2.0.0"
@@ -14997,6 +15234,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "npm-run-path@npm:3.1.0"
+  dependencies:
+    path-key: ^3.0.0
+  checksum: 141e0b8f0e3b137347a2896572c9a84701754dda0670d3ceb8c56a87702ee03c26227e4517ab93f2904acfc836547315e740b8289bb24ca0cd8ba2b198043b0f
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
@@ -15311,6 +15557,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"os-homedir@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "os-homedir@npm:1.0.2"
+  checksum: af609f5a7ab72de2f6ca9be6d6b91a599777afc122ac5cad47e126c1f67c176fe9b52516b9eeca1ff6ca0ab8587fe66208bc85e40a3940125f03cdb91408e9d2
+  languageName: node
+  linkType: hard
+
 "os-locale@npm:^1.4.0":
   version: 1.4.0
   resolution: "os-locale@npm:1.4.0"
@@ -15347,6 +15600,22 @@ __metadata:
   version: 3.0.0
   resolution: "p-cancelable@npm:3.0.0"
   checksum: 2b5ae34218f9c2cf7a7c18e5d9a726ef9b165ef07e6c959f6738371509e747334b5f78f3bcdeb03d8a12dcb978faf641fd87eb21486ed7d36fb823b8ddef3219
+  languageName: node
+  linkType: hard
+
+"p-event@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "p-event@npm:5.0.1"
+  dependencies:
+    p-timeout: ^5.0.2
+  checksum: 3bdd8df6092e6b149f25e9c2eb1c0843b3b4279b07be2a2c72c02b65b267a8908c2040fefd606f2497b0f2bcefcd214f8ca5a74f0c883515d400ccf1d88d5683
+  languageName: node
+  linkType: hard
+
+"p-finally@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "p-finally@npm:2.0.1"
+  checksum: 6306a2851c3b28f8b603624f395ae84dce76970498fed8aa6aae2d930595053746edf1e4ee0c4b78a97410d84aa4504d63179f5310d555511ecd226f53ed1e8e
   languageName: node
   linkType: hard
 
@@ -15426,6 +15695,22 @@ __metadata:
   dependencies:
     aggregate-error: ^3.0.0
   checksum: cb0ab21ec0f32ddffd31dfc250e3afa61e103ef43d957cc45497afe37513634589316de4eb88abdfd969fe6410c22c0b93ab24328833b8eb1ccc087fc0442a1c
+  languageName: node
+  linkType: hard
+
+"p-map@npm:^5.1.0":
+  version: 5.5.0
+  resolution: "p-map@npm:5.5.0"
+  dependencies:
+    aggregate-error: ^4.0.0
+  checksum: 065cb6fca6b78afbd070dd9224ff160dc23eea96e57863c09a0c8ea7ce921043f76854be7ee0abc295cff1ac9adcf700e79a1fbe3b80b625081087be58e7effb
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^5.0.2":
+  version: 5.1.0
+  resolution: "p-timeout@npm:5.1.0"
+  checksum: f5cd4e17301ff1ff1d8dbf2817df0ad88c6bba99349fc24d8d181827176ad4f8aca649190b8a5b1a428dfd6ddc091af4606835d3e0cb0656e04045da5c9e270c
   languageName: node
   linkType: hard
 
@@ -15695,6 +15980,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-type@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-type@npm:3.0.0"
+  dependencies:
+    pify: ^3.0.0
+  checksum: 735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -15772,10 +16066,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pify@npm:^2.0.0":
+"pify@npm:^2.0.0, pify@npm:^2.3.0":
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
+  languageName: node
+  linkType: hard
+
+"pify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pify@npm:3.0.0"
+  checksum: 6cdcbc3567d5c412450c53261a3f10991665d660961e06605decf4544a61a97a54fefe70a68d5c37080ff9d6f4cf51444c90198d1ba9f9309a6c0d6e9f5c4fde
   languageName: node
   linkType: hard
 
@@ -15786,7 +16087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pinkie-promise@npm:^2.0.0":
+"pinkie-promise@npm:^2.0.0, pinkie-promise@npm:^2.0.1":
   version: 2.0.1
   resolution: "pinkie-promise@npm:2.0.1"
   dependencies:
@@ -17474,6 +17775,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slash@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "slash@npm:1.0.0"
+  checksum: 4b6e21b1fba6184a7e2efb1dd173f692d8a845584c1bbf9dc818ff86f5a52fc91b413008223d17cc684604ee8bb9263a420b1182027ad9762e35388434918860
+  languageName: node
+  linkType: hard
+
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -18389,6 +18697,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"throwback@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "throwback@npm:4.1.0"
+  checksum: b323761e7b22a962382f217384d57a28d378c3ccc2d4e97828a3593e4aa35d36603b6a82c4200fee698d06f189b433030f63b2b066638417be05bda7be40dc17
+  languageName: node
+  linkType: hard
+
 "time-stamp@npm:^1.0.0":
   version: 1.1.0
   resolution: "time-stamp@npm:1.1.0"
@@ -18561,6 +18876,22 @@ __metadata:
     merge-source-map: 1.0.4
     nanobench: ^2.1.1
   checksum: 4ac71140073a7200af781f4d0b66e2ae6cdce50c1b604047eb30cad3a0cf9a3c784bb621e9eac2fa9c95ee0f440a5523b4e4dee3bc244c84ce9b891b17dd6fd9
+  languageName: node
+  linkType: hard
+
+"trash@npm:^8.1.0":
+  version: 8.1.1
+  resolution: "trash@npm:8.1.1"
+  dependencies:
+    "@sindresorhus/chunkify": ^0.2.0
+    "@stroncium/procfs": ^1.2.1
+    globby: ^7.1.1
+    is-path-inside: ^4.0.0
+    move-file: ^3.0.0
+    p-map: ^5.1.0
+    uuid: ^8.3.2
+    xdg-trashdir: ^3.1.0
+  checksum: ffb831a5ca62dd2b9362c619dab2a7cec356f7dc3304070b5c08f8161651cf72bf921785d12ec858a6ddaaed1cdb9385d074c89d0767a3a8a48ffc81dc1790bc
   languageName: node
   linkType: hard
 
@@ -18792,7 +19123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.0.0, type-fest@npm:^2.12.2, type-fest@npm:^2.5.0":
+"type-fest@npm:^2.0.0, type-fest@npm:^2.11.2, type-fest@npm:^2.12.2, type-fest@npm:^2.5.0":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: a4ef07ece297c9fba78fc1bd6d85dff4472fe043ede98bd4710d2615d15776902b595abf62bd78339ed6278f021235fb28a96361f8be86ed754f778973a0d278
@@ -19109,6 +19440,15 @@ __metadata:
   version: 3.1.1
   resolution: "use@npm:3.1.1"
   checksum: 08a130289f5238fcbf8f59a18951286a6e660d17acccc9d58d9b69dfa0ee19aa038e8f95721b00b432c36d1629a9e32a464bf2e7e0ae6a244c42ddb30bdd8b33
+  languageName: node
+  linkType: hard
+
+"user-home@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "user-home@npm:2.0.0"
+  dependencies:
+    os-homedir: ^1.0.0
+  checksum: a3329faa959fcd9e3e01a03347ca974f7f6b8896e6a634f29c61d8d5b61557d853c6fc5a6dff1a28e2da85b400d0e4490368a28de452ba8c41a2bf3a92cb110a
   languageName: node
   linkType: hard
 
@@ -19932,7 +20272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^4.0.1":
+"write-file-atomic@npm:^4.0.2":
   version: 4.0.2
   resolution: "write-file-atomic@npm:4.0.2"
   dependencies:
@@ -19984,6 +20324,25 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 97301c1c4d838fc81bd413f370f75c12aabe44527b31323b761eab3043a9ecb7e32ffd668548382c9a6a5ad3a1c3a9249608e8338e6b939f2f9540f1e21970b5
+  languageName: node
+  linkType: hard
+
+"xdg-basedir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "xdg-basedir@npm:4.0.0"
+  checksum: 0073d5b59a37224ed3a5ac0dd2ec1d36f09c49f0afd769008a6e9cd3cd666bd6317bd1c7ce2eab47e1de285a286bad11a9b038196413cd753b79770361855f3c
+  languageName: node
+  linkType: hard
+
+"xdg-trashdir@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "xdg-trashdir@npm:3.1.0"
+  dependencies:
+    "@sindresorhus/df": ^3.1.1
+    mount-point: ^3.0.0
+    user-home: ^2.0.0
+    xdg-basedir: ^4.0.0
+  checksum: 1b8ed9229af43fa17fcc2cbfd7b470459b2286da5eb141046817e25ba78eeee07d3a4ae28d5c32e2106641dd2c23cc18b46a77b813706ff85f6618c1f61b1827
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds E2E tests for the Snaps CLI, using `clet` as framework.

Tests are run on Linux, macOS, and Windows, as part of the regular Jest tests.

Closes #310.