### PR TITLE
Polyfill base64 (`atob`, `btoa`) functions

### DIFF
--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -42,6 +42,7 @@
     "@metamask/rpc-methods": "^0.31.0",
     "@metamask/snaps-utils": "^0.31.0",
     "@metamask/utils": "^5.0.0",
+    "@scure/base": "^1.1.1",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "pump": "^3.0.0",

--- a/packages/snaps-execution-environments/src/common/endowments/base64.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/base64.test.ts
@@ -1,0 +1,15 @@
+import base64 from './base64';
+
+describe('Base64 endowments', () => {
+  it('has expected properties', () => {
+    expect(base64).toMatchObject({
+      names: ['atob', 'btoa'],
+      factory: expect.any(Function),
+    });
+  });
+
+  it('encodes and decodes base64', () => {
+    const { atob, btoa } = base64.factory();
+    expect(atob(btoa('Snaps'))).toBe('Snaps');
+  });
+});

--- a/packages/snaps-execution-environments/src/common/endowments/base64.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/base64.ts
@@ -1,0 +1,40 @@
+import { stringToBytes, bytesToString } from '@metamask/utils';
+import { base64 } from '@scure/base';
+
+/**
+ * Encode a value to base64.
+ *
+ * @param value - The value to encode.
+ * @returns The encoded value.
+ */
+function encodeBase64(value: string): string {
+  return base64.encode(stringToBytes(value));
+}
+
+/**
+ * Decode a value from base64.
+ *
+ * @param value - The value to decode.
+ * @returns The decoded value.
+ */
+function decodeBase64(value: string): string {
+  return bytesToString(base64.decode(value));
+}
+
+/**
+ * Creates `atob` and `btoa` functions hardened by SES.
+ *
+ * @returns An object with the attenuated `atob` and `btoa` functions.
+ */
+const createBase64 = () => {
+  return {
+    atob: harden(decodeBase64),
+    btoa: harden(encodeBase64),
+  } as const;
+};
+
+const endowmentModule = {
+  names: ['atob', 'btoa'] as const,
+  factory: createBase64,
+};
+export default endowmentModule;

--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -1,3 +1,4 @@
+import base64 from './base64';
 import crypto from './crypto';
 import date from './date';
 import interval from './interval';
@@ -22,11 +23,9 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: AbortController, name: 'AbortController' },
   { endowment: AbortSignal, name: 'AbortSignal' },
   { endowment: ArrayBuffer, name: 'ArrayBuffer' },
-  { endowment: atob, name: 'atob' },
   { endowment: BigInt, name: 'BigInt' },
   { endowment: BigInt64Array, name: 'BigInt64Array' },
   { endowment: BigUint64Array, name: 'BigUint64Array' },
-  { endowment: btoa, name: 'btoa' },
   { endowment: DataView, name: 'DataView' },
   { endowment: Float32Array, name: 'Float32Array' },
   { endowment: Float64Array, name: 'Float64Array' },
@@ -50,6 +49,7 @@ const commonEndowments: CommonEndowmentSpecification[] = [
  */
 const buildCommonEndowments = (): EndowmentFactory[] => {
   const endowmentFactories: EndowmentFactory[] = [
+    base64,
     crypto,
     interval,
     math,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,6 +3356,7 @@ __metadata:
     "@metamask/rpc-methods": ^0.31.0
     "@metamask/snaps-utils": ^0.31.0
     "@metamask/utils": ^5.0.0
+    "@scure/base": ^1.1.1
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.36
     "@typescript-eslint/eslint-plugin": ^5.42.1


### PR DESCRIPTION
SES removes the `atob` and `btoa` functions because they are not platform agnostic(?). This adds a polyfill using `@scure/base` for encoding and decoding Base64.