### PR TITLE
Revert "0.33.0-flask.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- Update Ethers.js example ([#1373](https://github.com/MetaMask/snaps-monorepo/pull/1373))
-- Update signer examples ([#1360](https://github.com/MetaMask/snaps-monorepo/pull/1360))
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -261,8 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This package was previously a subset of [`snaps-cli`](https://github.com/MetaMask/snaps-cli/tree/main/examples), which has been renamed to [`@metamask/snaps-cli`](https://npmjs.com/package/@metamask/snaps-cli).
   - Some examples have been deleted because they were outdated.
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/examples/examples/bls-signer/package.json
+++ b/packages/examples/examples/bls-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-signer",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example Snap that signs messages using BLS.",
   "repository": {

--- a/packages/examples/examples/bls-signer/snap.manifest.json
+++ b/packages/examples/examples/bls-signer/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap that signs messages using BLS.",
   "proposedName": "bls-signer",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "dkAqwXXulHSi0C7+lc9bVuXeCvLaxhf8WnfBpj9UIOU=",
+    "shasum": "K34wTvr8Ee5Bj+tjmHEp/flfwGxwjTc4GEhiFoT+3sA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/browserify/package.json
+++ b/packages/examples/examples/browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example Snap built using TypeScript and Browserify",
   "repository": {

--- a/packages/examples/examples/browserify/snap.manifest.json
+++ b/packages/examples/examples/browserify/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap built using TypeScript and Browserify",
   "proposedName": "browserify-snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "+rCYqqkzvLOiN38xxLx953iNhalFW9tqF5Olw7hJ79A=",
+    "shasum": "Mq7JwWPuygAlqyHaYXgu08FGDAyKt9K/37PAzr8FG3c=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/ethers-js/package.json
+++ b/packages/examples/examples/ethers-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethers-js-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example Snap that that uses ethers.js.",
   "repository": {

--- a/packages/examples/examples/ethers-js/snap.manifest.json
+++ b/packages/examples/examples/ethers-js/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap that that uses ethers.js.",
   "proposedName": "ethers-js-snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "MGZ5hsX71kYj7/RvEr7xOlj5l6BvuQSxlfR2Jrgr0Ic=",
+    "shasum": "DG1SrtUfxv3wCel376j+ilwQCTNKlaAM4LGGmmcuPuM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/insights/package.json
+++ b/packages/examples/examples/insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transaction-insights-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example transaction insights Snap.",
   "repository": {

--- a/packages/examples/examples/insights/snap.manifest.json
+++ b/packages/examples/examples/insights/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example transaction insights Snap.",
   "proposedName": "Transaction Insights Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "45Ny95arHQ3RHO4uHHGzslGzsDuJsRSGkEGNN2rBFLY=",
+    "shasum": "CsChckzRkwRaRe+H1wl9K+uLhcVt4k+/pvMYKyYsr5U=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/ipfs/package.json
+++ b/packages/examples/examples/ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipfs-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example Snap that performs IPFS operations.",
   "repository": {

--- a/packages/examples/examples/ipfs/snap.manifest.json
+++ b/packages/examples/examples/ipfs/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap that performs IPFS operations.",
   "proposedName": "ipfs-snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "Alxb2stTicxdMtlJjFYg3n9k1o9Bv8OL5+oi5ar83Wo=",
+    "shasum": "5i2wvhxgf8OelllHiXWMOglqgTuWePbz8phtajXmLtQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/notifications/package.json
+++ b/packages/examples/examples/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notification-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "The 'Hello, world!' of MetaMask Snaps.",
   "repository": {

--- a/packages/examples/examples/notifications/snap.manifest.json
+++ b/packages/examples/examples/notifications/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "A notification example snap.",
   "proposedName": "Notification Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "gUWIZNrG+SXAUaRp8gfc6vyhtpxF6sxTGKXXK/JgDxk=",
+    "shasum": "nanj+sydfOa07ByjcYkH1DfSH79zECqiLjUAkit5mY0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/rollup/package.json
+++ b/packages/examples/examples/rollup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example Snap built using TypeScript and Rollup",
   "repository": {

--- a/packages/examples/examples/rollup/snap.manifest.json
+++ b/packages/examples/examples/rollup/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap built using TypeScript and Rollup",
   "proposedName": "rollup-snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "hjoa+TclrYoPCozS46j4Lk0AZUSnkagO9dXZ7HFobWU=",
+    "shasum": "DtlfjegvSepEns0Vzz0EtXa43k86CAsokTt9R6bDPU8=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/examples/signer/package.json
+++ b/packages/examples/examples/signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signer",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/examples/examples/signer/packages/bitcoin/package.json
+++ b/packages/examples/examples/signer/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signer-bitcoin",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^7.0.0",
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-types": "^0.32.2",
     "@metamask/utils": "^5.0.0",
     "@noble/secp256k1": "^1.7.1",
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@metamask/snaps-cli": "workspace:^",
+    "@metamask/snaps-cli": "^0.32.2",
     "through2": "^4.0.2"
   },
   "packageManager": "yarn@3.4.1"

--- a/packages/examples/examples/signer/packages/bitcoin/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/bitcoin/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An Bitcoin transaction signer, which uses a snap for deriving private keys",
   "proposedName": "signer-bitcoin",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "xlG10k/rSwa+lyTgA9icuwqcKVqYsjhQgxQzYh6z7+Q=",
+    "shasum": "wWNruPmUhyQxst7Rw5+o4DWM2N93FjJbw9Sh+BLHPr8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/core/package.json
+++ b/packages/examples/examples/signer/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signer-core",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -16,8 +16,8 @@
   },
   "devDependencies": {
     "@metamask/key-tree": "^7.0.0",
-    "@metamask/snaps-cli": "workspace:^",
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-cli": "^0.32.2",
+    "@metamask/snaps-types": "^0.32.2"
   },
   "packageManager": "yarn@3.4.1"
 }

--- a/packages/examples/examples/signer/packages/core/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/core/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "A snap using its own entropy for deriving child keys",
   "proposedName": "signer-core",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "iolI6Ji9z9npc5QSlE7NkwHUBW1t9ztOtQM18tKS1OE=",
+    "shasum": "nR1isjIDuP3HXD0doOHShgUMzHOsr8XKqcXlh0UGwMw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/signer/packages/ethereum/package.json
+++ b/packages/examples/examples/signer/packages/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signer-ethereum",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,12 +13,12 @@
   "dependencies": {
     "@ethereumjs/tx": "^3.5.2",
     "@metamask/key-tree": "^7.0.0",
-    "@metamask/snaps-types": "workspace:^",
+    "@metamask/snaps-types": "^0.32.2",
     "@metamask/utils": "^5.0.0",
     "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@metamask/snaps-cli": "workspace:^",
+    "@metamask/snaps-cli": "^0.32.2",
     "through2": "^4.0.2"
   },
   "packageManager": "yarn@3.4.1"

--- a/packages/examples/examples/signer/packages/ethereum/snap.manifest.json
+++ b/packages/examples/examples/signer/packages/ethereum/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An Ethereum transaction signer, which uses a snap for deriving private keys",
   "proposedName": "signer-ethereum",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "GIcO7CMlCVuFpD6aPcTKFIRvxJR+SSRtuJ78kqeJFeo=",
+    "shasum": "yXmqZ8EmaoNHM75wlE66Sp1F7gWKC/o6+CdkX/vW8DY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/typescript/package.json
+++ b/packages/examples/examples/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "The 'Hello, world!' of MetaMask Snaps, now written in TypeScript.",
   "repository": {

--- a/packages/examples/examples/typescript/snap.manifest.json
+++ b/packages/examples/examples/typescript/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap written in TypeScript.",
   "proposedName": "TypeScript Example Snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snap-template.git"
   },
   "source": {
-    "shasum": "VQQzlhxwzw6g5e2dU/oTBEh6EoOOrtrUidPlSBCM/dM=",
+    "shasum": "pQ2ZrngcDGpgOR9jH/3BNQW3pooeNdvBPnCozYWZD+4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/wasm/package.json
+++ b/packages/examples/examples/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example Snap that uses WebAssembly.",
   "repository": {

--- a/packages/examples/examples/wasm/snap.manifest.json
+++ b/packages/examples/examples/wasm/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap that uses WebAssembly.",
   "proposedName": "wasm",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "qxWWeMrGDbqTgotzXg/DMbGMdTTyTufFxiqC9VOFNqA=",
+    "shasum": "GGHB0m+idAKGxuf7q4CJm7BTwq/TS7Q3wa46fURSfPg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/examples/examples/webpack/package.json
+++ b/packages/examples/examples/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-snap",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "An example Snap built using TypeScript and Webpack",
   "repository": {

--- a/packages/examples/examples/webpack/snap.manifest.json
+++ b/packages/examples/examples/webpack/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "An example Snap built using TypeScript and Webpack",
   "proposedName": "webpack-snap",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/snaps-monorepo.git"
   },
   "source": {
-    "shasum": "GbE9ohJqRX5JfEfrKqD1GNcKmYry7WKK/ohHv32GaCc=",
+    "shasum": "/x0lCTmFc3GQp8p8jcCqCkcSMyEM2jp4qyGoUBz+CDc=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "private": true,
   "description": "Example MetaMask Snaps.",
   "repository": {

--- a/packages/multichain-provider/CHANGELOG.md
+++ b/packages/multichain-provider/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- No changes this release.
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -90,8 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#700](https://github.com/MetaMask/snaps-monorepo/pull/700))
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/multichain-provider/package.json
+++ b/packages/multichain-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/multichain-provider",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps-monorepo.git"

--- a/packages/rpc-methods/CHANGELOG.md
+++ b/packages/rpc-methods/CHANGELOG.md
@@ -6,16 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Added
-- Add subject type restrictions to snap-specific permissions ([#1366](https://github.com/MetaMask/snaps-monorepo/pull/1366))
-- Add `createSnapsMethodMiddleware` from extension ([#1330](https://github.com/MetaMask/snaps-monorepo/pull/1330))
-
-### Changed
-- **BREAKING:** Add encrypt and decrypt hook to let implementations use their own functions ([#1331](https://github.com/MetaMask/snaps-monorepo/pull/1331))
-- **BREAKING:** Add `snapIds` caveat mapper ([#1360](https://github.com/MetaMask/snaps-monorepo/pull/1360))
-  - Snap dependencies must be specified in a simplified manner. See the PR for an example.
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -322,8 +312,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First semi-stable release.
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/rpc-methods/package.json
+++ b/packages/rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/rpc-methods",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "MetaMask Snap RPC method implementations.",
   "repository": {
     "type": "git",

--- a/packages/snaps-browserify-plugin/CHANGELOG.md
+++ b/packages/snaps-browserify-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- No changes this release.
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -139,8 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#410](https://github.com/MetaMask/snaps-monorepo/pull/410), [#421](https://github.com/MetaMask/snaps-monorepo/pull/421))
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-browserify-plugin/package.json
+++ b/packages/snaps-browserify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-browserify-plugin",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "keywords": [
     "browserify-plugin"
   ],

--- a/packages/snaps-cli/CHANGELOG.md
+++ b/packages/snaps-cli/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- Support ES2022 features ([#1373](https://github.com/MetaMask/snaps-monorepo/pull/1373))
-- Automatically watch `snap.config.js` and `snap.manifest.json` files ([#1358](https://github.com/MetaMask/snaps-monorepo/pull/1358))
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -326,8 +321,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example snaps ([#72](https://github.com/MetaMask/snaps-monorepo/pull/72))
   - The examples now live in their own package, [`@metamask/snap-examples`](https://npmjs.com/package/@metamask/snap-examples).
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-cli/package.json
+++ b/packages/snaps-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-cli",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "A CLI for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-controllers/CHANGELOG.md
+++ b/packages/snaps-controllers/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- Add subject type restrictions to snap-specific permissions ([#1366](https://github.com/MetaMask/snaps-monorepo/pull/1366))
-- Add console endowment that prepends snap IDs to log output ([#1355](https://github.com/MetaMask/snaps-monorepo/pull/1355))
-- Add `DisconnectOrigin` action ([#1329](https://github.com/MetaMask/snaps-monorepo/pull/1329))
-- Add Web Worker support for snap execution ([#1320](https://github.com/MetaMask/snaps-monorepo/pull/1320))
-
 ## [0.32.2]
 ### Fixed
 - Properly handle Promise in `JsonSnapsRegistry` signature verification ([#1317](https://github.com/MetaMask/snaps-monorepo/pull/1317))
@@ -504,8 +497,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First semi-stable release.
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-controllers/package.json
+++ b/packages/snaps-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-controllers",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "Controllers for MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-execution-environments/CHANGELOG.md
+++ b/packages/snaps-execution-environments/CHANGELOG.md
@@ -6,15 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- **BREAKING:** Block `wallet_requestPermissions` ([#1371](https://github.com/MetaMask/snaps-monorepo/pull/1371))
-- Add console endowment that prepends snap IDs to log output ([#1355](https://github.com/MetaMask/snaps-monorepo/pull/1355))
-- Add Web Worker support for snap execution ([#1320](https://github.com/MetaMask/snaps-monorepo/pull/1320))
-
-### Fixed
-- Fix Math endowment in Node.js ([#1347](https://github.com/MetaMask/snaps-monorepo/pull/1347))
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -252,8 +243,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously, default endowments were specified in the execution environment itself. Now, all endowments must be specified in the `executeSnap` RPC parameters, except for the `wallet` API object.
 - Add endowments to the global `self` in addition to `window` ([#263](https://github.com/MetaMask/snaps-monorepo/pull/263))
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-execution-environments/package.json
+++ b/packages/snaps-execution-environments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-execution-environments",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "Snap sandbox environments for executing SES javascript",
   "repository": {
     "type": "git",

--- a/packages/snaps-rollup-plugin/CHANGELOG.md
+++ b/packages/snaps-rollup-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- No changes this release.
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -138,8 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#431](https://github.com/MetaMask/snaps-monorepo/pull/431))
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-rollup-plugin/package.json
+++ b/packages/snaps-rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-rollup-plugin",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "keywords": [
     "rollup",
     "rollup-plugin"

--- a/packages/snaps-types/CHANGELOG.md
+++ b/packages/snaps-types/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- No changes this release.
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -269,8 +265,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-types/package.json
+++ b/packages/snaps-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-types",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "description": "TypeScript types for developing MetaMask Snaps.",
   "repository": {
     "type": "git",

--- a/packages/snaps-ui/CHANGELOG.md
+++ b/packages/snaps-ui/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- No changes this release.
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -62,8 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#978](https://github.com/MetaMask/snaps-monorepo/pull/978), [#1009](https://github.com/MetaMask/snaps-monorepo/pull/1009))
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-ui/package.json
+++ b/packages/snaps-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-ui",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps-monorepo.git"

--- a/packages/snaps-utils/CHANGELOG.md
+++ b/packages/snaps-utils/CHANGELOG.md
@@ -6,16 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- **BREAKING:** Added `snapIds` caveat mapper ([#1360](https://github.com/MetaMask/snaps-monorepo/pull/1360))
-  - Snap dependencies must be specified in a simplified manner. See the PR for an example.
-- Add subject type restrictions to snap-specific permissions ([#1366](https://github.com/MetaMask/snaps-monorepo/pull/1366))
-- Add Web Worker support for snap execution ([#1320](https://github.com/MetaMask/snaps-monorepo/pull/1320))
-
-### Fixed
-- Add `WebAssembly` to eval mock ([#1359](https://github.com/MetaMask/snaps-monorepo/pull/1359))
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -193,8 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#410](https://github.com/MetaMask/snaps-monorepo/pull/410), [#421](https://github.com/MetaMask/snaps-monorepo/pull/421))
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-utils/package.json
+++ b/packages/snaps-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-utils",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/snaps-monorepo.git"

--- a/packages/snaps-webpack-plugin/CHANGELOG.md
+++ b/packages/snaps-webpack-plugin/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.33.0-flask.1]
-### Changed
-- No changes this release.
-
 ## [0.32.2]
 ### Changed
 - No changes this release.
@@ -142,8 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release ([#420](https://github.com/MetaMask/snaps-monorepo/pull/420))
 
-[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.33.0-flask.1...HEAD
-[0.33.0-flask.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...v0.33.0-flask.1
+[Unreleased]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.2...HEAD
 [0.32.2]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/MetaMask/snaps-monorepo/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/MetaMask/snaps-monorepo/compare/v0.31.0...v0.32.0

--- a/packages/snaps-webpack-plugin/package.json
+++ b/packages/snaps-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-webpack-plugin",
-  "version": "0.33.0-flask.1",
+  "version": "0.32.2",
   "keywords": [
     "webpack",
     "plugin"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,7 +2689,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-cli@workspace:^, @metamask/snaps-cli@workspace:packages/snaps-cli":
+"@metamask/snaps-cli@^0.32.2, @metamask/snaps-cli@workspace:^, @metamask/snaps-cli@workspace:packages/snaps-cli":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-cli@workspace:packages/snaps-cli"
   dependencies:
@@ -2967,7 +2967,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/snaps-types@workspace:^, @metamask/snaps-types@workspace:packages/snaps-types":
+"@metamask/snaps-types@^0.32.2, @metamask/snaps-types@workspace:^, @metamask/snaps-types@workspace:packages/snaps-types":
   version: 0.0.0-use.local
   resolution: "@metamask/snaps-types@workspace:packages/snaps-types"
   dependencies:
@@ -17111,8 +17111,8 @@ __metadata:
   resolution: "signer-bitcoin@workspace:packages/examples/examples/signer/packages/bitcoin"
   dependencies:
     "@metamask/key-tree": ^7.0.0
-    "@metamask/snaps-cli": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-cli": ^0.32.2
+    "@metamask/snaps-types": ^0.32.2
     "@metamask/utils": ^5.0.0
     "@noble/secp256k1": ^1.7.1
     buffer: ^6.0.3
@@ -17125,8 +17125,8 @@ __metadata:
   resolution: "signer-core@workspace:packages/examples/examples/signer/packages/core"
   dependencies:
     "@metamask/key-tree": ^7.0.0
-    "@metamask/snaps-cli": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-cli": ^0.32.2
+    "@metamask/snaps-types": ^0.32.2
     "@metamask/utils": ^5.0.0
     async-mutex: ^0.4.0
   languageName: unknown
@@ -17138,8 +17138,8 @@ __metadata:
   dependencies:
     "@ethereumjs/tx": ^3.5.2
     "@metamask/key-tree": ^7.0.0
-    "@metamask/snaps-cli": "workspace:^"
-    "@metamask/snaps-types": "workspace:^"
+    "@metamask/snaps-cli": ^0.32.2
+    "@metamask/snaps-types": ^0.32.2
     "@metamask/utils": ^5.0.0
     buffer: ^6.0.3
     through2: ^4.0.2


### PR DESCRIPTION
Reverts MetaMask/snaps-monorepo#1376

Reverts the release as it failed due to a parsing error in the auto-changelog. We need to use the latest action-publish-release and therefore need to revert to apply that.