### PR TITLE
Add instructions for passing `GITHUB_NPM_TOKEN` environment variable during `yarn install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you're a MetaMask contributor, you can create these preview versions via draf
      npmScopes:
         metamask:
            npmAlwaysAuth: true
-           npmAuthToken: <your personal access token>
+           npmAuthToken: ${GITHUB_NPM_TOKEN}
            npmRegistryServer: 'https://npm.pkg.github.com'
      ```
 
@@ -57,7 +57,17 @@ If you're a MetaMask contributor, you can create these preview versions via draf
 
 3. Go to GitHub and open up a pull request for this repository, then post a comment on the PR with the text `@metamaskbot publish-preview`. (This triggers the `publish-preview` GitHub action.)
 4. After a few minutes, you will see a new comment indicating that all packages have been published with the format `<package name>-<commit id>`.
-5. Switch back to your project locally and update `package.json` by replacing the versions for the packages you've changed in your PR using the new version format (e.g. `1.2.3-e2df9b4` instead of `~1.2.3`), then run `yarn install`.
+5. Switch back to your project locally and update `package.json` by
+   replacing the versions for the packages you've changed in your PR using
+   the new version format (e.g. `1.2.3-e2df9b4` instead of `~1.2.3`), then
+   run `GITHUB_NPM_TOKEN=your-token yarn install`.
+
+   - It's recommended to use your machine's local keychain to store the
+     token, and receive it from there. For example on macOS, you can use:
+     ```bash
+     GITHUB_NPM_TOKEN=$(security find-generic-password -s 'GitHub NPM Token' -w) yarn install
+     ```
+
 6. Repeat steps 3-5 after pushing new changes to your PR to generate and use new preview versions.
 
 #### As an independent contributor
@@ -84,7 +94,7 @@ If you're a contributor and you've forked this repository, you can create previe
      npmScopes:
         <your GitHub username>:
            npmAlwaysAuth: true
-           npmAuthToken: <your personal access token>
+           npmAuthToken: ${GITHUB_NPM_TOKEN}
            npmRegistryServer: 'https://npm.pkg.github.com'
      ```
 
@@ -92,7 +102,16 @@ If you're a contributor and you've forked this repository, you can create previe
 
 3. Open the `package.json` for each package that you want to publish and change the scope in the name from `@metamask` to `@<your GitHub username>`.
 4. Switch to your fork of this repository locally and run `yarn prepare-preview-builds "$(git rev-parse --short HEAD)" && yarn build && yarn publish-previews` to generate preview versions for all packages based on the current branch and publish them to GitHub Package Registry. Take note of the version that is published; it should look like `1.2.3-e2df9b4` instead of `1.2.3`.
-5. Switch back to your project and update `package.json` by replacing the versions for all packages you've changed using the version that was output in the previous step, then run `yarn install`.
+5. Switch back to your project and update `package.json` by replacing the
+   versions for all packages you've changed using the version that was
+   output in the previous step, then run `GITHUB_NPM_TOKEN=your-token yarn install`.
+
+   - It's recommended to use your machine's local keychain to store the
+     token, and receive it from there. For example on macOS, you can use:
+     ```bash
+     GITHUB_NPM_TOKEN=$(security find-generic-password -s 'GitHub NPM Token' -w) yarn install
+     ```
+
 6. If you make any new changes to your project, repeat steps 3-5 to generate and use new preview versions.
 7. As changes will have been made to this repository (due to step 4), make sure to clear out those changes after you've completed testing.
 


### PR DESCRIPTION
## Description

This pull request adds instructions on how to pass the `GITHUB_NPM_TOKEN` environment variable required to authenticate
against GitHub's NPM Package Registry when running `yarn install` command to install the preview packages generated in
the upstream repository. 

By default, `yarn install` won't authenticate against the NPM registry from GitHub. Therefore, we need to pass the
authentication token as an environment variable to authenticate with it. This change provides detailed instructions on
how to pass `GITHUB_NPM_TOKEN` variable as an environment variable during `yarn install`. 

Additionally, this will help prevent accidental commits of the token if you had it stored in the `.yarnrc.yml` file.

This is a necessary change to ensure that developers can install preview packages from the upstream repository without
any issues, and adhere to GitHub's authentication requirements for using its NPM registry.

## Changes

1. Add instructions on how to pass `GITHUB_NPM_TOKEN` environment variable when running `yarn install`.