### PR TITLE
Block `wallet_requestPermissions`

### DIFF
--- a/packages/snaps-execution-environments/src/common/utils.test.ts
+++ b/packages/snaps-execution-environments/src/common/utils.test.ts
@@ -55,6 +55,12 @@ describe('assertSnapOutboundRequest', () => {
     ).toThrow('The method does not exist / is not available.');
   });
 
+  it('disallows wallet_requestPermissions', () => {
+    expect(() =>
+      assertSnapOutboundRequest({ method: 'wallet_requestPermissions' }),
+    ).toThrow('The method does not exist / is not available.');
+  });
+
   it('throws for invalid JSON values', () => {
     expect(() =>
       assertSnapOutboundRequest({
@@ -80,6 +86,12 @@ describe('assertEthereumOutboundRequest', () => {
   it('disallows snaps_ prefixed methods', () => {
     expect(() =>
       assertEthereumOutboundRequest({ method: 'snap_notify' }),
+    ).toThrow('The method does not exist / is not available.');
+  });
+
+  it('disallows wallet_requestPermissions', () => {
+    expect(() =>
+      assertEthereumOutboundRequest({ method: 'wallet_requestPermissions' }),
     ).toThrow('The method does not exist / is not available.');
   });
 

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -101,7 +101,7 @@ export function proxyStreamProvider(
   return proxy as StreamProvider;
 }
 
-// We're blocking these two RPC methods for v1, will revisit later.
+// We're blocking these RPC methods for v1, will revisit later.
 const BLOCKED_RPC_METHODS = Object.freeze([
   'eth_requestAccounts',
   'wallet_requestSnaps',

--- a/packages/snaps-execution-environments/src/common/utils.ts
+++ b/packages/snaps-execution-environments/src/common/utils.ts
@@ -105,6 +105,7 @@ export function proxyStreamProvider(
 const BLOCKED_RPC_METHODS = Object.freeze([
   'eth_requestAccounts',
   'wallet_requestSnaps',
+  'wallet_requestPermissions',
 ]);
 
 /**


### PR DESCRIPTION
Block `wallet_requestPermissions` for now, until we figure out a strategy for snaps having dynamic permissions.

Fixes https://github.com/MetaMask/MetaMask-planning/issues/534