### PR TITLE
Allow use of $schema in manifest files

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ If a package is neither referenced nor ignored, linting will fail.
 
 Run `yarn test` and `yarn lint` in the project root directory, or in a workspace.
 
+You need to have both Chrome and Firefox installed globally on your computer to run browser tests.
+
 ### Publishing
 
 1. Run [Create Release Pull Request workflow](https://github.com/MetaMask/snaps-monorepo/actions/workflows/create-release-pr.yml)

--- a/packages/snaps-utils/src/manifest/manifest.ts
+++ b/packages/snaps-utils/src/manifest/manifest.ts
@@ -21,13 +21,14 @@ import { readVirtualFile, VirtualFile } from '../virtual-file';
 import { SnapManifest } from './validation';
 
 const MANIFEST_SORT_ORDER: Record<keyof SnapManifest, number> = {
-  version: 1,
-  description: 2,
-  proposedName: 3,
-  repository: 4,
-  source: 5,
-  initialPermissions: 6,
-  manifestVersion: 7,
+  $schema: 1,
+  version: 2,
+  description: 3,
+  proposedName: 4,
+  repository: 5,
+  source: 6,
+  initialPermissions: 7,
+  manifestVersion: 8,
 };
 
 /**

--- a/packages/snaps-utils/src/manifest/validation.test.ts
+++ b/packages/snaps-utils/src/manifest/validation.test.ts
@@ -145,6 +145,15 @@ describe('isSnapManifest', () => {
     expect(isSnapManifest(getSnapManifest())).toBe(true);
   });
 
+  it('accepts $schema property', () => {
+    const manifest = {
+      ...getSnapManifest(),
+      $schema:
+        'https://raw.githubusercontent.com/MetaMask/SIPs/main/assets/sip-9/snap.manifest.schema.json',
+    };
+    expect(isSnapManifest(manifest)).toBe(true);
+  });
+
   it.each([
     true,
     false,

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -192,6 +192,7 @@ export const SnapManifestStruct = object({
   }),
   initialPermissions: PermissionsStruct,
   manifestVersion: literal('0.1'),
+  $schema: optional(string()), // enables JSON-Schema linting in VSC and other IDEs
 });
 
 export type SnapManifest = Infer<typeof SnapManifestStruct>;


### PR DESCRIPTION
$schema property is used to locate the JSON Schema that IDEs (specifically VSC) use to lint the JSON file.