### PR TITLE
Fix `handleSnapInstall` side-effect

### DIFF
--- a/packages/rpc-methods/src/restricted/invokeSnap.test.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.test.ts
@@ -21,6 +21,7 @@ import {
   WALLET_SNAP_PERMISSION_KEY,
   handleSnapInstall,
   InstallSnaps,
+  GetPermittedSnaps,
 } from './invokeSnap';
 
 describe('builder', () => {
@@ -231,11 +232,14 @@ describe('implementation', () => {
 
 describe('handleSnapInstall', () => {
   it('calls SnapController:install with the right parameters', async () => {
-    const messenger = new MockControllerMessenger<InstallSnaps, never>();
+    const messenger = new MockControllerMessenger<
+      InstallSnaps | GetPermittedSnaps,
+      never
+    >();
 
     const sideEffectMessenger = messenger.getRestricted({
       name: 'PermissionController',
-      allowedActions: ['SnapController:install'],
+      allowedActions: ['SnapController:install', 'SnapController:getPermitted'],
     });
 
     const expectedResult = {
@@ -246,6 +250,8 @@ describe('handleSnapInstall', () => {
       'SnapController:install',
       async () => expectedResult,
     );
+
+    messenger.registerActionHandler('SnapController:getPermitted', () => ({}));
 
     jest.spyOn(sideEffectMessenger, 'call');
 

--- a/packages/rpc-methods/src/restricted/invokeSnap.ts
+++ b/packages/rpc-methods/src/restricted/invokeSnap.ts
@@ -47,8 +47,6 @@ export type GetPermittedSnaps = {
   handler: (origin: string) => InstallSnapsResult;
 };
 
-// add a get snaps type here and then union it below with InstallSnaps
-
 type AllowedActions = InstallSnaps | GetPermittedSnaps;
 
 export type InvokeSnapMethodHooks = {
@@ -114,11 +112,6 @@ export const handleSnapInstall: PermissionSideEffect<
 >['onPermitted'] = async ({ requestData, messagingSystem }) => {
   const snaps = requestData.permissions[WALLET_SNAP_PERMISSION_KEY].caveats?.[0]
     .value as RequestedSnapPermissions;
-
-  // get installed snaps
-  // dedupe against this snaps variable
-  // will need to check if this messaging system will be able to call
-  // getInstalledSnaps...we might need to open a quick PR into core to add the allowedAction
 
   const permittedSnaps = messagingSystem.call(
     `SnapController:getPermitted`,


### PR DESCRIPTION
Currently, the way the `PermissionController` is setup, we're required to merge caveat values for subsequent `wallet_requestPermissions` calls. In the case of `wallet_snap`, we end up re-installing already installed snaps in addition to the newly requested snaps. Dedupe logic was added  to prevent re-installation of already installed snaps when those snaps haven't been requested (to be installed).

**Note:** The `SnapController:getPermitted`(`${this.snapController.name}:getPermitted`) action should be added to the `PermissionController`'s messenger's `allowedActions` in the extension.