### PR TITLE
Fix Math endowment in Node.js

### DIFF
--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 79.28,
   "functions": 91.79,
-  "lines": 89.66,
-  "statements": 89.71
+  "lines": 89.7,
+  "statements": 89.76
 }

--- a/packages/snaps-execution-environments/src/common/endowments/crypto.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/crypto.ts
@@ -1,6 +1,6 @@
 import { rootRealmGlobal } from '../globalObject';
 
-const createCrypto = () => {
+export const createCrypto = () => {
   if (
     'crypto' in rootRealmGlobal &&
     typeof rootRealmGlobal.crypto === 'object' &&

--- a/packages/snaps-execution-environments/src/common/endowments/math.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.test.ts
@@ -1,12 +1,6 @@
 import { rootRealmGlobal } from '../globalObject';
 import math from './math';
 
-// The math endowment uses the Web Crypto API, which is only available in
-// browsers out-of-the-box. In Node.js, we need to manually add the global
-// object.
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-globalThis.crypto = require('node:crypto').webcrypto;
-
 describe('Math endowment', () => {
   it('has expected properties', () => {
     expect(math).toMatchObject({

--- a/packages/snaps-execution-environments/src/common/endowments/math.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.ts
@@ -23,7 +23,7 @@ function createMath() {
     return { ...target, [key]: rootRealmGlobal.Math[key] };
   }, {});
 
-  // Since the math endowment requires crypto, we can leverage the crypto endowment factory to get a hardened (and potentially) polyfilled instance of webcrypto
+  // Since the math endowment requires crypto, we can leverage the crypto endowment factory to get a hardened and platform agnostic instance of webcrypto
   const { crypto: hardenedCrypto } = createCrypto();
 
   return harden({

--- a/packages/snaps-execution-environments/src/common/endowments/math.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/math.ts
@@ -1,4 +1,5 @@
 import { rootRealmGlobal } from '../globalObject';
+import { createCrypto } from './crypto';
 
 /**
  * Create a {@link Math} object, with the same properties as the global
@@ -22,6 +23,9 @@ function createMath() {
     return { ...target, [key]: rootRealmGlobal.Math[key] };
   }, {});
 
+  // Since the math endowment requires crypto, we can leverage the crypto endowment factory to get a hardened (and potentially) polyfilled instance of webcrypto
+  const { crypto: hardenedCrypto } = createCrypto();
+
   return harden({
     Math: {
       ...math,
@@ -42,7 +46,7 @@ function createMath() {
         //
         // - https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey
         // - https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
-        return crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
+        return hardenedCrypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32;
       },
     },
   });


### PR DESCRIPTION
Fixes the Math endowment when running in Node.js. Previously we would assume `crypto` to be available, but that isn't the case in the scope where we are creating the Math endowment.