### PR TITLE
Watch manifest and config files

### DIFF
--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -28,9 +28,9 @@ module.exports = deepmerge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 97.64,
-      functions: 94.59,
-      lines: 98.49,
-      statements: 98.5,
+      functions: 94.66,
+      lines: 98.5,
+      statements: 98.51,
     },
   },
   setupFiles: ['./test/setup.js'],

--- a/packages/snaps-cli/jest.config.js
+++ b/packages/snaps-cli/jest.config.js
@@ -27,7 +27,7 @@ module.exports = deepmerge(baseConfig, {
   coveragePathIgnorePatterns: ['./src/types'],
   coverageThreshold: {
     global: {
-      branches: 97.64,
+      branches: 97.59,
       functions: 94.66,
       lines: 98.5,
       statements: 98.51,

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.test.ts
@@ -88,7 +88,7 @@ describe('watch', () => {
       expect(validateFilePathMock).toHaveBeenCalledWith(mockSrc);
       expect(validateOutfileNameMock).toHaveBeenCalledWith(mockOutfileName);
       expect(chokidarMock.mock.calls[0][0]).toStrictEqual([
-        'src/',
+        'src',
         NpmSnapFileNames.Manifest,
         CONFIG_FILE,
       ]);
@@ -117,7 +117,7 @@ describe('watch', () => {
       expect(validateFilePathMock).toHaveBeenCalledWith('foo/index.js');
       expect(validateOutfileNameMock).toHaveBeenCalledWith(mockOutfileName);
       expect(chokidarMock.mock.calls[0][0]).toStrictEqual([
-        'foo/',
+        'foo',
         NpmSnapFileNames.Manifest,
         CONFIG_FILE,
       ]);

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.test.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.test.ts
@@ -1,11 +1,12 @@
 import * as snapUtils from '@metamask/snaps-utils';
-import { logError, logInfo } from '@metamask/snaps-utils';
+import { logError, logInfo, NpmSnapFileNames } from '@metamask/snaps-utils';
 import chokidar from 'chokidar';
 import EventEmitter from 'events';
 import http from 'http';
 import path from 'path';
 
 import watch from '.';
+import { CONFIG_FILE } from '../../utils';
 import * as build from '../build/bundle';
 import * as evalModule from '../eval/evalHandler';
 import * as manifest from '../manifest/manifestHandler';
@@ -86,7 +87,11 @@ describe('watch', () => {
       expect(validateDirPathMock).toHaveBeenCalledWith(mockDist, true);
       expect(validateFilePathMock).toHaveBeenCalledWith(mockSrc);
       expect(validateOutfileNameMock).toHaveBeenCalledWith(mockOutfileName);
-      expect(chokidarMock.mock.calls[0][0]).toBe('src/');
+      expect(chokidarMock.mock.calls[0][0]).toStrictEqual([
+        'src/',
+        NpmSnapFileNames.Manifest,
+        CONFIG_FILE,
+      ]);
     });
 
     it('successfully processes arguments from yargs: nested src path', async () => {
@@ -111,7 +116,11 @@ describe('watch', () => {
       expect(validateDirPathMock).toHaveBeenCalledWith(mockDist, true);
       expect(validateFilePathMock).toHaveBeenCalledWith('foo/index.js');
       expect(validateOutfileNameMock).toHaveBeenCalledWith(mockOutfileName);
-      expect(chokidarMock.mock.calls[0][0]).toBe('foo/');
+      expect(chokidarMock.mock.calls[0][0]).toStrictEqual([
+        'foo/',
+        NpmSnapFileNames.Manifest,
+        CONFIG_FILE,
+      ]);
     });
 
     it('successfully handles when an outfileName is not provided', async () => {

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.ts
@@ -5,11 +5,12 @@ import {
   validateDirPath,
   validateFilePath,
   validateOutfileName,
+  NpmSnapFileNames,
 } from '@metamask/snaps-utils';
 import chokidar from 'chokidar';
 
 import { YargsArgs } from '../../types/yargs';
-import { loadConfig } from '../../utils';
+import { CONFIG_FILE, loadConfig } from '../../utils';
 import { bundle } from '../build/bundle';
 import { evalHandler } from '../eval/evalHandler';
 import { manifestHandler } from '../manifest/manifestHandler';
@@ -41,9 +42,10 @@ export async function watch(argv: YargsArgs): Promise<void> {
   }
   await validateFilePath(src);
   await validateDirPath(dist, true);
-  const rootDir = src.includes('/')
+  const srcDir = src.includes('/')
     ? src.substring(0, src.lastIndexOf('/') + 1)
     : '.';
+  const watchDirs = [srcDir, NpmSnapFileNames.Manifest, CONFIG_FILE];
   const outfilePath = getOutfilePath(dist, outfileName);
 
   const buildSnap = async (path?: string, logMessage?: string) => {
@@ -74,7 +76,7 @@ export async function watch(argv: YargsArgs): Promise<void> {
   };
 
   chokidar
-    .watch(rootDir, {
+    .watch(watchDirs, {
       ignoreInitial: true,
       ignored: [
         '**/node_modules/**',
@@ -114,9 +116,7 @@ export async function watch(argv: YargsArgs): Promise<void> {
     .on('unlink', (path) => logInfo(`File removed: ${path}`))
     .on('error', (error: Error) => {
       logError(`Watcher error: ${error.message}`, error);
-    })
+    });
 
-    .add(rootDir);
-
-  logInfo(`Watching '${rootDir}' for changes...`);
+  logInfo(`Watching '${watchDirs.join(', ')}' for changes...`);
 }

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.ts
@@ -8,6 +8,7 @@ import {
   NpmSnapFileNames,
 } from '@metamask/snaps-utils';
 import chokidar from 'chokidar';
+import pathUtils from 'path';
 
 import { YargsArgs } from '../../types/yargs';
 import { CONFIG_FILE, loadConfig } from '../../utils';
@@ -42,9 +43,7 @@ export async function watch(argv: YargsArgs): Promise<void> {
   }
   await validateFilePath(src);
   await validateDirPath(dist, true);
-  const srcDir = src.includes('/')
-    ? src.substring(0, src.lastIndexOf('/') + 1)
-    : '.';
+  const srcDir = pathUtils.dirname(src);
   const watchDirs = [srcDir, NpmSnapFileNames.Manifest, CONFIG_FILE];
   const outfilePath = getOutfilePath(dist, outfileName);
 

--- a/packages/snaps-cli/src/cmds/watch/watchHandler.ts
+++ b/packages/snaps-cli/src/cmds/watch/watchHandler.ts
@@ -118,5 +118,7 @@ export async function watch(argv: YargsArgs): Promise<void> {
       logError(`Watcher error: ${error.message}`, error);
     });
 
-  logInfo(`Watching '${watchDirs.join(', ')}' for changes...`);
+  logInfo(
+    `Watching ${watchDirs.map((dir) => `'${dir}'`).join(', ')} for changes...`,
+  );
 }


### PR DESCRIPTION
Watch manifest and config files to ensure automatic rebuild when changing permissions or changing build configuration.

Also fixes an issue detecting source paths on Windows

Fixes #1357 