### PR TITLE
Add LavaMoat policy generation to CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -54,6 +54,8 @@ jobs:
           cache: yarn
       - run: yarn --immutable --immutable-cache
       - run: yarn build
+      - name: Generate LavaMoat policy
+        run: yarn workspace @metamask/snaps-execution-environments build:lavamoat:policy
       - name: Require clean working directory
         shell: bash
         run: |

--- a/packages/snaps-execution-environments/lavamoat/build-system/policy.json
+++ b/packages/snaps-execution-environments/lavamoat/build-system/policy.json
@@ -1017,7 +1017,7 @@
     },
     "@lavamoat/lavapack>combine-source-map>inline-source-map": {
       "globals": {
-        "Buffer": true
+        "Buffer.from": true
       },
       "packages": {
         "@lavamoat/lavapack>combine-source-map>inline-source-map>source-map": true


### PR DESCRIPTION
## Description

This pull request adds a LavaMoat policy generation step to CI. This will ensure that the policy is up-to-date in CI, since we check that the working directory is clean.

## Changes

1. Add a LavaMoat policy generation step to the build process.
2. Update the global 'Buffer' to 'Buffer.from' in the inline-source-map package.