### PR TITLE
Skip subjects without the `wallet_snap` permission in `removeSnapFromSubject`

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,5 +1,5 @@
 {
-  "branches": 89.73,
+  "branches": 89.75,
   "functions": 94.7,
   "lines": 96.67,
   "statements": 96.58

--- a/packages/snaps-controllers/src/snaps/SnapController.test.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.test.ts
@@ -4428,6 +4428,64 @@ describe('SnapController', () => {
 
       snapController.destroy();
     });
+
+    it("will skip subjects that don't have the snap permission", async () => {
+      const messenger = getSnapControllerMessenger();
+      const snapController = getSnapController(
+        getSnapControllerOptions({
+          messenger,
+          state: {
+            snaps: getPersistedSnapsState(),
+          },
+        }),
+      );
+
+      const permissions = {
+        [WALLET_SNAP_PERMISSION_KEY]: {
+          ...MOCK_WALLET_SNAP_PERMISSION,
+          caveats: [
+            {
+              type: SnapCaveatType.SnapIds,
+              value: {
+                [MOCK_SNAP_ID]: {},
+              },
+            },
+          ],
+        },
+      };
+
+      const callActionSpy = jest.spyOn(messenger, 'call');
+      callActionSpy.mockImplementation((method, ...args): any => {
+        if (method === 'PermissionController:getSubjectNames') {
+          return [MOCK_ORIGIN, MOCK_SNAP_ID];
+        } else if (method === 'PermissionController:getPermissions') {
+          if (args[0] === MOCK_ORIGIN) {
+            return permissions;
+          }
+
+          return {};
+        }
+        return undefined;
+      });
+
+      await snapController.removeSnap(MOCK_SNAP_ID);
+      expect(callActionSpy).toHaveBeenCalledTimes(5);
+      expect(callActionSpy).toHaveBeenNthCalledWith(
+        4,
+        'PermissionController:revokePermissions',
+        {
+          [MOCK_ORIGIN]: [WALLET_SNAP_PERMISSION_KEY],
+        },
+      );
+      expect(callActionSpy).not.toHaveBeenCalledWith(
+        'PermissionController:revokePermissions',
+        {
+          [MOCK_SNAP_ID]: [WALLET_SNAP_PERMISSION_KEY],
+        },
+      );
+
+      snapController.destroy();
+    });
   });
 
   describe('enableSnap', () => {
@@ -5110,8 +5168,8 @@ describe('SnapController', () => {
     it('calls SnapController.removeSnap()', async () => {
       const messenger = getSnapControllerMessenger();
       const mockSnap = getMockSnapData({
-        id: 'npm:example',
-        origin: 'foo.com',
+        id: MOCK_SNAP_ID,
+        origin: MOCK_ORIGIN,
         enabled: true,
       });
 

--- a/packages/snaps-controllers/src/snaps/SnapController.ts
+++ b/packages/snaps-controllers/src/snaps/SnapController.ts
@@ -1464,13 +1464,16 @@ export class SnapController extends BaseController<
       'PermissionController:getPermissions',
       origin,
     ) as SubjectPermissions<PermissionConstraint>;
+
     const snapIdsCaveat = subjectPermissions?.[
       WALLET_SNAP_PERMISSION_KEY
     ]?.caveats?.find((caveat) => caveat.type === SnapCaveatType.SnapIds) as
       | Caveat<string, Json>
       | undefined;
 
-    assert(snapIdsCaveat !== undefined);
+    if (!snapIdsCaveat) {
+      return;
+    }
 
     const caveatHasSnap = Boolean(
       (snapIdsCaveat.value as Record<string, Json>)?.[snapId],


### PR DESCRIPTION
This removes the assertion that all the subjects passed to `removeSnapFromSubject` have the `wallet_snap` permission since the snap itself is a subject, some of the subject passed to this function are not containing the `wallet_snap` permission. It also adds a test.