### PR TITLE
Export permissions specification builders

### DIFF
--- a/packages/snaps-controllers/coverage.json
+++ b/packages/snaps-controllers/coverage.json
@@ -1,6 +1,6 @@
 {
-  "branches": 89.75,
-  "functions": 94.72,
-  "lines": 96.69,
-  "statements": 96.6
+  "branches": 89.8,
+  "functions": 94.78,
+  "lines": 96.71,
+  "statements": 96.62
 }

--- a/packages/snaps-controllers/src/snaps/endowments/keyring.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/keyring.ts
@@ -43,13 +43,14 @@ type KeyringSpecificationBuilderOptions = {
 /**
  * The specification builder for the keyring endowment permission.
  *
+ * @param _builderOptions - Optional specification builder options.
  * @returns The specification for the keyring endowment permission.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.Endowment,
   KeyringSpecificationBuilderOptions,
   KeyringSpecification
-> = (): KeyringSpecification => {
+> = (_builderOptions?: any): KeyringSpecification => {
   return {
     permissionType: PermissionType.Endowment,
     targetKey,

--- a/packages/snaps-controllers/src/snaps/endowments/rpc.ts
+++ b/packages/snaps-controllers/src/snaps/endowments/rpc.ts
@@ -43,13 +43,14 @@ type RpcSpecificationBuilderOptions = {
 /**
  * The specification builder for the JSON-RPC endowment permission.
  *
+ * @param _builderOptions - Optional specification builder options.
  * @returns The specification for the JSON-RPC endowment permission.
  */
 const specificationBuilder: PermissionSpecificationBuilder<
   PermissionType.Endowment,
   RpcSpecificationBuilderOptions,
   RpcSpecification
-> = (): RpcSpecification => {
+> = (_builderOptions?: any): RpcSpecification => {
   return {
     permissionType: PermissionType.Endowment,
     targetKey,

--- a/packages/snaps-controllers/src/snaps/permission.test.ts
+++ b/packages/snaps-controllers/src/snaps/permission.test.ts
@@ -1,0 +1,191 @@
+import {
+  buildSnapEndowmentSpecifications,
+  buildSnapRestrictedMethodSpecifications,
+} from './permissions';
+
+describe('buildSnapEndowmentSpecifications', () => {
+  it('returns the expected object', () => {
+    const specifications = buildSnapEndowmentSpecifications([]);
+    expect(specifications).toMatchInlineSnapshot(`
+      {
+        "endowment:cronjob": {
+          "allowedCaveats": [
+            "snapCronjob",
+          ],
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:cronjob",
+        },
+        "endowment:ethereum-provider": {
+          "allowedCaveats": null,
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:ethereum-provider",
+        },
+        "endowment:keyring": {
+          "allowedCaveats": [
+            "snapKeyring",
+          ],
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:keyring",
+          "validator": [Function],
+        },
+        "endowment:long-running": {
+          "allowedCaveats": null,
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:long-running",
+        },
+        "endowment:network-access": {
+          "allowedCaveats": null,
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:network-access",
+        },
+        "endowment:rpc": {
+          "allowedCaveats": [
+            "rpcOrigin",
+          ],
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:rpc",
+          "validator": [Function],
+        },
+        "endowment:transaction-insight": {
+          "allowedCaveats": [
+            "transactionOrigin",
+          ],
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:transaction-insight",
+          "validator": [Function],
+        },
+        "endowment:webassembly": {
+          "allowedCaveats": null,
+          "endowmentGetter": [Function],
+          "permissionType": "Endowment",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "endowment:webassembly",
+        },
+      }
+    `);
+  });
+});
+
+describe('buildSnapRestrictedMethodSpecifications', () => {
+  it('returns the expected object', () => {
+    const specifications = buildSnapRestrictedMethodSpecifications([], {});
+    expect(specifications).toMatchInlineSnapshot(`
+      {
+        "snap_dialog": {
+          "allowedCaveats": null,
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "snap_dialog",
+        },
+        "snap_getBip32Entropy": {
+          "allowedCaveats": [
+            "permittedDerivationPaths",
+          ],
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "snap_getBip32Entropy",
+          "validator": [Function],
+        },
+        "snap_getBip32PublicKey": {
+          "allowedCaveats": [
+            "permittedDerivationPaths",
+          ],
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "snap_getBip32PublicKey",
+          "validator": [Function],
+        },
+        "snap_getBip44Entropy": {
+          "allowedCaveats": [
+            "permittedCoinTypes",
+          ],
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "snap_getBip44Entropy",
+          "validator": [Function],
+        },
+        "snap_getEntropy": {
+          "allowedCaveats": null,
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "snap_getEntropy",
+        },
+        "snap_manageState": {
+          "allowedCaveats": null,
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "snap_manageState",
+        },
+        "snap_notify": {
+          "allowedCaveats": null,
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "subjectTypes": [
+            "snap",
+          ],
+          "targetKey": "snap_notify",
+        },
+        "wallet_snap": {
+          "allowedCaveats": [
+            "snapIds",
+          ],
+          "methodImplementation": [Function],
+          "permissionType": "RestrictedMethod",
+          "sideEffect": {
+            "onPermitted": [Function],
+          },
+          "targetKey": "wallet_snap",
+          "validator": [Function],
+        },
+      }
+    `);
+  });
+});

--- a/packages/snaps-simulator/src/features/simulation/sagas.ts
+++ b/packages/snaps-simulator/src/features/simulation/sagas.ts
@@ -14,6 +14,8 @@ import {
   setupMultiplex,
   endowmentCaveatSpecifications as snapsEndowmentCaveatSpecifications,
   processSnapPermissions,
+  buildSnapEndowmentSpecifications,
+  buildSnapRestrictedMethodSpecifications,
 } from '@metamask/snaps-controllers';
 import {
   logError,
@@ -53,8 +55,7 @@ import {
   getSubjectMetadataController,
 } from './slice';
 import {
-  buildSnapEndowmentSpecifications,
-  buildSnapRestrictedMethodSpecifications,
+  ExcludedSnapEndowments,
   getEndowments,
   unrestrictedMethods,
 } from './snap-permissions';
@@ -73,8 +74,8 @@ export function* initSaga({ payload }: PayloadAction<string>) {
   const srp: string = yield select(getSrp);
 
   const permissionSpecifications = {
-    ...buildSnapEndowmentSpecifications(),
-    ...buildSnapRestrictedMethodSpecifications({
+    ...buildSnapEndowmentSpecifications(Object.keys(ExcludedSnapEndowments)),
+    ...buildSnapRestrictedMethodSpecifications([], {
       // TODO: Add all the hooks required
       getUnlockPromise: async () => Promise.resolve(true),
       getMnemonic: async () => mnemonicPhraseToBytes(srp),

--- a/packages/snaps-simulator/src/features/simulation/snap-permissions.ts
+++ b/packages/snaps-simulator/src/features/simulation/snap-permissions.ts
@@ -1,39 +1,8 @@
 import { GenericPermissionController } from '@metamask/permission-controller';
-import {
-  restrictedMethodPermissionBuilders,
-  selectHooks,
-} from '@metamask/rpc-methods';
 import { endowmentPermissionBuilders } from '@metamask/snaps-controllers';
 import { DEFAULT_ENDOWMENTS } from '@metamask/snaps-utils';
 
 export const ExcludedSnapEndowments = Object.freeze(['endowment:keyring']);
-
-export const buildSnapEndowmentSpecifications = () =>
-  Object.values(endowmentPermissionBuilders).reduce(
-    (allSpecifications, { targetKey, specificationBuilder }) => {
-      if (!ExcludedSnapEndowments.includes(targetKey)) {
-        // @ts-expect-error Ignore for now
-        allSpecifications[targetKey] = specificationBuilder();
-      }
-      return allSpecifications;
-    },
-    {},
-  );
-
-export const buildSnapRestrictedMethodSpecifications = (
-  hooks: Record<string, unknown>,
-) =>
-  Object.values(restrictedMethodPermissionBuilders).reduce(
-    (specifications, { targetKey, specificationBuilder, methodHooks }) => {
-      // @ts-expect-error Ignore for now
-      specifications[targetKey] = specificationBuilder({
-        // @ts-expect-error Ignore for now
-        methodHooks: selectHooks(hooks, methodHooks),
-      });
-      return specifications;
-    },
-    {},
-  );
 
 // Copied from the extension
 /**


### PR DESCRIPTION
Export `buildSnapEndowmentSpecifications` & `buildSnapRestrictedMethodSpecifications` which is used in the extension and snaps-simulator.

Fixes #1430