### PR TITLE
Fix manifest validation

### DIFF
--- a/packages/snaps-utils/coverage.json
+++ b/packages/snaps-utils/coverage.json
@@ -1,6 +1,6 @@
 {
   "branches": 93.06,
   "functions": 100,
-  "lines": 98.95,
+  "lines": 98.96,
   "statements": 98.97
 }

--- a/packages/snaps-utils/src/manifest/validation.test.ts
+++ b/packages/snaps-utils/src/manifest/validation.test.ts
@@ -185,7 +185,7 @@ describe('assertIsSnapManifest', () => {
     getSnapManifest({ version: 'foo bar' }),
   ])('throws for an invalid snap manifest', (value) => {
     expect(() => assertIsSnapManifest(value)).toThrow(
-      '"snap.manifest.json" is invalid:',
+      /At path: .+|Expected .+/u,
     );
   });
 });

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -216,7 +216,7 @@ export function assertIsSnapManifest(
   value: unknown,
 ): asserts value is SnapManifest {
   assertStruct(
-    value,
+    createSnapManifest(value),
     SnapManifestStruct,
     `"${NpmSnapFileNames.Manifest}" is invalid`,
   );

--- a/packages/snaps-utils/src/manifest/validation.ts
+++ b/packages/snaps-utils/src/manifest/validation.ts
@@ -203,7 +203,12 @@ export type SnapManifest = Infer<typeof SnapManifestStruct>;
  * @returns Whether the value is a valid {@link SnapManifest} object.
  */
 export function isSnapManifest(value: unknown): value is SnapManifest {
-  return is(value, SnapManifestStruct);
+  try {
+    const snapManifest = createSnapManifest(value);
+    return is(snapManifest, SnapManifestStruct);
+  } catch (error) {
+    return false;
+  }
 }
 
 /**

--- a/packages/snaps-utils/src/test-utils/manifest.ts
+++ b/packages/snaps-utils/src/test-utils/manifest.ts
@@ -1,4 +1,5 @@
 import { SemVerVersion } from '@metamask/utils';
+import { CronExpression } from 'src/cronjob';
 
 import { SnapManifest } from '../manifest/validation';
 import {
@@ -34,6 +35,22 @@ export const MOCK_SNAP_VERSION = '1.0.0' as SemVerVersion;
 export const MOCK_INITIAL_PERMISSIONS = {
   snap_confirm: {},
   'endowment:rpc': { snaps: true, dapps: false },
+  'endowment:cronjob': {
+    jobs: [
+      {
+        expression: {
+          minute: '*',
+          hour: '*',
+          dayOfMonth: '*',
+          month: '*',
+          dayOfWeek: '*',
+        } as unknown as CronExpression,
+        request: {
+          method: 'fireCronjob',
+        },
+      },
+    ],
+  },
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/packages/snaps-utils/src/test-utils/manifest.ts
+++ b/packages/snaps-utils/src/test-utils/manifest.ts
@@ -1,6 +1,6 @@
 import { SemVerVersion } from '@metamask/utils';
-import { CronExpression } from 'src/cronjob';
 
+import { type CronExpression } from '../cronjob';
 import { SnapManifest } from '../manifest/validation';
 import {
   Chain,


### PR DESCRIPTION
Manifest was being asserted as-is, which doesn't pass it through `superstruct`'s coercion.

Fixes #1390