### PR TITLE
Add `WebAssembly` to eval mock

### DIFF
--- a/packages/snaps-utils/src/mock.ts
+++ b/packages/snaps-utils/src/mock.ts
@@ -5,7 +5,11 @@ import { DEFAULT_ENDOWMENTS } from './default-endowments';
 
 const NETWORK_APIS = ['fetch'];
 
-export const ALL_APIS: string[] = [...DEFAULT_ENDOWMENTS, ...NETWORK_APIS];
+export const ALL_APIS: string[] = [
+  ...DEFAULT_ENDOWMENTS,
+  ...NETWORK_APIS,
+  'WebAssembly',
+];
 
 type MockSnapGlobal = {
   request: () => Promise<any>;

--- a/packages/snaps-utils/src/mock.ts
+++ b/packages/snaps-utils/src/mock.ts
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 
 import { DEFAULT_ENDOWMENTS } from './default-endowments';
 
-const NETWORK_APIS = ['fetch'];
+const NETWORK_APIS = ['fetch', 'Request', 'Headers', 'Response'];
 
 export const ALL_APIS: string[] = [
   ...DEFAULT_ENDOWMENTS,


### PR DESCRIPTION
Add `WebAssembly` to eval mock to fix issues with eval failing when devs are leveraging WebAssembly.