### PR TITLE
Properly handle Promise in `JsonSnapsRegistry` signature verification

### DIFF
--- a/packages/snaps-controllers/src/snaps/registry/json.ts
+++ b/packages/snaps-controllers/src/snaps/registry/json.ts
@@ -253,7 +253,7 @@ export class JsonSnapsRegistry extends BaseController<
   async #verifySignature(database: string, signature: string) {
     assert(this.#publicKey, 'No public key provided.');
 
-    const valid = verify({
+    const valid = await verify({
       registry: database,
       signature: JSON.parse(signature),
       publicKey: this.#publicKey,


### PR DESCRIPTION
## Description

This pull request consists of two changes:
- Fixing a test in JsonSnapsRegistry class that had the wrong signature.
- Adding the `async` keyword to the `verify` method in JsonSnapsRegistry class.

### Test case fix

One of the tests in the JsonSnapsRegistry class had a wrong signature that resulted in a test failure. This commit fixes
the signature to match the JSON response obtained during the test execution. Additionally, a new test case was added
to check situations where an invalid signature is present. 

### async keyword addition

The `verify` method in JsonSnapsRegistry class returns a Promise. The missing `async` keyword would result in the method
not being awaited, and it would not resolve. The `async` keyword is added to ensure that the `verify` method is resolved.

This change leads to better code readability and ensures that the test cases will pass successfully.

## Changes

1. Fix the signature used in a test case for JsonSnapsRegistry class.
2. Add new test case to validate situations with invalid signature.
3. Add `async` keyword in front of the verify method call for JsonSnapsRegistry class.