### PR TITLE
Patch `inline-source-map` to remove deprecated use of Buffer

### DIFF
--- a/.yarn/patches/inline-source-map-npm-0.6.2-96902459a0.patch
+++ b/.yarn/patches/inline-source-map-npm-0.6.2-96902459a0.patch
@@ -1,0 +1,13 @@
+diff --git a/index.js b/index.js
+index df74d6126073947a34234f271a033c4d13ed02e5..833a4846989673c597500be60301a52132ebaa09 100644
+--- a/index.js
++++ b/index.js
+@@ -91,7 +91,7 @@ Generator.prototype.addSourceContent = function (sourceFile, sourcesContent) {
+  */
+ Generator.prototype.base64Encode = function () {
+   var map = this.toString();
+-  return new Buffer(map).toString('base64');
++  return Buffer.from(map).toString('base64');
+ };
+ 
+ /**

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@lavamoat/lavapack@^3.3.0": "patch:@lavamoat/lavapack@npm%3A3.3.0#./.yarn/patches/@lavamoat-lavapack-npm-3.3.0-5a61b5374d.patch",
     "@types/mocha@^10.0.1": "patch:@types/mocha@npm:10.0.1#.yarn/patches/@types-mocha-npm-10.0.1-7c94e9e170.patch",
     "clet@^1.0.1": "patch:clet@npm%3A1.0.1#./.yarn/patches/clet-npm-1.0.1-8523231bdc.patch",
+    "inline-source-map@~0.6.0": "patch:inline-source-map@npm%3A0.6.2#./.yarn/patches/inline-source-map-npm-0.6.2-96902459a0.patch",
     "jest-fetch-mock@^3.0.3": "patch:jest-fetch-mock@npm:3.0.3#.yarn/patches/jest-fetch-mock-npm-3.0.3-ac072ca8af.patch",
     "lavamoat-browserify@^15.5.0": "patch:lavamoat-browserify@npm%3A15.5.0#./.yarn/patches/lavamoat-browserify-npm-15.5.0-ce0bbe5e4c.patch",
     "luxon@^3.2.1": "patch:luxon@npm%3A3.3.0#./.yarn/patches/luxon-npm-3.3.0-bdbae9bfd5.patch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12324,12 +12324,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inline-source-map@npm:~0.6.0":
+"inline-source-map@npm:0.6.2":
   version: 0.6.2
   resolution: "inline-source-map@npm:0.6.2"
   dependencies:
     source-map: ~0.5.3
   checksum: 1f7fa2ad1764d03a0a525d5c47993f9e3d0445f29c2e2413d2878deecb6ecb1e6f9137a6207e3db8dc129565bde15de88c1ba2665407e753e7f3ec768ca29262
+  languageName: node
+  linkType: hard
+
+"inline-source-map@patch:inline-source-map@npm%3A0.6.2#./.yarn/patches/inline-source-map-npm-0.6.2-96902459a0.patch::locator=root%40workspace%3A.":
+  version: 0.6.2
+  resolution: "inline-source-map@patch:inline-source-map@npm%3A0.6.2#./.yarn/patches/inline-source-map-npm-0.6.2-96902459a0.patch::version=0.6.2&hash=7b9dc6&locator=root%40workspace%3A."
+  dependencies:
+    source-map: ~0.5.3
+  checksum: b25c0c215ba3b88e6a18c0bf3625ba5b306a5438235f21ad3357e6e0f5b3a09af8afcf9daf3f0a394f836c6ed695b34debc4802323a2604b5fa1798265350df0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Patches `inline-source-map` to remove deprecated use of Buffer. This patch is identical to the one applied in the extension.