### PR TITLE
Fix a few issues with installation and updating

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.24,
-  "functions": 95.15,
-  "lines": 96.56,
-  "statements": 96.46
+  "branches": 89.29,
+  "functions": 95.17,
+  "lines": 96.58,
+  "statements": 96.48
 }

--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.29,
+  "branches": 89.53,
   "functions": 95.17,
-  "lines": 96.58,
-  "statements": 96.48
+  "lines": 96.64,
+  "statements": 96.55
 }

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -741,7 +741,7 @@ describe('SnapController', () => {
     controller.destroy();
   });
 
-  it('throws an error if semver version range doesnt match downloaded version', async () => {
+  it("throws an error if semver version range doesn't match downloaded version", async () => {
     const controller = getSnapController(
       getSnapControllerOptions({ detectSnapLocation: loopbackDetect() }),
     );
@@ -751,7 +751,7 @@ describe('SnapController', () => {
         [MOCK_SNAP_ID]: { version: '1.2.0' },
       }),
     ).rejects.toThrow(
-      `Version mismatch. Manifest for "npm:@metamask/example-snap" specifies version "1.0.0" which doesn't satisfy requested version range "1.2.0"`,
+      `Version mismatch. Manifest for "npm:@metamask/example-snap" specifies version "1.0.0" which doesn't satisfy requested version range "1.2.0".`,
     );
 
     controller.destroy();

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -741,6 +741,22 @@ describe('SnapController', () => {
     controller.destroy();
   });
 
+  it('throws an error if semver version range doesnt match downloaded version', async () => {
+    const controller = getSnapController(
+      getSnapControllerOptions({ detectSnapLocation: loopbackDetect() }),
+    );
+
+    await expect(
+      controller.installSnaps(MOCK_ORIGIN, {
+        [MOCK_SNAP_ID]: { version: '1.2.0' },
+      }),
+    ).rejects.toThrow(
+      `Version mismatch. Manifest for "npm:@metamask/example-snap" specifies version "1.0.0" which doesn't satisfy requested version range "1.2.0"`,
+    );
+
+    controller.destroy();
+  });
+
   it('throws an error if snap is not on allowlist and allowlisting is required', async () => {
     const controller = getSnapController(
       getSnapControllerOptions({
@@ -3250,6 +3266,8 @@ describe('SnapController', () => {
       expect(controller.get(snapId3)).toBeUndefined();
       expect(controller.get(snapId1)?.manifest.version).toBe(oldVersion);
       expect(controller.get(snapId2)?.manifest.version).toBe(oldVersion);
+      expect(controller.get(snapId1)?.status).toBe('stopped');
+      expect(controller.get(snapId2)?.status).toBe('stopped');
 
       controller.destroy();
       await service.terminateAllSnaps();

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1845,7 +1845,7 @@ export class SnapController extends BaseController<
 
       if (!satisfiesVersionRange(newVersion, newVersionRange)) {
         throw new Error(
-          `Version mismatch. Manifest for "${snapId}" specifies version "${newVersion}" which doesn't satisfy requested version range "${newVersionRange}"`,
+          `Version mismatch. Manifest for "${snapId}" specifies version "${newVersion}" which doesn't satisfy requested version range "${newVersionRange}".`,
         );
       }
 
@@ -2001,7 +2001,7 @@ export class SnapController extends BaseController<
         assertIsSnapManifest(manifest);
         if (!satisfiesVersionRange(manifest.version, versionRange)) {
           throw new Error(
-            `Version mismatch. Manifest for "${snapId}" specifies version "${manifest.version}" which doesn't satisfy requested version range "${versionRange}"`,
+            `Version mismatch. Manifest for "${snapId}" specifies version "${manifest.version}" which doesn't satisfy requested version range "${versionRange}".`,
           );
         }
         await this.#assertIsInstallAllowed(snapId, {


### PR DESCRIPTION
Fix a few issues related to installation and updating:
- Fixes an issue where rollback would sometimes leave snaps stuck in an updating state with no way to recover
- Fixes a lack of checking that the installed version of a snap matches the provided version range

Fixes #1307 