### PR TITLE
Clean up snap ID typing

### DIFF
--- a/packages/snaps-controllers/src/cronjob/CronjobController.ts
+++ b/packages/snaps-controllers/src/cronjob/CronjobController.ts
@@ -6,6 +6,7 @@ import { GetPermissions } from '@metamask/permission-controller';
 import {
   HandlerType,
   SnapId,
+  ValidatedSnapId,
   TruncatedSnap,
   CronjobSpecification,
   parseCronExpression,
@@ -53,7 +54,7 @@ export type CronjobControllerArgs = {
 export type Cronjob = {
   timer?: Timer;
   id: string;
-  snapId: SnapId;
+  snapId: ValidatedSnapId;
 } & CronjobSpecification;
 
 export type StoredJobInformation = {
@@ -147,7 +148,7 @@ export class CronjobController extends BaseController<
    * @param snapId - ID of a Snap.
    * @returns Array of Cronjob specifications.
    */
-  private getSnapJobs(snapId: SnapId): Cronjob[] | undefined {
+  private getSnapJobs(snapId: ValidatedSnapId): Cronjob[] | undefined {
     const permissions = this.#messenger.call(
       'PermissionController:getPermissions',
       snapId,
@@ -167,7 +168,7 @@ export class CronjobController extends BaseController<
    *
    * @param snapId - ID of a snap.
    */
-  register(snapId: SnapId) {
+  register(snapId: ValidatedSnapId) {
     const jobs = this.getSnapJobs(snapId);
     jobs?.forEach((job) => this.schedule(job));
   }

--- a/packages/snaps-controllers/src/multichain/MultiChainController.test.ts
+++ b/packages/snaps-controllers/src/multichain/MultiChainController.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jest/prefer-strict-equal */
 
 import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/rpc-methods';
-import { getSnapChecksum } from '@metamask/snaps-utils';
+import { ValidatedSnapId, getSnapChecksum } from '@metamask/snaps-utils';
 import {
   MOCK_ORIGIN,
   MOCK_SNAP_ID,
@@ -179,7 +179,7 @@ describe('MultiChainController', () => {
               PERSISTED_MOCK_KEYRING_SNAP,
               getPersistedSnapObject({
                 ...PERSISTED_MOCK_KEYRING_SNAP,
-                id: secondSnapId,
+                id: secondSnapId as ValidatedSnapId,
                 sourceCode: secondSnapSourceCode,
                 manifest: getSnapManifest({
                   shasum: getSnapChecksum(
@@ -197,7 +197,7 @@ describe('MultiChainController', () => {
       const snap = snapController.getExpect(MOCK_SNAP_ID);
       await snapController.startSnap(snap.id);
 
-      const snap2 = snapController.getExpect(secondSnapId);
+      const snap2 = snapController.getExpect(secondSnapId as ValidatedSnapId);
       await snapController.startSnap(snap2.id);
 
       rootMessenger.registerActionHandler(

--- a/packages/snaps-controllers/src/multichain/MultiChainController.ts
+++ b/packages/snaps-controllers/src/multichain/MultiChainController.ts
@@ -29,6 +29,7 @@ import {
   isAccountIdArray,
   Namespaces,
   logError,
+  ValidatedSnapId,
 } from '@metamask/snaps-utils';
 import { hasProperty, assert } from '@metamask/utils';
 import { nanoid } from 'nanoid';
@@ -149,7 +150,7 @@ export class MultiChainController extends BaseController<
       Object.values(session.handlingSnaps).map((snapId) =>
         this.messagingSystem.call(
           'SnapController:decrementActiveReferences',
-          snapId,
+          snapId as ValidatedSnapId,
         ),
       ),
     );
@@ -300,7 +301,7 @@ export class MultiChainController extends BaseController<
       Object.values(session.handlingSnaps).map((snapId) =>
         this.messagingSystem.call(
           'SnapController:incrementActiveReferences',
-          snapId,
+          snapId as ValidatedSnapId,
         ),
       ),
     );
@@ -366,7 +367,7 @@ export class MultiChainController extends BaseController<
     );
 
     return this.snapRequest({
-      snapId,
+      snapId: snapId as ValidatedSnapId,
       origin,
       method: 'handleRequest',
       args: data,
@@ -390,7 +391,7 @@ export class MultiChainController extends BaseController<
     method,
     args,
   }: {
-    snapId: SnapId;
+    snapId: ValidatedSnapId;
     origin: string;
     method: keyof SnapKeyring;
     args?: unknown;
@@ -416,7 +417,7 @@ export class MultiChainController extends BaseController<
    */
   private async getSnapAccounts(
     origin: string,
-    snapId: SnapId,
+    snapId: ValidatedSnapId,
   ): Promise<AccountId[] | null> {
     try {
       const result = await this.snapRequest({
@@ -473,7 +474,7 @@ export class MultiChainController extends BaseController<
   ): Promise<Record<NamespaceId, { snapId: SnapId; accounts: AccountId[] }[]>> {
     const dedupedSnaps = [
       ...new Set(Object.values(namespacesAndSnaps).flat()),
-    ] as SnapId[];
+    ] as ValidatedSnapId[];
 
     const allAccounts = await dedupedSnaps.reduce<
       Promise<Record<string, AccountId[]>>

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -14,6 +14,7 @@ import {
   SnapStatus,
   VirtualFile,
   DEFAULT_REQUESTED_SNAP_VERSION,
+  ValidatedSnapId,
 } from '@metamask/snaps-utils';
 import {
   DEFAULT_SNAP_BUNDLE,
@@ -285,6 +286,7 @@ describe('SnapController', () => {
   });
 
   it('can rehydrate state', async () => {
+    const id = 'npm:foo' as ValidatedSnapId;
     const firstSnapController = getSnapController(
       getSnapControllerOptions({
         state: {
@@ -292,7 +294,7 @@ describe('SnapController', () => {
             getPersistedSnapObject({
               version: '0.0.1',
               sourceCode: DEFAULT_SNAP_BUNDLE,
-              id: 'npm:foo',
+              id,
               status: SnapStatus.Installing,
             }),
           ),
@@ -313,11 +315,11 @@ describe('SnapController', () => {
       }),
     );
 
-    expect(secondSnapController.isRunning('npm:foo')).toBe(false);
-    await secondSnapController.startSnap('npm:foo');
+    expect(secondSnapController.isRunning(id)).toBe(false);
+    await secondSnapController.startSnap(id);
 
-    expect(secondSnapController.state.snaps['npm:foo']).toBeDefined();
-    expect(secondSnapController.isRunning('npm:foo')).toBe(true);
+    expect(secondSnapController.state.snaps[id]).toBeDefined();
+    expect(secondSnapController.isRunning(id)).toBe(true);
     firstSnapController.destroy();
     secondSnapController.destroy();
   });
@@ -3116,8 +3118,8 @@ describe('SnapController', () => {
     });
 
     it('rolls back any updates and installs made during a failure scenario', async () => {
-      const snapId1 = 'npm:@metamask/example-snap1';
-      const snapId2 = 'npm:@metamask/example-snap2';
+      const snapId1 = 'npm:@metamask/example-snap1' as ValidatedSnapId;
+      const snapId2 = 'npm:@metamask/example-snap2' as ValidatedSnapId;
       const snapId3 = 'npm:@metamask/example-snap3';
       const oldVersion = '1.0.0';
       const newVersion = '1.0.1';
@@ -3193,8 +3195,8 @@ describe('SnapController', () => {
     });
 
     it('will not create snapshots for already installed snaps that have invalid requested ranges', async () => {
-      const snapId1 = 'npm:@metamask/example-snap1';
-      const snapId2 = 'npm:@metamask/example-snap2';
+      const snapId1 = 'npm:@metamask/example-snap1' as ValidatedSnapId;
+      const snapId2 = 'npm:@metamask/example-snap2' as ValidatedSnapId;
       const snapId3 = 'npm:@metamask/example-snap3';
       const oldVersion = '1.0.0';
       const newVersion = '1.0.1';
@@ -4384,7 +4386,9 @@ describe('SnapController', () => {
           state: {
             snaps: getPersistedSnapsState(
               getPersistedSnapObject(),
-              getPersistedSnapObject({ id: `${MOCK_SNAP_ID}2` }),
+              getPersistedSnapObject({
+                id: `${MOCK_SNAP_ID}2` as ValidatedSnapId,
+              }),
             ),
           },
         }),
@@ -4535,12 +4539,12 @@ describe('SnapController', () => {
       const publishMock = jest.spyOn(messenger, 'publish');
 
       const mockSnapA = getMockSnapData({
-        id: 'npm:exampleA',
+        id: 'npm:exampleA' as ValidatedSnapId,
         origin: 'foo.com',
       });
 
       const mockSnapB = getMockSnapData({
-        id: 'npm:exampleB',
+        id: 'npm:exampleB' as ValidatedSnapId,
         origin: 'bar.io',
       });
 
@@ -4605,7 +4609,7 @@ describe('SnapController', () => {
       const messenger = getSnapControllerMessenger(rootMessenger);
 
       const mockSnap = getMockSnapData({
-        id: 'npm:example',
+        id: 'npm:example' as ValidatedSnapId,
         origin: 'foo.com',
       });
 
@@ -4641,14 +4645,14 @@ describe('SnapController', () => {
       const publishMock = jest.spyOn(messenger, 'publish');
 
       const mockSnapA = getMockSnapData({
-        id: 'npm:exampleA',
+        id: 'npm:exampleA' as ValidatedSnapId,
         origin: 'foo.com',
         blocked: true,
         enabled: false,
       });
 
       const mockSnapB = getMockSnapData({
-        id: 'npm:exampleB',
+        id: 'npm:exampleB' as ValidatedSnapId,
         origin: 'bar.io',
       });
 
@@ -4703,7 +4707,7 @@ describe('SnapController', () => {
       const messenger = getSnapControllerMessenger(rootMessenger);
 
       const mockSnap = getMockSnapData({
-        id: 'npm:example',
+        id: 'npm:example' as ValidatedSnapId,
         origin: 'foo.com',
       });
 
@@ -4747,7 +4751,7 @@ describe('SnapController', () => {
       const messenger = getSnapControllerMessenger(rootMessenger);
 
       const mockSnap = getMockSnapData({
-        id: 'npm:example',
+        id: 'npm:example' as ValidatedSnapId,
         origin: 'foo.com',
       });
 
@@ -4947,7 +4951,7 @@ describe('SnapController', () => {
   describe('SnapController:has', () => {
     it('checks if a snap exists in state', () => {
       const messenger = getSnapControllerMessenger();
-
+      const id = 'npm:fooSnap' as ValidatedSnapId;
       const snapController = getSnapController(
         getSnapControllerOptions({
           messenger,
@@ -4956,7 +4960,7 @@ describe('SnapController', () => {
               getPersistedSnapObject({
                 version: '0.0.1',
                 sourceCode: DEFAULT_SNAP_BUNDLE,
-                id: 'npm:fooSnap',
+                id,
                 manifest: getSnapManifest(),
                 enabled: true,
                 status: SnapStatus.Installing,
@@ -4967,7 +4971,7 @@ describe('SnapController', () => {
       );
 
       const hasSpy = jest.spyOn(snapController, 'has');
-      const result = messenger.call('SnapController:has', 'npm:fooSnap');
+      const result = messenger.call('SnapController:has', id);
 
       expect(hasSpy).toHaveBeenCalledTimes(1);
       expect(result).toBe(true);
@@ -5060,7 +5064,7 @@ describe('SnapController', () => {
     it('calls SnapController.enableSnap()', () => {
       const messenger = getSnapControllerMessenger();
       const mockSnap = getMockSnapData({
-        id: 'npm:example',
+        id: 'npm:example' as ValidatedSnapId,
         origin: 'foo.com',
         enabled: false,
       });
@@ -5085,7 +5089,7 @@ describe('SnapController', () => {
     it('calls SnapController.disableSnap()', async () => {
       const messenger = getSnapControllerMessenger();
       const mockSnap = getMockSnapData({
-        id: 'npm:example',
+        id: 'npm:example' as ValidatedSnapId,
         origin: 'foo.com',
         enabled: true,
       });
@@ -5110,7 +5114,7 @@ describe('SnapController', () => {
     it('calls SnapController.removeSnap()', async () => {
       const messenger = getSnapControllerMessenger();
       const mockSnap = getMockSnapData({
-        id: 'npm:example',
+        id: 'npm:example' as ValidatedSnapId,
         origin: 'foo.com',
         enabled: true,
       });
@@ -5269,7 +5273,7 @@ describe('SnapController', () => {
         `${MOCK_SNAP_ID}3`,
       ];
       const snapObjects = permittedSnaps.map((snapId) =>
-        getPersistedSnapObject({ id: snapId }),
+        getPersistedSnapObject({ id: snapId as ValidatedSnapId }),
       );
       const snaps = getPersistedSnapsState(...snapObjects);
       const snapController = getSnapController(

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -720,12 +720,11 @@ export class SnapController extends BaseController<
         ...{
           ...state,
           snaps: Object.values(state?.snaps ?? {}).reduce(
-            (
-              memo: Record<ValidatedSnapId, Snap>,
-              snap: Snap & { sourceCode: string },
-            ) => {
+            (memo: Record<ValidatedSnapId, Snap>, snap: PersistedSnap) => {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              // this is to catch any old state that may still have sourceCode in the snap state
+              // sourceCode is stripped out to prevent piping to MetaMask UI,
+              // it is stored in the runtime while we're running a snap and then
+              // persisted to state when needed.
               const { sourceCode, ...rest } = snap;
               memo[snap.id] = rest;
               return memo;

--- a/packages/snaps-controllers/src/snaps/registry/registry.ts
+++ b/packages/snaps-controllers/src/snaps/registry/registry.ts
@@ -1,11 +1,11 @@
 import { BlockReason, SnapsRegistryDatabase } from '@metamask/snaps-registry';
-import { SnapId } from '@metamask/snaps-utils';
+import { SnapId, ValidatedSnapId } from '@metamask/snaps-utils';
 import { SemVerVersion } from '@metamask/utils';
 
 export type SnapsRegistryInfo = { version: SemVerVersion; checksum: string };
 export type SnapsRegistryRequest = Record<SnapId, SnapsRegistryInfo>;
 export type SnapsRegistryMetadata =
-  SnapsRegistryDatabase['verifiedSnaps'][SnapId]['metadata'];
+  SnapsRegistryDatabase['verifiedSnaps'][ValidatedSnapId]['metadata'];
 
 // TODO: Decide on names for these
 export enum SnapsRegistryStatus {
@@ -22,7 +22,7 @@ export type SnapsRegistryResult = {
 export type SnapsRegistry = {
   get(
     snaps: SnapsRegistryRequest,
-  ): Promise<Record<SnapId, SnapsRegistryResult>>;
+  ): Promise<Record<ValidatedSnapId, SnapsRegistryResult>>;
 
   /**
    * Get metadata for the given snap ID.

--- a/packages/snaps-controllers/src/test-utils/controller.ts
+++ b/packages/snaps-controllers/src/test-utils/controller.ts
@@ -8,7 +8,7 @@ import {
   SubjectType,
 } from '@metamask/permission-controller';
 import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/rpc-methods';
-import { SnapCaveatType } from '@metamask/snaps-utils';
+import { SnapCaveatType, ValidatedSnapId } from '@metamask/snaps-utils';
 import {
   MockControllerMessenger,
   getPersistedSnapObject,
@@ -412,7 +412,7 @@ export const getSnapControllerWithEES = (
 };
 
 export const getPersistedSnapsState = (
-  ...snaps: PersistedSnapControllerState['snaps'][string][]
+  ...snaps: PersistedSnapControllerState['snaps'][ValidatedSnapId][]
 ): PersistedSnapControllerState['snaps'] => {
   return (snaps.length > 0 ? snaps : [getPersistedSnapObject()]).reduce<
     PersistedSnapControllerState['snaps']

--- a/packages/snaps-utils/src/snaps.ts
+++ b/packages/snaps-utils/src/snaps.ts
@@ -78,7 +78,7 @@ export enum SnapStatusEvents {
   Update = 'UPDATE',
 }
 
-export type StatusContext = { snapId: string };
+export type StatusContext = { snapId: ValidatedSnapId };
 export type StatusEvents = { type: SnapStatusEvents };
 export type StatusStates = {
   value: SnapStatus;
@@ -112,7 +112,7 @@ export type Snap = {
   /**
    * The ID of the Snap.
    */
-  id: SnapId;
+  id: ValidatedSnapId;
 
   /**
    * The initial permissions of the Snap, which will be requested when it is

--- a/packages/snaps-utils/src/test-utils/snap.ts
+++ b/packages/snaps-utils/src/test-utils/snap.ts
@@ -112,7 +112,7 @@ export const getMockSnapData = ({
   origin,
   sourceCode,
 }: {
-  id: string;
+  id: ValidatedSnapId;
   origin: string;
   sourceCode?: string;
   blocked?: boolean;


### PR DESCRIPTION
Closes #1245 

The `SnapId` and `ValidatedSnapId` types were used interchangeably in the snaps controllers, this PR replaces usage of `SnapId` at the points of execution where the `SnapId` has already been validated or is known to be valid. 