### PR TITLE
Upgrade `chromedriver` to version 112.0.0

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -126,6 +126,8 @@ jobs:
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - uses: actions/checkout@v3
+      - name: Install Google Chrome
+        run: yarn install-chrome
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -126,8 +126,6 @@ jobs:
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install Google Chrome
-        run: yarn install-chrome
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -140,6 +138,8 @@ jobs:
             packages/snaps-execution-environments/dist/browserify
           key: test-build-${{ runner.os }}-${{ matrix.node-version }}-${{ github.sha }}
       - run: yarn --immutable --immutable-cache
+      - name: Install Google Chrome
+        run: yarn install-chrome
       - run: yarn workspace ${{ matrix.package-name }} run test:ci
       - name: Get coverage folder
         id: get-coverage-folder

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ typings/
 
 # Webpack generated files
 packages/examples/examples/webpack/index.html
+
+# Ubuntu package files
+.deb

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/node": "^17.0.36",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
-    "chromedriver": "^110.0.0",
+    "chromedriver": "^112.0.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:prepare": "yarn workspace @metamask/snaps-execution-environments run build:test",
     "child-workspace-package-names-as-json": "ts-node scripts/child-workspace-package-names-as-json.ts",
     "prepare-preview-builds": "yarn workspaces foreach --parallel run prepare-manifest:preview",
-    "publish-previews": "yarn workspaces foreach --parallel run publish:preview"
+    "publish-previews": "yarn workspaces foreach --parallel run publish:preview",
+    "install-chrome": "./scripts/install-chrome.sh"
   },
   "simple-git-hooks": {
     "pre-commit": "yarn lint-staged && yarn dedupe --check"

--- a/scripts/install-chrome.sh
+++ b/scripts/install-chrome.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+# To get the latest version, see <https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable>
+CHROME_VERSION='112.0.5615.49-1'
+CHROME_BINARY="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
+CHROME_BINARY_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/${CHROME_BINARY}"
+
+# To retrieve this checksum, run the `wget` and `shasum` commands below
+CHROME_BINARY_SHA512SUM='eb80ebc1a44a00caee1b153879e4e980518611f5be532da62066cd8ec63df69d518eef9e2917a9c3b735382bb5807b03313fa66b28c823f87607e5d07dffc606'
+
+wget -O "${CHROME_BINARY}" -t 5 "${CHROME_BINARY_URL}"
+
+if [[ $(shasum -a 512 "${CHROME_BINARY}" | cut '--delimiter= ' -f1) != "${CHROME_BINARY_SHA512SUM}" ]]
+then
+  echo "Google Chrome binary checksum did not match."
+  exit 1
+else
+  echo "Google Chrome binary checksum verified."
+fi
+
+(sudo dpkg -i "${CHROME_BINARY}" || sudo apt-get -fy install)
+
+rm -rf "${CHROME_BINARY}"
+
+printf '%s\n' "Chrome ${CHROME_VERSION} configured"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7625,9 +7625,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:^110.0.0":
-  version: 110.0.0
-  resolution: "chromedriver@npm:110.0.0"
+"chromedriver@npm:^112.0.0":
+  version: 112.0.0
+  resolution: "chromedriver@npm:112.0.0"
   dependencies:
     "@testim/chrome-version": ^1.1.3
     axios: ^1.2.1
@@ -7638,7 +7638,7 @@ __metadata:
     tcp-port-used: ^1.0.1
   bin:
     chromedriver: bin/chromedriver
-  checksum: 52c51f21ef523865af6496736e92689bf8a16d477653cb096ff22ad3bbf16495935b6f42f860a3cdea3123e2d8a4084688acc07a06da4924b7c0e2d2bc646ae4
+  checksum: 6cd254c50326ca1775adac54cac1dc1b96a32fd9af1dfb7c44e812c619286ec96c727f74adbbece50a1f3efd463b895f05aadbce95cec9e23525b8bdf379de7f
   languageName: node
   linkType: hard
 
@@ -17630,7 +17630,7 @@ __metadata:
     "@types/node": ^17.0.36
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
-    chromedriver: ^110.0.0
+    chromedriver: ^112.0.0
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
     eslint-plugin-import: ^2.26.0


### PR DESCRIPTION
## Description

This pull request upgrades `chromedriver` to the `112.0.0` version which is required to support the latest Chrome browser.
The current version was causing issues while running our tests, which made it necessary to upgrade.

As `chromedriver` is used by the WebDriverIO automated testing framework to control Chrome browser, it is important to keep it
up-to-date to ensure smooth test runs. This change ensures that our tests can be run on the latest version of Chrome
without any issues.

## Changes

1. Upgrade `chromedriver` to version `112.0.0`.

Closes #1342.