### PR TITLE
Add encrypt and decrypt hook for custom encryption implementations

### DIFF
--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -27,7 +27,6 @@
     "publish:preview": "yarn npm publish --tag preview"
   },
   "dependencies": {
-    "@metamask/browser-passworder": "^4.0.2",
     "@metamask/key-tree": "^7.0.0",
     "@metamask/permission-controller": "^3.1.0",
     "@metamask/snaps-ui": "workspace:^",
@@ -42,6 +41,7 @@
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",
+    "@metamask/browser-passworder": "^4.0.2",
     "@metamask/eslint-config": "^11.0.0",
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.1",

--- a/packages/rpc-methods/src/restricted/manageState.test.ts
+++ b/packages/rpc-methods/src/restricted/manageState.test.ts
@@ -1,4 +1,4 @@
-import { encrypt } from '@metamask/browser-passworder';
+import { decrypt, encrypt } from '@metamask/browser-passworder';
 import {
   MOCK_LOCAL_SNAP_ID,
   MOCK_SNAP_ID,
@@ -42,6 +42,8 @@ describe('snap_manageState', () => {
         updateSnapState: jest.fn(),
         getMnemonic: jest.fn(),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       };
 
       expect(
@@ -80,6 +82,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       const result = await manageStateImplementation({
@@ -105,6 +109,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       const result = await manageStateImplementation({
@@ -130,6 +136,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       await manageStateImplementation({
@@ -162,6 +170,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       await manageStateImplementation({
@@ -204,6 +214,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       await manageStateImplementation({
@@ -257,6 +269,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       expect(async () =>
@@ -284,6 +298,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       await expect(
@@ -312,6 +328,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       const newState = (a: unknown) => {
@@ -349,6 +367,8 @@ describe('snap_manageState', () => {
           .fn()
           .mockResolvedValue(TEST_SECRET_RECOVERY_PHRASE_BYTES),
         getUnlockPromise: jest.fn(),
+        encrypt,
+        decrypt,
       });
 
       const newState = {


### PR DESCRIPTION
## Description

This pull request adds a new encrypt and decrypt hook to the project to let implementers use their own encryption and
decryption functions. `@metamask/browser-passworder` previously handled these functions, but with this PR we are replacing
it with the new hooks.

The main motivation behind this change is compatibility. We want to ensure that both the extension and mobile version
of MetaMask can use the same JSON-RPC method logic, and provide their own encryption implementations.

This change increases the flexibility of our codebase and simplifies the work of future implementers.

## Changes

1. Add a new encrypt and decrypt hook to the `snap_manageState` JSON-RPC method.
2. Replace `@metamask/browser-passworder` with the new encrypt and decrypt hooks.
   - `@metamask/browser-passworder` is still used for testing, so it's now a devDependency.

Closes #1319.