### PR TITLE
Refactor console endowment to include a subset of available console functions

### DIFF
--- a/packages/snaps-controllers/src/services/node/NodeProcessExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/node/NodeProcessExecutionService.test.ts
@@ -124,7 +124,7 @@ describe('NodeProcessExecutionService', () => {
     expect(await unhandledErrorPromise).toEqual({
       code: -32603,
       data: {
-        snapName: 'TestSnap',
+        snapId: 'TestSnap',
         stack: expect.any(String),
       },
       message: 'random error inside',

--- a/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.test.ts
+++ b/packages/snaps-controllers/src/services/node/NodeThreadExecutionService.test.ts
@@ -127,7 +127,7 @@ describe('NodeThreadExecutionService', () => {
     expect(await unhandledErrorPromise).toEqual({
       code: -32603,
       data: {
-        snapName: 'TestSnap',
+        snapId: 'TestSnap',
         stack: expect.any(String),
       },
       message: 'random error inside',

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 79.28,
+  "branches": 79.16,
   "functions": 91.79,
   "lines": 89.7,
   "statements": 89.76

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 79.16,
-  "functions": 92.25,
+  "branches": 79.31,
+  "functions": 92.3,
   "lines": 89.96,
   "statements": 90.03
 }

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 79.16,
   "functions": 92.25,
-  "lines": 90.12,
-  "statements": 90.18
+  "lines": 89.96,
+  "statements": 90.03
 }

--- a/packages/snaps-execution-environments/coverage.json
+++ b/packages/snaps-execution-environments/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 79.16,
-  "functions": 91.79,
-  "lines": 89.7,
-  "statements": 89.76
+  "functions": 92.25,
+  "lines": 90.12,
+  "statements": 90.18
 }

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.test.browser.ts
@@ -805,7 +805,7 @@ describe('BaseSnapExecutor', () => {
           code: -32603,
           data: {
             stack: error.stack,
-            snapName: MOCK_SNAP_ID,
+            snapId: MOCK_SNAP_ID,
           },
           message: error.message,
         },
@@ -865,7 +865,7 @@ describe('BaseSnapExecutor', () => {
           code: -32603,
           data: {
             stack: error.stack,
-            snapName: MOCK_SNAP_ID,
+            snapId: MOCK_SNAP_ID,
           },
           message: error.message,
         },
@@ -1649,17 +1649,17 @@ describe('BaseSnapExecutor', () => {
   describe('executeSnap', () => {
     [
       {
-        snapName: 1,
+        snapId: 1,
         code: 'module.exports.onRpcRequest = () => 1;',
         endowments: [],
       },
       {
-        snapName: MOCK_SNAP_ID,
+        snapId: MOCK_SNAP_ID,
         code: 1,
         endowments: [],
       },
       {
-        snapName: MOCK_SNAP_ID,
+        snapId: MOCK_SNAP_ID,
         code: 'module.exports.onRpcRequest = () => 1;',
         endowments: ['foo', 1],
       },
@@ -1694,25 +1694,25 @@ describe('BaseSnapExecutor', () => {
   describe('snapRpc', () => {
     [
       {
-        snapName: 1,
+        snapId: 1,
         method: HandlerType.OnRpcRequest,
         origin: MOCK_ORIGIN,
         request: { jsonrpc: '2.0', method: '', params: [] },
       },
       {
-        snapName: MOCK_SNAP_ID,
+        snapId: MOCK_SNAP_ID,
         method: 1,
         origin: MOCK_ORIGIN,
         request: { jsonrpc: '2.0', method: '', params: [] },
       },
       {
-        snapName: MOCK_SNAP_ID,
+        snapId: MOCK_SNAP_ID,
         method: HandlerType.OnRpcRequest,
         origin: 1,
         request: { jsonrpc: '2.0', method: '', params: [] },
       },
       {
-        snapName: MOCK_SNAP_ID,
+        snapId: MOCK_SNAP_ID,
         method: HandlerType.OnRpcRequest,
         origin: MOCK_ORIGIN,
         request: 1,
@@ -1765,7 +1765,7 @@ describe('BaseSnapExecutor', () => {
     it('throws a human-readable error if the request arguments are invalid', async () => {
       const executor = new TestSnapExecutor();
       const params = {
-        snapName: 1,
+        snapId: 1,
         method: HandlerType.OnRpcRequest,
         origin: MOCK_ORIGIN,
         request: { jsonrpc: '2.0', method: '', params: [] },

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -314,6 +314,7 @@ export class BaseSnapExecutor {
       const { endowments, teardown: endowmentTeardown } = createEndowments(
         snap,
         ethereum,
+        snapName,
         _endowments,
       );
 

--- a/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
+++ b/packages/snaps-execution-environments/src/common/BaseSnapExecutor.ts
@@ -88,7 +88,7 @@ const EXECUTION_ENVIRONMENT_METHODS = {
   },
   executeSnap: {
     struct: ExecuteSnapRequestArgumentsStruct,
-    params: ['snapName', 'sourceCode', 'endowments'],
+    params: ['snapId', 'sourceCode', 'endowments'],
   },
   terminate: {
     struct: TerminateRequestArgumentsStruct,
@@ -270,16 +270,16 @@ export class BaseSnapExecutor {
    * Attempts to evaluate a snap in SES. Generates APIs for the snap. May throw
    * on errors.
    *
-   * @param snapName - The name of the snap.
+   * @param snapId - The id of the snap.
    * @param sourceCode - The source code of the snap, in IIFE format.
    * @param _endowments - An array of the names of the endowments.
    */
   protected async startSnap(
-    snapName: string,
+    snapId: string,
     sourceCode: string,
     _endowments?: string[],
   ): Promise<void> {
-    log(`Starting snap '${snapName}' in worker.`);
+    log(`Starting snap '${snapId}' in worker.`);
     if (this.snapPromiseErrorHandler) {
       removeEventListener('unhandledrejection', this.snapPromiseErrorHandler);
     }
@@ -289,12 +289,12 @@ export class BaseSnapExecutor {
     }
 
     this.snapErrorHandler = (error: ErrorEvent) => {
-      this.errorHandler(error.error, { snapName });
+      this.errorHandler(error.error, { snapId });
     };
 
     this.snapPromiseErrorHandler = (error: PromiseRejectionEvent) => {
       this.errorHandler(error instanceof Error ? error : error.reason, {
-        snapName,
+        snapId,
       });
     };
 
@@ -314,13 +314,13 @@ export class BaseSnapExecutor {
       const { endowments, teardown: endowmentTeardown } = createEndowments(
         snap,
         ethereum,
-        snapName,
+        snapId,
         _endowments,
       );
 
       // !!! Ensure that this is the only place the data is being set.
       // Other methods access the object value and mutate its properties.
-      this.snapData.set(snapName, {
+      this.snapData.set(snapId, {
         idleTeardown: endowmentTeardown,
         runningEvaluations: new Set(),
         exports: {},
@@ -343,14 +343,14 @@ export class BaseSnapExecutor {
       compartment.globalThis.global = compartment.globalThis;
       compartment.globalThis.window = compartment.globalThis;
 
-      await this.executeInSnapContext(snapName, () => {
+      await this.executeInSnapContext(snapId, () => {
         compartment.evaluate(sourceCode);
-        this.registerSnapExports(snapName, snapModule);
+        this.registerSnapExports(snapId, snapModule);
       });
     } catch (error) {
-      this.removeSnap(snapName);
+      this.removeSnap(snapId);
       throw new Error(
-        `Error while running snap '${snapName}': ${(error as Error).message}`,
+        `Error while running snap '${snapId}': ${(error as Error).message}`,
       );
     }
   }
@@ -369,8 +369,8 @@ export class BaseSnapExecutor {
     this.snapData.clear();
   }
 
-  private registerSnapExports(snapName: string, snapModule: any) {
-    const data = this.snapData.get(snapName);
+  private registerSnapExports(snapId: string, snapModule: any) {
+    const data = this.snapData.get(snapId);
     // Somebody deleted the Snap before we could register
     if (!data) {
       return;
@@ -452,10 +452,10 @@ export class BaseSnapExecutor {
   /**
    * Removes the snap with the given name.
    *
-   * @param snapName - The name of the snap to remove.
+   * @param snapId - The id of the snap to remove.
    */
-  private removeSnap(snapName: string): void {
-    this.snapData.delete(snapName);
+  private removeSnap(snapId: string): void {
+    this.snapData.delete(snapId);
   }
 
   /**
@@ -464,19 +464,19 @@ export class BaseSnapExecutor {
    * counted as an evaluation of the specified snap. When the count of running
    * evaluations of a snap reaches zero, its endowments are torn down.
    *
-   * @param snapName - The name of the snap whose context to execute in.
+   * @param snapId - The id of the snap whose context to execute in.
    * @param executor - The function that will be executed in the snap's context.
    * @returns The executor's return value.
    * @template Result - The return value of the executor.
    */
   private async executeInSnapContext<Result>(
-    snapName: string,
+    snapId: string,
     executor: () => Promise<Result> | Result,
   ): Promise<Result> {
-    const data = this.snapData.get(snapName);
+    const data = this.snapData.get(snapId);
     if (data === undefined) {
       throw new Error(
-        `Tried to execute in context of unknown snap: "${snapName}".`,
+        `Tried to execute in context of unknown snap: "${snapId}".`,
       );
     }
 
@@ -487,7 +487,7 @@ export class BaseSnapExecutor {
           reject(
             // TODO(rekmarks): Specify / standardize error code for this case.
             ethErrors.rpc.internal(
-              `The snap "${snapName}" has been terminated during execution.`,
+              `The snap "${snapId}" has been terminated during execution.`,
             ),
           )),
     );

--- a/packages/snaps-execution-environments/src/common/commands.ts
+++ b/packages/snaps-execution-environments/src/common/commands.ts
@@ -80,8 +80,8 @@ export function getCommandMethodImplementations(
       return Promise.resolve('OK');
     },
 
-    executeSnap: async (snapName, sourceCode, endowments) => {
-      await startSnap(snapName, sourceCode, endowments);
+    executeSnap: async (snapId, sourceCode, endowments) => {
+      await startSnap(snapId, sourceCode, endowments);
       return 'OK';
     },
 

--- a/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/commonEndowmentFactory.ts
@@ -1,4 +1,7 @@
+import { SnapId } from '@metamask/snaps-utils';
+
 import { rootRealmGlobal } from '../globalObject';
+import consoleEndowment from './console';
 import crypto from './crypto';
 import date from './date';
 import interval from './interval';
@@ -8,9 +11,13 @@ import textDecoder from './textDecoder';
 import textEncoder from './textEncoder';
 import timeout from './timeout';
 
+export type EndowmentFactoryOptions = {
+  snapId?: SnapId;
+};
+
 export type EndowmentFactory = {
   names: readonly string[];
-  factory: () => { [key: string]: unknown };
+  factory: (options?: EndowmentFactoryOptions) => { [key: string]: unknown };
 };
 
 export type CommonEndowmentSpecification = {
@@ -18,6 +25,8 @@ export type CommonEndowmentSpecification = {
   name: string;
   bind?: boolean;
 };
+
+export const EndowmentsWithFactoryOptions = new Set(['console']);
 
 // Array of common endowments
 const commonEndowments: CommonEndowmentSpecification[] = [
@@ -29,7 +38,6 @@ const commonEndowments: CommonEndowmentSpecification[] = [
   { endowment: BigInt64Array, name: 'BigInt64Array' },
   { endowment: BigUint64Array, name: 'BigUint64Array' },
   { endowment: btoa, name: 'btoa', bind: true },
-  { endowment: console, name: 'console' },
   { endowment: DataView, name: 'DataView' },
   { endowment: Float32Array, name: 'Float32Array' },
   { endowment: Float64Array, name: 'Float64Array' },
@@ -61,6 +69,7 @@ const buildCommonEndowments = (): EndowmentFactory[] => {
     textDecoder,
     textEncoder,
     date,
+    consoleEndowment,
   ];
 
   commonEndowments.forEach((endowmentSpecification) => {

--- a/packages/snaps-execution-environments/src/common/endowments/console.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/console.test.ts
@@ -1,0 +1,140 @@
+import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
+
+import { rootRealmGlobal } from '../globalObject';
+import consoleEndowment, { consoleAttenuatedMethods } from './console';
+
+describe('Console endowment', () => {
+  it('has expected properties', () => {
+    expect(consoleEndowment).toMatchObject({
+      names: ['console'],
+      factory: expect.any(Function),
+    });
+  });
+
+  it('returns console properties from rootRealmGlobal', () => {
+    const { console }: { console: Partial<typeof rootRealmGlobal.console> } =
+      consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+    const consoleProperties = Object.getOwnPropertyNames(
+      rootRealmGlobal.console,
+    );
+    const unchangedProperties = consoleProperties.filter(
+      (property) => !consoleAttenuatedMethods.has(property),
+    ) as (keyof typeof rootRealmGlobal.console)[];
+    unchangedProperties.forEach((unchangedProperty) => {
+      expect(console[unchangedProperty]).toStrictEqual(
+        rootRealmGlobal.console[unchangedProperty],
+      );
+    });
+  });
+
+  describe('log', () => {
+    it('does not return the original console.log', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      expect(console.log).not.toStrictEqual(rootRealmGlobal.console.log);
+    });
+
+    it('will log a message identifying the source of the call (snap id)', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
+      console.log('This is a log message.');
+      expect(logSpy).toHaveBeenNthCalledWith(
+        1,
+        `[SNAP LOG | snapId: ${MOCK_SNAP_ID}]`,
+      );
+      expect(logSpy).toHaveBeenNthCalledWith(2, 'This is a log message.');
+    });
+  });
+
+  describe('error', () => {
+    it('does not return the original console.error', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      expect(console.error).not.toStrictEqual(rootRealmGlobal.console.error);
+    });
+
+    it('will log a message identifying the source of the call (snap id)', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
+      const errorSpy = jest.spyOn(rootRealmGlobal.console, 'error');
+      console.error('This is an error message.');
+      expect(logSpy).toHaveBeenCalledWith(
+        `[SNAP ERROR | snapId: ${MOCK_SNAP_ID}]`,
+      );
+      expect(errorSpy).toHaveBeenCalledWith('This is an error message.');
+    });
+  });
+
+  describe('assert', () => {
+    it('does not return the original console.assert', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      expect(console.assert).not.toStrictEqual(rootRealmGlobal.console.assert);
+    });
+
+    it('will log a message identifying the source of the call (snap id)', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
+      const assertSpy = jest.spyOn(rootRealmGlobal.console, 'assert');
+      console.assert(1 > 2, 'This is an assert message.');
+      expect(logSpy).toHaveBeenCalledWith(
+        `[SNAP ASSERT | snapId: ${MOCK_SNAP_ID}]`,
+      );
+      expect(assertSpy).toHaveBeenCalledWith(
+        1 > 2,
+        'This is an assert message.',
+      );
+    });
+  });
+
+  describe('debug', () => {
+    it('does not return the original console.debug', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      expect(console.debug).not.toStrictEqual(rootRealmGlobal.console.debug);
+    });
+
+    it('will log a message identifying the source of the call (snap id)', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
+      const debugSpy = jest.spyOn(rootRealmGlobal.console, 'debug');
+      console.debug('This is a debug message.');
+      expect(logSpy).toHaveBeenCalledWith(
+        `[SNAP DEBUG | snapId: ${MOCK_SNAP_ID}]`,
+      );
+      expect(debugSpy).toHaveBeenCalledWith('This is a debug message.');
+    });
+  });
+
+  describe('info', () => {
+    it('does not return the original console.info', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      expect(console.info).not.toStrictEqual(rootRealmGlobal.console.info);
+    });
+
+    it('will log a message identifying the source of the call (snap id)', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      const infoSpy = jest.spyOn(rootRealmGlobal.console, 'info');
+      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
+      console.info('This is an info message.');
+      expect(logSpy).toHaveBeenCalledWith(
+        `[SNAP INFO | snapId: ${MOCK_SNAP_ID}]`,
+      );
+      expect(infoSpy).toHaveBeenCalledWith('This is an info message.');
+    });
+  });
+
+  describe('warn', () => {
+    it('does not return the original console.warn', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      expect(console.warn).not.toStrictEqual(rootRealmGlobal.console.warn);
+    });
+
+    it('will log a message identifying the source of the call (snap id)', () => {
+      const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
+      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
+      const warnSpy = jest.spyOn(rootRealmGlobal.console, 'warn');
+      console.warn('This is a warn message.');
+      expect(logSpy).toHaveBeenCalledWith(
+        `[SNAP WARN | snapId: ${MOCK_SNAP_ID}]`,
+      );
+      expect(warnSpy).toHaveBeenCalledWith('This is a warn message.');
+    });
+  });
+});

--- a/packages/snaps-execution-environments/src/common/endowments/console.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/console.test.ts
@@ -37,11 +37,10 @@ describe('Console endowment', () => {
       const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
       const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
       console.log('This is a log message.');
-      expect(logSpy).toHaveBeenNthCalledWith(
-        1,
-        `[SNAP LOG | snapId: ${MOCK_SNAP_ID}]`,
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(
+        `[Snap: ${MOCK_SNAP_ID}] This is a log message.`,
       );
-      expect(logSpy).toHaveBeenNthCalledWith(2, 'This is a log message.');
     });
   });
 
@@ -53,13 +52,12 @@ describe('Console endowment', () => {
 
     it('will log a message identifying the source of the call (snap id)', () => {
       const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
-      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
       const errorSpy = jest.spyOn(rootRealmGlobal.console, 'error');
       console.error('This is an error message.');
-      expect(logSpy).toHaveBeenCalledWith(
-        `[SNAP ERROR | snapId: ${MOCK_SNAP_ID}]`,
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        `[Snap: ${MOCK_SNAP_ID}] This is an error message.`,
       );
-      expect(errorSpy).toHaveBeenCalledWith('This is an error message.');
     });
   });
 
@@ -71,15 +69,12 @@ describe('Console endowment', () => {
 
     it('will log a message identifying the source of the call (snap id)', () => {
       const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
-      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
       const assertSpy = jest.spyOn(rootRealmGlobal.console, 'assert');
       console.assert(1 > 2, 'This is an assert message.');
-      expect(logSpy).toHaveBeenCalledWith(
-        `[SNAP ASSERT | snapId: ${MOCK_SNAP_ID}]`,
-      );
+      expect(assertSpy).toHaveBeenCalledTimes(1);
       expect(assertSpy).toHaveBeenCalledWith(
-        1 > 2,
-        'This is an assert message.',
+        false,
+        `[Snap: ${MOCK_SNAP_ID}] This is an assert message.`,
       );
     });
   });
@@ -92,13 +87,12 @@ describe('Console endowment', () => {
 
     it('will log a message identifying the source of the call (snap id)', () => {
       const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
-      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
       const debugSpy = jest.spyOn(rootRealmGlobal.console, 'debug');
       console.debug('This is a debug message.');
-      expect(logSpy).toHaveBeenCalledWith(
-        `[SNAP DEBUG | snapId: ${MOCK_SNAP_ID}]`,
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `[Snap: ${MOCK_SNAP_ID}] This is a debug message.`,
       );
-      expect(debugSpy).toHaveBeenCalledWith('This is a debug message.');
     });
   });
 
@@ -111,12 +105,11 @@ describe('Console endowment', () => {
     it('will log a message identifying the source of the call (snap id)', () => {
       const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
       const infoSpy = jest.spyOn(rootRealmGlobal.console, 'info');
-      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
       console.info('This is an info message.');
-      expect(logSpy).toHaveBeenCalledWith(
-        `[SNAP INFO | snapId: ${MOCK_SNAP_ID}]`,
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy).toHaveBeenCalledWith(
+        `[Snap: ${MOCK_SNAP_ID}] This is an info message.`,
       );
-      expect(infoSpy).toHaveBeenCalledWith('This is an info message.');
     });
   });
 
@@ -128,13 +121,12 @@ describe('Console endowment', () => {
 
     it('will log a message identifying the source of the call (snap id)', () => {
       const { console } = consoleEndowment.factory({ snapId: MOCK_SNAP_ID });
-      const logSpy = jest.spyOn(rootRealmGlobal.console, 'log');
       const warnSpy = jest.spyOn(rootRealmGlobal.console, 'warn');
       console.warn('This is a warn message.');
-      expect(logSpy).toHaveBeenCalledWith(
-        `[SNAP WARN | snapId: ${MOCK_SNAP_ID}]`,
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        `[Snap: ${MOCK_SNAP_ID}] This is a warn message.`,
       );
-      expect(warnSpy).toHaveBeenCalledWith('This is a warn message.');
     });
   });
 });

--- a/packages/snaps-execution-environments/src/common/endowments/console.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/console.ts
@@ -1,3 +1,6 @@
+import { SnapId } from '@metamask/snaps-utils';
+import { assert } from '@metamask/utils';
+
 import { rootRealmGlobal } from '../globalObject';
 import { EndowmentFactoryOptions } from './commonEndowmentFactory';
 
@@ -11,6 +14,29 @@ export const consoleAttenuatedMethods = new Set([
 ]);
 
 /**
+ * Gets the appropriate (prepended) message to pass to one of the attenuated
+ * method calls.
+ *
+ * @param snapId - Id of the snap that we're getting a message for.
+ * @param message - The id of the snap that will interact with the endowment.
+ * @param args - The array of additional arguments.
+ * @returns An array of arguments to be passed into an attenuated console method call.
+ */
+function getMessage(snapId: SnapId, message: unknown, ...args: unknown[]) {
+  const prefix = `[Snap: ${snapId}]`;
+
+  // If the first argument is a string, prepend the prefix to the message, and keep the
+  // rest of the arguments as-is.
+  if (typeof message === 'string') {
+    return [`${prefix} ${message}`, ...args];
+  }
+
+  // Otherwise, the `message` is an object, array, etc., so add the prefix as a separate
+  // message to the arguments.
+  return [prefix, message, ...args];
+}
+
+/**
  * Create a a {@link console} object, with the same properties as the global
  * {@link console} object, but with some methods replaced.
  *
@@ -19,6 +45,7 @@ export const consoleAttenuatedMethods = new Set([
  * @returns The {@link console} object with the replaced methods.
  */
 function createConsole({ snapId }: EndowmentFactoryOptions = {}) {
+  assert(snapId !== undefined);
   const keys = Object.getOwnPropertyNames(
     rootRealmGlobal.console,
   ) as (keyof typeof console)[];
@@ -35,32 +62,39 @@ function createConsole({ snapId }: EndowmentFactoryOptions = {}) {
     console: {
       ...attenuatedConsole,
       log: (message?: any, ...optionalParams: any[]) => {
-        rootRealmGlobal.console.log(`[SNAP LOG | snapId: ${snapId}]`);
-        rootRealmGlobal.console.log(message, ...optionalParams);
+        rootRealmGlobal.console.log(
+          ...getMessage(snapId, message, ...optionalParams),
+        );
       },
       assert: (
         value: any,
         message?: string | undefined,
         ...optionalParams: any[]
       ) => {
-        rootRealmGlobal.console.log(`[SNAP ASSERT | snapId: ${snapId}]`);
-        rootRealmGlobal.console.assert(value, message, ...optionalParams);
+        rootRealmGlobal.console.assert(
+          value,
+          ...getMessage(snapId, message, ...optionalParams),
+        );
       },
       error: (message?: any, ...optionalParams: any[]) => {
-        rootRealmGlobal.console.log(`[SNAP ERROR | snapId: ${snapId}]`);
-        rootRealmGlobal.console.error(message, ...optionalParams);
+        rootRealmGlobal.console.error(
+          ...getMessage(snapId, message, ...optionalParams),
+        );
       },
       debug: (message?: any, ...optionalParams: any[]) => {
-        rootRealmGlobal.console.log(`[SNAP DEBUG | snapId: ${snapId}]`);
-        rootRealmGlobal.console.debug(message, ...optionalParams);
+        rootRealmGlobal.console.debug(
+          ...getMessage(snapId, message, ...optionalParams),
+        );
       },
       info: (message?: any, ...optionalParams: any[]) => {
-        rootRealmGlobal.console.log(`[SNAP INFO | snapId: ${snapId}]`);
-        rootRealmGlobal.console.info(message, ...optionalParams);
+        rootRealmGlobal.console.info(
+          ...getMessage(snapId, message, ...optionalParams),
+        );
       },
       warn: (message?: any, ...optionalParams: any[]) => {
-        rootRealmGlobal.console.log(`[SNAP WARN | snapId: ${snapId}]`);
-        rootRealmGlobal.console.warn(message, ...optionalParams);
+        rootRealmGlobal.console.warn(
+          ...getMessage(snapId, message, ...optionalParams),
+        );
       },
     },
   });

--- a/packages/snaps-execution-environments/src/common/endowments/console.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/console.ts
@@ -14,6 +14,37 @@ export const consoleAttenuatedMethods = new Set([
 ]);
 
 /**
+ * A set of all the `console` values that will be passed to the snap. This has
+ * all the values that are available in both the browser and Node.js.
+ */
+const consoleMethods = new Set([
+  'debug',
+  'error',
+  'info',
+  'log',
+  'warn',
+  'dir',
+  'dirxml',
+  'table',
+  'trace',
+  'group',
+  'groupCollapsed',
+  'groupEnd',
+  'clear',
+  'count',
+  'countReset',
+  'assert',
+  'profile',
+  'profileEnd',
+  'time',
+  'timeLog',
+  'timeEnd',
+  'timeStamp',
+  'context',
+  'createTask',
+]);
+
+/**
  * Gets the appropriate (prepended) message to pass to one of the attenuated
  * method calls.
  *
@@ -51,11 +82,11 @@ function createConsole({ snapId }: EndowmentFactoryOptions = {}) {
   ) as (keyof typeof console)[];
 
   const attenuatedConsole = keys.reduce((target, key) => {
-    if (consoleAttenuatedMethods.has(key)) {
-      return target;
+    if (consoleMethods.has(key) && !consoleAttenuatedMethods.has(key)) {
+      return { ...target, [key]: rootRealmGlobal.console[key] };
     }
 
-    return { ...target, [key]: rootRealmGlobal.console[key] };
+    return target;
   }, {});
 
   return harden({

--- a/packages/snaps-execution-environments/src/common/endowments/console.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/console.ts
@@ -1,11 +1,69 @@
+import { rootRealmGlobal } from '../globalObject';
+import { EndowmentFactoryOptions } from './commonEndowmentFactory';
+
+export const consoleAttenuatedMethods = new Set([
+  'log',
+  'assert',
+  'error',
+  'debug',
+  'info',
+  'warn',
+]);
+
 /**
  * Create a a {@link console} object, with the same properties as the global
  * {@link console} object, but with some methods replaced.
  *
+ * @param options - Factory options used in construction of the endowment.
+ * @param options.snapId - The id of the snap that will interact with the endowment.
  * @returns The {@link console} object with the replaced methods.
  */
-function createConsole() {
-  return {};
+function createConsole({ snapId }: EndowmentFactoryOptions = {}) {
+  const keys = Object.getOwnPropertyNames(
+    rootRealmGlobal.console,
+  ) as (keyof typeof console)[];
+
+  const attenuatedConsole = keys.reduce((target, key) => {
+    if (consoleAttenuatedMethods.has(key)) {
+      return target;
+    }
+
+    return { ...target, [key]: rootRealmGlobal.console[key] };
+  }, {});
+
+  return harden({
+    console: {
+      ...attenuatedConsole,
+      log: (message?: any, ...optionalParams: any[]) => {
+        rootRealmGlobal.console.log(`[SNAP LOG | snapId: ${snapId}]`);
+        rootRealmGlobal.console.log(message, ...optionalParams);
+      },
+      assert: (
+        value: any,
+        message?: string | undefined,
+        ...optionalParams: any[]
+      ) => {
+        rootRealmGlobal.console.log(`[SNAP ASSERT | snapId: ${snapId}]`);
+        rootRealmGlobal.console.assert(value, message, ...optionalParams);
+      },
+      error: (message?: any, ...optionalParams: any[]) => {
+        rootRealmGlobal.console.log(`[SNAP ERROR | snapId: ${snapId}]`);
+        rootRealmGlobal.console.error(message, ...optionalParams);
+      },
+      debug: (message?: any, ...optionalParams: any[]) => {
+        rootRealmGlobal.console.log(`[SNAP DEBUG | snapId: ${snapId}]`);
+        rootRealmGlobal.console.debug(message, ...optionalParams);
+      },
+      info: (message?: any, ...optionalParams: any[]) => {
+        rootRealmGlobal.console.log(`[SNAP INFO | snapId: ${snapId}]`);
+        rootRealmGlobal.console.info(message, ...optionalParams);
+      },
+      warn: (message?: any, ...optionalParams: any[]) => {
+        rootRealmGlobal.console.log(`[SNAP WARN | snapId: ${snapId}]`);
+        rootRealmGlobal.console.warn(message, ...optionalParams);
+      },
+    },
+  });
 }
 
 const endowmentModule = {

--- a/packages/snaps-execution-environments/src/common/endowments/console.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/console.ts
@@ -1,0 +1,16 @@
+/**
+ * Create a a {@link console} object, with the same properties as the global
+ * {@link console} object, but with some methods replaced.
+ *
+ * @returns The {@link console} object with the replaced methods.
+ */
+function createConsole() {
+  return {};
+}
+
+const endowmentModule = {
+  names: ['console'] as const,
+  factory: createConsole,
+};
+
+export default endowmentModule;

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -2,9 +2,14 @@
 
 import 'ses';
 
+import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
+
 import { walkAndSearch } from '../test-utils/endowments';
 import { testEndowmentHardening } from '../test-utils/hardening';
-import buildCommonEndowments from './commonEndowmentFactory';
+import buildCommonEndowments, {
+  EndowmentsWithFactoryOptions,
+} from './commonEndowmentFactory';
+import consoleEndowment from './console';
 import CryptoEndowment from './crypto';
 import date from './date';
 import interval from './interval';
@@ -32,7 +37,13 @@ globalThis.btoa = harden(originalBtoa);
 describe('endowments', () => {
   describe('hardening', () => {
     const modules = buildCommonEndowments();
-    modules.forEach((endowment) => endowment.factory());
+    modules
+      .filter((module) => {
+        return module.names.every((name) => {
+          return !EndowmentsWithFactoryOptions.has(name);
+        });
+      })
+      .forEach((endowment) => endowment.factory());
 
     // Specially attenuated endowments or endowments that require
     // to be imported in a different way
@@ -49,6 +60,9 @@ describe('endowments', () => {
     const { Math: mathAttenuated } = math.factory();
     const { fetch: fetchAttenuated } = network.factory();
     const { Date: DateAttenuated } = date.factory();
+    const { console: consoleAttenuated } = consoleEndowment.factory({
+      snapId: MOCK_SNAP_ID,
+    });
 
     const TEST_ENDOWMENTS = {
       // Constructor functions.
@@ -140,9 +154,9 @@ describe('endowments', () => {
       },
 
       // Objects.
-      console: {
-        endowments: { console },
-        factory: () => console,
+      consoleAttenuated: {
+        endowments: { consoleAttenuated },
+        factory: () => consoleAttenuated,
       },
       crypto: {
         endowments: { crypto },

--- a/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/endowments.test.browser.ts
@@ -255,6 +255,10 @@ describe('endowments', () => {
         },
         {
           factory: expect.any(Function),
+          names: ['console'],
+        },
+        {
+          factory: expect.any(Function),
           names: ['AbortController'],
         },
         {
@@ -284,10 +288,6 @@ describe('endowments', () => {
         {
           factory: expect.any(Function),
           names: ['btoa'],
-        },
-        {
-          factory: expect.any(Function),
-          names: ['console'],
         },
         {
           factory: expect.any(Function),

--- a/packages/snaps-execution-environments/src/common/endowments/index.test.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.test.ts
@@ -1,3 +1,4 @@
+import { MOCK_SNAP_ID } from '@metamask/snaps-utils/test-utils';
 import fetchMock from 'jest-fetch-mock';
 
 import { createEndowments } from '.';
@@ -21,10 +22,11 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
       );
 
       expect(
-        createEndowments(mockSnapAPI as any, mockEthereum as any),
+        createEndowments(mockSnapAPI as any, mockEthereum as any, MOCK_SNAP_ID),
       ).toStrictEqual({
         endowments: {
           snap: mockSnapAPI,
@@ -40,6 +42,7 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         ['mockEndowment'],
       );
       expect(endowments.mockEndowment).toBeDefined();
@@ -50,6 +53,7 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         ['ethereum'],
       );
       expect(endowments.ethereum).toBe(mockEthereum);
@@ -59,6 +63,7 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         ['setTimeout'],
       );
 
@@ -73,6 +78,7 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         ['setTimeout'],
       );
 
@@ -87,6 +93,7 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         ['setTimeout', 'clearTimeout'],
       );
 
@@ -102,6 +109,7 @@ describe('Endowment utils', () => {
       const { endowments } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         [
           'console',
           'Uint8Array',
@@ -114,7 +122,7 @@ describe('Endowment utils', () => {
 
       expect(endowments).toMatchObject({
         snap: mockSnapAPI,
-        console,
+        console: expect.any(Object),
         Uint8Array: expect.any(Function),
         Math: expect.any(Object),
         setTimeout: expect.any(Function),
@@ -123,18 +131,23 @@ describe('Endowment utils', () => {
       });
 
       expect(endowments.snap).toBe(mockSnapAPI);
-      expect(endowments.console).toBe(console);
       expect(endowments.Uint8Array).toBe(Uint8Array);
       expect(endowments.WebAssembly).toBe(WebAssembly);
 
       expect(endowments.clearTimeout).not.toBe(clearTimeout);
       expect(endowments.setTimeout).not.toBe(setTimeout);
       expect(endowments.Math).not.toBe(Math);
+      expect(endowments.console).not.toBe(console);
     });
 
     it('throws for unknown endowments', () => {
       expect(() =>
-        createEndowments(mockSnapAPI as any, mockEthereum as any, ['foo']),
+        createEndowments(
+          mockSnapAPI as any,
+          mockEthereum as any,
+          MOCK_SNAP_ID,
+          ['foo'],
+        ),
       ).toThrow('Unknown endowment: "foo"');
     });
 
@@ -142,6 +155,7 @@ describe('Endowment utils', () => {
       const { endowments, teardown } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
       );
 
@@ -179,6 +193,7 @@ describe('Endowment utils', () => {
       const { endowments, teardown } = createEndowments(
         mockSnapAPI as any,
         mockEthereum as any,
+        MOCK_SNAP_ID,
         ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
       );
 

--- a/packages/snaps-execution-environments/src/common/endowments/index.ts
+++ b/packages/snaps-execution-environments/src/common/endowments/index.ts
@@ -1,10 +1,13 @@
 import { StreamProvider } from '@metamask/providers';
 import { SnapsGlobalObject } from '@metamask/rpc-methods';
-import { logWarning } from '@metamask/snaps-utils';
+import { SnapId, logWarning } from '@metamask/snaps-utils';
 import { hasProperty } from '@metamask/utils';
 
 import { rootRealmGlobal } from '../globalObject';
-import buildCommonEndowments from './commonEndowmentFactory';
+import buildCommonEndowments, {
+  EndowmentFactoryOptions,
+  EndowmentsWithFactoryOptions,
+} from './commonEndowmentFactory';
 
 type EndowmentFactoryResult = {
   /**
@@ -34,7 +37,7 @@ const endowmentFactories = registeredEndowments.reduce((factories, builder) => {
     factories.set(name, builder.factory);
   });
   return factories;
-}, new Map<string, () => EndowmentFactoryResult>());
+}, new Map<string, (options?: EndowmentFactoryOptions) => EndowmentFactoryResult>());
 
 /**
  * Gets the endowments for a particular Snap. Some endowments, like `setTimeout`
@@ -45,12 +48,14 @@ const endowmentFactories = registeredEndowments.reduce((factories, builder) => {
  *
  * @param snap - The Snaps global API object.
  * @param ethereum - The Snap's EIP-1193 provider object.
+ * @param snapId - The id of the snap that will use the created endowments.
  * @param endowments - The list of endowments to provide to the snap.
  * @returns An object containing the Snap's endowments.
  */
 export function createEndowments(
   snap: SnapsGlobalObject,
   ethereum: StreamProvider,
+  snapId: SnapId,
   endowments: string[] = [],
 ): { endowments: Record<string, unknown>; teardown: () => Promise<void> } {
   const attenuatedEndowments: Record<string, unknown> = {};
@@ -73,9 +78,15 @@ export function createEndowments(
           // This may not have an actual use case, but, safety first.
 
           // We just confirmed that endowmentFactories has the specified key.
-          const { teardownFunction, ...endowment } =
+          let factoryResult;
+          if (EndowmentsWithFactoryOptions.has(endowmentName)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            endowmentFactories.get(endowmentName)!();
+            factoryResult = endowmentFactories.get(endowmentName)!({ snapId });
+          } else {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            factoryResult = endowmentFactories.get(endowmentName)!();
+          }
+          const { teardownFunction, ...endowment } = factoryResult;
           Object.assign(attenuatedEndowments, endowment);
           if (teardownFunction) {
             teardowns.push(teardownFunction);

--- a/packages/snaps-execution-environments/src/openrpc.json
+++ b/packages/snaps-execution-environments/src/openrpc.json
@@ -32,7 +32,7 @@
       "description": "executes a snap in the environment. The snap can then be interacted with via `snapRpc`",
       "params": [
         {
-          "name": "snapName",
+          "name": "snapId",
           "required": true,
           "description": "the name of the snap",
           "schema": {
@@ -75,7 +75,7 @@
           "name": "BasicTestSnapExecuteExample",
           "params": [
             {
-              "name": "snapName",
+              "name": "snapId",
               "value": "TestSnap"
             },
             {


### PR DESCRIPTION
## Description

This change updates the console endowment by limiting it to a subset of the available console functions, as the existing implementation was causing SES hardening to fail.

## Changes

1. Refactor console endowment to include a subset of available console functions